### PR TITLE
Missing document always raises a NotFoundError exception.

### DIFF
--- a/elasticsearch_dsl/document.py
+++ b/elasticsearch_dsl/document.py
@@ -136,8 +136,6 @@ class DocType(ObjectBase):
             id=id,
             **kwargs
         )
-        if not doc['found']:
-            return None
         return cls.from_es(doc)
 
     @classmethod


### PR DESCRIPTION
The Elasticsearch client raises a ``NotFoundError`` exception when a document is not found. Hence, it is not relevant to inspect the response body of the server.

Moreover, when a document is not found, the integration tests only verify that the ``NotFoundError`` exception is raised:
https://github.com/elastic/elasticsearch-dsl-py/blob/master/test_elasticsearch_dsl/test_integration/test_document.py#L44