### PR TITLE
Add encoding instruction to test_analysis.py

### DIFF
--- a/test_elasticsearch_dsl/test_analysis.py
+++ b/test_elasticsearch_dsl/test_analysis.py
@@ -1,3 +1,4 @@
+# coding: utf-8
 from elasticsearch_dsl import analysis
 
 def test_analyzer_serializes_as_name():


### PR DESCRIPTION
On master running `python setup.py test` fails with the following message
```
___________________________________ ERROR collecting test_elasticsearch_dsl/test_analysis.py ___________________________________
pytest-2.7.0-py2.7.egg/_pytest/python.py:488: in _importtestmodule
    mod = self.fspath.pyimport(ensuresyspath=True)
py-1.4.26-py2.7.egg/py/_path/local.py:641: in pyimport
    __import__(modname)
E     File "/Users/arsen/Workspace/elasticsearch-dsl-py/test_elasticsearch_dsl/test_analysis.py", line 35
E   SyntaxError: Non-ASCII character '\xc3' in file /Users/arsen/Workspace/elasticsearch-dsl-py/test_elasticsearch_dsl/test_analysis.py on line 35, but no encoding declared; see http://www.python.org/peps/pep-0263.html for details
```

This pull request adds necessary coding instructions defined by PEP 0263