### PR TITLE
Added 'aliases' support to Index

### DIFF
--- a/docs/persistence.rst
+++ b/docs/persistence.rst
@@ -320,6 +320,11 @@ in a migration:
         number_of_replicas=0
     )
 
+    # define aliases
+    blogs.aliases(
+        old_blogs={}
+    )
+
     # register a doc_type with the index
     blogs.doc_type(Post)
 

--- a/elasticsearch_dsl/index.py
+++ b/elasticsearch_dsl/index.py
@@ -8,6 +8,7 @@ class Index(object):
         self._mappings = {}
         self._using = using
         self._settings = {}
+        self._aliases = {}
 
     def _get_connection(self):
         return connections.get_connection(self._using)
@@ -24,6 +25,10 @@ class Index(object):
 
     def settings(self, **kwargs):
         self._settings.update(kwargs)
+        return self
+
+    def aliases(self, **kwargs):
+        self._aliases.update(kwargs)
         return self
 
     def search(self):
@@ -49,6 +54,8 @@ class Index(object):
         out = {}
         if self._settings:
             out['settings'] = self._settings
+        if self._aliases:
+            out['aliases'] = self._aliases
         mappings, analysis = self._get_mappings()
         if mappings:
             out['mappings'] = mappings

--- a/test_elasticsearch_dsl/test_index.py
+++ b/test_elasticsearch_dsl/test_index.py
@@ -1,5 +1,9 @@
 from elasticsearch_dsl import DocType, Index, String, Date
 
+from random import choice
+
+import string
+
 class Post(DocType):
     title = String()
     published_from = Date()
@@ -11,17 +15,19 @@ def test_search_is_limited_to_index_name():
 
     assert s._index == ['my-index']
 
+
 def test_settings_are_saved():
     i = Index('i')
     i.settings(number_of_replicas=0)
     i.settings(number_of_shards=1)
 
     assert {
-        'settings': {
-            'number_of_shards': 1,
-            'number_of_replicas': 0,
-        }
-    } == i.to_dict()
+               'settings': {
+                   'number_of_shards': 1,
+                   'number_of_replicas': 0,
+               }
+           } == i.to_dict()
+
 
 def test_registered_doc_type_included_in_to_dict():
     i = Index('i', using='alias')
@@ -29,15 +35,16 @@ def test_registered_doc_type_included_in_to_dict():
 
     assert Post._doc_type.index == 'i'
     assert {
-        'mappings': {
-            'post': {
-                'properties': {
-                    'title': {'type': 'string'},
-                    'published_from': {'type': 'date'},
-                }
-            }    
-        }
-    } == i.to_dict()
+               'mappings': {
+                   'post': {
+                       'properties': {
+                           'title': {'type': 'string'},
+                           'published_from': {'type': 'date'},
+                       }
+                   }
+               }
+           } == i.to_dict()
+
 
 def test_registered_doc_type_included_in_search():
     i = Index('i', using='alias')
@@ -47,3 +54,22 @@ def test_registered_doc_type_included_in_search():
 
     assert s._doc_type_map == {'post': Post.from_es}
 
+
+def test_aliases_add_to_object():
+    random_alias = ''.join((choice(string.ascii_letters) for _ in range(100)))
+    alias_dict = {random_alias: {}}
+
+    index = Index('i', using='alias')
+    index.aliases(**alias_dict)
+
+    assert index._aliases == alias_dict
+
+
+def test_aliases_returned_from_to_dict():
+    random_alias = ''.join((choice(string.ascii_letters) for _ in range(100)))
+    alias_dict = {random_alias: {}}
+
+    index = Index('i', using='alias')
+    index.aliases(**alias_dict)
+
+    assert index._aliases == index.to_dict()['aliases'] == alias_dict


### PR DESCRIPTION
@HonzaKral, this PR adds aliases support to indexes. I wanted to add an alias at creation time and not have to do a separate call.

I didn't add a test, would you like me to?