### PR TITLE
Update index.rst

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -179,7 +179,15 @@ existing ``dict``, modifying it using the API and serializing it back to a
 .. code:: python
 
     body = {...} # insert complicated query here
-
+    
+    # In case you have an aggregation or a filter to migrate to dsl and extend further
+    # you will have to create an empty body with default query structure.
+    
+    body = {'query': {'match_all': {}}}
+    
+    # Now append your aggregation of a filter that you are trying to further use
+    # body.update(facet_dict) or body.update(aggr)
+    
     # Convert to Search object
     s = Search.from_dict(body)
 


### PR DESCRIPTION
When trying to migrate an aggregation(only) and pass the from_dict , dsl fails and doesn't convert properly until i realized the change in the syntax and added "{'query': {'match_all': {}}}" to the body before calculating the aggregation.

Please correct me if i am missing something here, but i felt that this is something that should be either fixed or be in the documentation.