### PR TITLE
Allow passing extra search params through DocType.search

### DIFF
--- a/elasticsearch_dsl/document.py
+++ b/elasticsearch_dsl/document.py
@@ -119,11 +119,12 @@ class DocType(ObjectBase):
         cls._doc_type.init(index, using)
 
     @classmethod
-    def search(cls):
+    def search(cls, **extra):
         return Search(
             using=cls._doc_type.using,
             index=cls._doc_type.index,
             doc_type={cls._doc_type.name: cls.from_es},
+            extra=extra
         )
 
     @classmethod


### PR DESCRIPTION
Turns this:

```python
s = self.document.search()
s._extra = {'track_scores': True}
```

Into this:

```python
s = self.document.search(track_scores=True)
```