### PR TITLE
Custom alias and index in DocType.search

### DIFF
--- a/elasticsearch_dsl/document.py
+++ b/elasticsearch_dsl/document.py
@@ -124,10 +124,10 @@ class DocType(ObjectBase):
         cls._doc_type.init(index, using)
 
     @classmethod
-    def search(cls):
+    def search(cls, using=None, index=None):
         return Search(
-            using=cls._doc_type.using,
-            index=cls._doc_type.index,
+            using=using or cls._doc_type.using,
+            index=index or cls._doc_type.index,
             doc_type={cls._doc_type.name: cls.from_es},
         )
 

--- a/test_elasticsearch_dsl/test_document.py
+++ b/test_elasticsearch_dsl/test_document.py
@@ -296,3 +296,11 @@ def test_delete_no_index(mock_client):
     md = MyDoc()
     with raises(ValidationException):
         md.delete(using='mock')
+
+def test_search_with_custom_alias_and_index(mock_client):
+    search_object = MyDoc.search(
+      using="staging",
+      index=["custom_index1", "custom_index2"])
+    
+    assert search_object._using == "staging"
+    assert search_object._index == ["custom_index1", "custom_index2"]


### PR DESCRIPTION
## Proposition to use documents.DocType.search() with custom parameters for Elasticsearch alias and index.

Currently, we can save DocType into any index, as well as get and delete object:
```python

def save(self, using=None, index=None, validate=True, **kwargs):
```

It's strange, why the same behaviour not available for DocType.search().

From my point of view, we have a case, when a large amount data should be loaded and processed in separate index (which is different then in DocType.meta), using custom parameters would allow to keep codebase clean.
