### PR TITLE
Change document.save/delete to raise ValidationError on no index

### DIFF
--- a/elasticsearch_dsl/document.py
+++ b/elasticsearch_dsl/document.py
@@ -8,6 +8,7 @@ from .utils import ObjectBase, AttrDict
 from .result import ResultMeta
 from .search import Search
 from .connections import connections
+from .exceptions import ValidationException
 
 DOC_META_FIELDS = frozenset((
     'id', 'parent', 'routing', 'timestamp', 'ttl', 'version', 'version_type'
@@ -165,7 +166,7 @@ class DocType(ObjectBase):
         if index is None:
             index = getattr(self.meta, 'index', self._doc_type.index)
         if index is None:
-            raise #XXX - no index
+            raise ValidationException('No index')
         # extract parent, routing etc from meta
         doc_meta = dict(
             (k, self.meta[k])
@@ -199,7 +200,7 @@ class DocType(ObjectBase):
         if index is None:
             index = getattr(self.meta, 'index', self._doc_type.index)
         if index is None:
-            raise #XXX - no index
+            raise ValidationException('No index')
         # extract parent, routing etc from meta
         doc_meta = dict(
             (k, self.meta[k])

--- a/test_elasticsearch_dsl/test_document.py
+++ b/test_elasticsearch_dsl/test_document.py
@@ -265,3 +265,13 @@ def test_meta_fields_can_be_accessed_directly_with_underscore():
     assert md.meta.id == 42
     assert md._id == 42
     assert md.meta.parent is md._parent is p
+
+def test_save_no_index(mock_client):
+    md = MyDoc()
+    with raises(ValidationException):
+        md.save(using='mock')
+
+def test_delete_no_index(mock_client):
+    md = MyDoc()
+    with raises(ValidationException):
+        md.delete(using='mock')


### PR DESCRIPTION
The previous behaviour was incompatible between python versions:

A raise on python3 gives us the following:
```
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
RuntimeError: No active exception to reraise
```

And on python2:
```
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
TypeError: exceptions must be old-style classes or derived from BaseException, not NoneType
```

This makes the behaviour uniform and the error message more helpful.