### PR TITLE
Common Terms should be renamed Common

### DIFF
--- a/elasticsearch_dsl/query.py
+++ b/elasticsearch_dsl/query.py
@@ -87,7 +87,7 @@ QUERIES = (
     ('span_or', {'clauses': {'type': 'query', 'multi': True}}),
 
     # core queries
-    ('common_terms', None),
+    ('common', None),
     ('fuzzy', None),
     ('fuzzy_like_this', None),
     ('fuzzy_like_this_field', None),


### PR DESCRIPTION
See the docs here:

http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/query-dsl-common-terms-query.html#query-dsl-common-terms-query
