### PR TITLE
Mark accessing to _meta as expected to fail

### DIFF
--- a/test_elasticsearch_dsl/test_result.py
+++ b/test_elasticsearch_dsl/test_result.py
@@ -1,7 +1,8 @@
-from pytest import raises
+from pytest import raises, mark
 
 from elasticsearch_dsl import result
 
+@mark.xfail
 def test_interactive_helpers(dummy_response):
     res = result.Response(dummy_response)
     hits = res.hits
@@ -17,6 +18,7 @@ def test_interactive_helpers(dummy_response):
     assert '<Response: %s>' % rhits == repr(res)
     assert rhits == repr(hits)
     assert set(['meta', 'city', 'name']) == set(dir(h))
+    assert h._meta
     assert "<Result(test-index/company/elasticsearch): %r>" % dummy_response['hits']['hits'][0]['_source'] == repr(h)
 
 def test_enpty_response_is_false(dummy_response):


### PR DESCRIPTION
https://github.com/elastic/elasticsearch-dsl-py/commit/493c27cec4c1c54ee6b22b26f6dd170a879967c7 does not work as expected: using `hit._meta` no longer works, only `hit.meta` works. Here's a failing test (marked as "expected to fail" with pytest) to show the issue.