### PR TITLE
Added support for sliced searching

### DIFF
--- a/test_elasticsearch_dsl/test_search.py
+++ b/test_elasticsearch_dsl/test_search.py
@@ -111,6 +111,16 @@ def test_sort():
     assert [] == s._sort
     assert search.Search().to_dict() == s.to_dict()
 
+def test_slice():
+    s = search.Search()
+    assert {'query': {'match_all': {}}, 'from': 3, 'size': 7} == s[3:10].to_dict()
+    assert {'query': {'match_all': {}}, 'from': 0, 'size': 5} == s[:5].to_dict()
+    assert {'query': {'match_all': {}}, 'from': 3, 'size': 10} == s[3:].to_dict()
+
+def test_index():
+    s = search.Search()
+    assert {'query': {'match_all': {}}, 'from': 3, 'size': 1} == s[3].to_dict()
+
 def test_search_to_dict():
     s = search.Search()
     assert {"query": {"match_all": {}}} == s.to_dict()


### PR DESCRIPTION
This adds pagination by slicing or index access.

For example:

```
>>> Search()[5:10].to_dict()
{'from': 5, 'query': {'match_all': {}}, 'size': 5}
>>> Search()[:10].to_dict()
{'from': 0, 'query': {'match_all': {}}, 'size': 10}
>>> Search()[10:].to_dict()
{'from': 10, 'query': {'match_all': {}}, 'size': 10}
>>> Search()[0].to_dict()
{'from': 0, 'query': {'match_all': {}}, 'size': 1}
```
