### PR TITLE
Updated Search._clone to better support subclassing

### DIFF
--- a/elasticsearch_dsl/search.py
+++ b/elasticsearch_dsl/search.py
@@ -132,9 +132,11 @@ class Search(object):
     def _clone(self):
         """
         Return a clone of the current search request. Performs a shallow copy
-        of all the underlying objects. Used internally by most state modifying APIs.
+        of all the underlying objects. Used internally by most state modifying
+        APIs.
         """
-        s = Search(using=self._using, index=self._index, doc_type=self._doc_type)
+        s = self.__class__(using=self._using, index=self._index,
+                           doc_type=self._doc_type)
         s._sort = self._sort[:]
         s._fields = self._fields[:]
         s._extra = self._extra.copy()


### PR DESCRIPTION
I did this to support use-cases like the following:

```
from elasticsearch_dsl.search import Search as dslSearch
from statsd import statsd


class Search(dslSearch):

    def execute(self):
        with statsd.timer('search.execute'):
            results = super(Search, self).execute()
            statsd.timing('search.took', results.took)
            return results
```

Previously anytime `_clone` got called it would return the original `Search` class, not the subclassed one.
