### PR TITLE
Added `__iter__` to iterate of a search query

### DIFF
--- a/elasticsearch_dsl/search.py
+++ b/elasticsearch_dsl/search.py
@@ -119,6 +119,9 @@ class Search(object):
             s._extra['size'] = 1
             return s
 
+    def __iter__(self):
+        return iter(self.execute())
+
     @classmethod
     def from_dict(cls, d):
         """


### PR DESCRIPTION
This is so you can do something like this:
```
qs = Search(...).query(...)
for item in qs:
    ...
```
to iterate over the `Result` objects easily.

Comments welcome on where to add tests or if this isn't wanted or intended.