### PR TITLE
geohash_grid instead of geo_hashgrid

### DIFF
--- a/elasticsearch_dsl/aggs.py
+++ b/elasticsearch_dsl/aggs.py
@@ -88,7 +88,7 @@ AGGS = (
     (Bucket, 'filter', {'filter': {'type': 'filter'}}),
     (Bucket, 'filters', {'filters': {'type': 'filter', 'hash': True}}),
     (Bucket, 'geo_distance', None),
-    (Bucket, 'geo_hashgrid', None),
+    (Bucket, 'geohash_grid', None),
     (Bucket, 'global', None),
     (Bucket, 'histogram', None),
     (Bucket, 'iprange', None),


### PR DESCRIPTION
The agg keyword is misspelled
http://www.elasticsearch.org/guide/en/elasticsearch/reference/current/search-aggregations-bucket-geohashgrid-aggregation.html
