### PR TITLE
Fixed 'using' keyword param not being saved when passed

### DIFF
--- a/elasticsearch_dsl/index.py
+++ b/elasticsearch_dsl/index.py
@@ -6,7 +6,7 @@ class Index(object):
         self._name = name
         self._doc_types = {}
         self._mappings = {}
-        self._using = 'default'
+        self._using = using
         self._settings = {}
 
     def _get_connection(self):


### PR DESCRIPTION
The using keyword argument was being ignored instead of being saved against the object.