### PR TITLE
Fix _make_dsl_class with Python 2

### DIFF
--- a/elasticsearch_dsl/utils.py
+++ b/elasticsearch_dsl/utils.py
@@ -19,7 +19,7 @@ def _make_dsl_class(base, name, params_def=None, suffix=''):
     attrs = {'name': name}
     if params_def:
         attrs['_param_defs'] = params_def
-    cls_name = str(''.join(s.title() for s in name.split('_'))) + suffix
+    cls_name = str(''.join(s.title() for s in name.split('_')) + suffix)
     return type(cls_name, (base, ), attrs)
 
 class AttrList(object):

--- a/test_elasticsearch_dsl/test_utils.py
+++ b/test_elasticsearch_dsl/test_utils.py
@@ -1,11 +1,13 @@
 from elasticsearch_dsl import utils
 
+
 def test_attrdict_bool():
     d = utils.AttrDict({})
 
     assert not d
     d.title = 'Title'
     assert d
+
 
 def test_attrlist_items_get_wrapped_during_iteration():
     al = utils.AttrList([1, object(), [1], {}])
@@ -14,3 +16,9 @@ def test_attrlist_items_get_wrapped_during_iteration():
 
     assert isinstance(l[2], utils.AttrList)
     assert isinstance(l[3], utils.AttrDict)
+
+
+def test_make_dsl_class():
+    t = utils._make_dsl_class(object, 'X')
+
+    assert t.__name__ == 'X'


### PR DESCRIPTION
type doesn't like unicode parameter in Python 2
