### PR TITLE
Minor update to Exception message for Invalid DSL class

### DIFF
--- a/elasticsearch_dsl/utils.py
+++ b/elasticsearch_dsl/utils.py
@@ -188,7 +188,7 @@ class DslBase(object):
         try:
             return cls._classes[name]
         except KeyError:
-            raise UnknownDslObject('DSL class %s does not exist in %s.' % (name, cls._type_name))
+            raise UnknownDslObject('DSL class `%s` does not exist in %s.' % (name, cls._type_name))
 
     def __init__(self, **params):
         self._params = {}


### PR DESCRIPTION
I personally found it difficult to quickly parse Exception messages for invalid DSL classes, so thought I'd wrap the class-id in backticks. Super simple, but handly for quickly reading exceptions.