### PR TITLE
Inherit using and index from parent Meta, if possible

### DIFF
--- a/elasticsearch_dsl/document.py
+++ b/elasticsearch_dsl/document.py
@@ -29,11 +29,17 @@ class DocTypeOptions(object):
     def __init__(self, name, bases, attrs):
         meta = attrs.pop('Meta', None)
 
+        # some Meta attributes should be inherited from parents' Meta, if possible
+        base_meta = None
+        for b in bases:
+            if hasattr(b, '_doc_type'):
+                base_meta = b._doc_type
+
         # default index, if not overriden by doc._meta
-        self.index = getattr(meta, 'index', None)
+        self.index = getattr(meta, 'index', getattr(base_meta, 'index', None))
 
         # default cluster alias, can be overriden in doc._meta
-        self.using = getattr(meta, 'using', 'default')
+        self.using = getattr(meta, 'using', getattr(base_meta, 'using', 'default'))
 
         # get doc_type name, if not defined take the name of the class and
         # tranform it to lower_case

--- a/test_elasticsearch_dsl/test_document.py
+++ b/test_elasticsearch_dsl/test_document.py
@@ -15,6 +15,9 @@ class MySubDoc(MyDoc):
         doc_type = 'my_custom_doc'
         index = 'default-index'
 
+class MySubSubDoc(MySubDoc):
+    extra = field.Long()
+
 
 def test_to_dict_is_recursive_and_can_cope_with_multi_values():
     md = MyDoc(name=['a', 'b', 'c'])
@@ -96,3 +99,26 @@ def test_meta_fields_are_stored_in_meta_and_ignored_by_to_dict():
     assert {'name': 'My First doc!'} == md.to_dict()
     assert {'id': 42, 'index': 'my-index'} == md._meta.to_dict()
 
+def test_meta_inheritance():
+    assert issubclass(MySubSubDoc, MySubDoc)
+    assert issubclass(MySubSubDoc, document.DocType)
+    assert hasattr(MySubSubDoc, '_doc_type')
+    # doc_type should not be inherited
+    assert 'my_sub_sub_doc' == MySubSubDoc._doc_type.name
+    # index and using should be
+    assert MySubSubDoc._doc_type.index == MySubDoc._doc_type.index
+    assert MySubSubDoc._doc_type.using == MySubDoc._doc_type.using
+    assert {
+        'my_sub_sub_doc': {
+            'properties': {
+                'created_at': {'type': 'date'},
+                'name': {'type': 'string', 'index': 'not_analyzed'},
+                'title': {'index': 'not_analyzed', 'type': 'string'},
+                'inner': {
+                    'type': 'object',
+                    'properties': {'old_field': {'type': 'string'}}
+                },
+                'extra': {'type': 'long'}
+            }
+        }
+    } == MySubSubDoc._doc_type.mapping.to_dict()


### PR DESCRIPTION
When subclassing documents, I think it makes sense to inherit `Meta.index` and `Meta.using` from the parent document, if they are defined. Of course this won't stop you from overriding them, but I wouldn't expect it to be required to do so.

I specifically excluded `doc_type` from being inherited, but could see it working either way. On one hand, this is a conservative default - it lets you fully separate the parent and the child docs when indexing. But it might make sense to inherit `doc_type` by default, too - you could index both in the same ES type without consequence (I think the parent would ignore the extra child fields), but perhaps more likely is the case when you don't care about the parent class at all.

In fact, in writing this, it occurs to me that maybe it's worth having a `Meta.abstract` option, but I don't know all the ramifications of adding that. Food for thought I guess :)
