### PR TITLE
Add __getitem__ to InnerObject class

### DIFF
--- a/elasticsearch_dsl/field.py
+++ b/elasticsearch_dsl/field.py
@@ -88,6 +88,9 @@ class InnerObject(object):
     def _empty(self):
         return {}
 
+    def __getitem__(self, name):
+        return self.properties[name]
+
     def update(self, other_object):
         if not hasattr(other_object, 'properties'):
             # not an inner/nested object, no merge possible

--- a/elasticsearch_dsl/field.py
+++ b/elasticsearch_dsl/field.py
@@ -91,6 +91,9 @@ class InnerObject(object):
     def __getitem__(self, name):
         return self.properties[name]
 
+    def __contains__(self, name):
+        return name in self.properties
+
     def update(self, other_object):
         if not hasattr(other_object, 'properties'):
             # not an inner/nested object, no merge possible


### PR DESCRIPTION
Add `__getitem__` method to Inner object, so if we have a complex mapping, something like this
```
class Blog(DocType):
  author = String(index='not_analyzed')

  post = Object(properties={
    'date': Date(),
    'title': String(),
    'paragraph': Object(properties={
      'sentence': String(),
      'meaning': String()
    })
  })
```

Right now if you want to get the definition of 'paragraph', you have to do the following:
```
mapping = Blog._doc_type.mapping  # First get the mapping
post_object = mapping['post']  # very simple and nice
paragraph_object = post_object.properties['paragraph']  # this would be ok, but doesn't seem consistent with design
```

With this change this workflow becomes:
```
mapping = Blog._doc_type.mapping  # First get the mapping
post_object = mapping['post']  # very simple and nice
paragraph_object = post_object['paragraph']  # just like the last line
```

I think this makes design consistent. Other solution would be to change the 2nd line to
```
post_object = mapping.properties['post']  # make this line be the same as 3rd line
```
But personally I like the other way better.


Also added `__contians__` for the same reason. To be able to do the following:
```
mapping = Blog._doc_type.mapping  # First get the mapping
post_object = mapping['post']  # very simple and nice
assert 'sentence' in post_object
assert 'random_string' not in post_object
```