### PR TITLE
Handle results with no "fields" and "_source"

### DIFF
--- a/elasticsearch_dsl/result.py
+++ b/elasticsearch_dsl/result.py
@@ -38,8 +38,10 @@ class Result(AttrDict):
     def __init__(self, document):
         if 'fields' in document:
             super(Result, self).__init__(document['fields'])
-        else:
+        elif '_source' in document:
             super(Result, self).__init__(document['_source'])
+        else:
+            super(Result, self).__init__({})
         # assign _meta as attribute and not as key in self._d_
         super(AttrDict, self).__setattr__('_meta', ResultMeta(document))
 

--- a/test_elasticsearch_dsl/conftest.py
+++ b/test_elasticsearch_dsl/conftest.py
@@ -87,6 +87,13 @@ def dummy_response():
               "twitter": "honzakral",
             },
           },
+          {
+            "_index": "test-index",
+            "_type": "employee",
+            "_id": "53",
+            "_score": 16.0,
+            "_parent": "elasticsearch",
+          },
         ],
         "max_score": 12.0,
         "total": 123

--- a/test_elasticsearch_dsl/test_result.py
+++ b/test_elasticsearch_dsl/test_result.py
@@ -7,7 +7,7 @@ def test_interactive_helpers(dummy_response):
     hits = res.hits
     h = hits[0]
 
-    rhits = "[<Result(test-index/company/elasticsearch): %s>, <Result(test-index/employee/42): %s...}>, <Result(test-index/employee/47): %s...}>]" % (
+    rhits = "[<Result(test-index/company/elasticsearch): %s>, <Result(test-index/employee/42): %s...}>, <Result(test-index/employee/47): %s...}>, <Result(test-index/employee/53): {}>]" % (
             repr(dummy_response['hits']['hits'][0]['_source']),
             repr(dummy_response['hits']['hits'][1]['_source'])[:60],
             repr(dummy_response['hits']['hits'][2]['_source'])[:60],
@@ -24,7 +24,7 @@ def test_iterating_over_response_gives_you_hits(dummy_response):
 
     assert res.success()
     assert 123 == res.took
-    assert 3 == len(hits)
+    assert 4 == len(hits)
     assert all(isinstance(h, result.Result) for h in hits)
     h = hits[0]
 


### PR DESCRIPTION
Allows for queries returning only meta info.

E.g.

``` python
Search(es).index("index").fields().execute()
```
