### PR TITLE
Closes #211 - Allow additional args to the Search.from_dict function

### DIFF
--- a/elasticsearch_dsl/search.py
+++ b/elasticsearch_dsl/search.py
@@ -162,24 +162,39 @@ class Search(object):
             return s
 
     @classmethod
-    def from_dict(cls, d):
+    def from_dict(cls, d, *args, **kwargs):
         """
-        Construct a `Search` instance from a raw dict containing the search
-        body. Useful when migrating from raw dictionaries.
+        Construct a new `Search` instance from a raw dictionary containing
+        the search body. Useful when migrating from raw dictionaries.
+
+        Any additional positional or keyword parameters to this function,
+        aside from the raw query dictionary, will be passed to the
+        `Search` constructor.
 
         Example::
 
-            s = Search.from_dict({
-                "query": {
-                    "bool": {
-                        "must": [...]
+            raw_query = {
+                "query" : {
+                    "filtered" : {
+                        "query" : {
+                            "match_all" : {}
+                        },
+                        "filter" : {
+                            "term" : {
+                                "price" : 20
+                            }
+                        }
                     }
-                },
-                "aggs": {...}
-            })
+                }
+            }
+
+            client = Elasticsearch()
+            s = Search.from_dict(raw_query, using=client, index='products')
             s = s.filter('term', published=True)
+            print(s.execute())
+
         """
-        s = cls()
+        s = cls(*args, **kwargs)
         s.update_from_dict(d)
         return s
 
@@ -263,7 +278,7 @@ class Search(object):
                     'params': {'n': 3}
                 }
             )
-        
+
         """
         s = self._clone()
         for name in kwargs:
@@ -424,7 +439,7 @@ class Search(object):
         """
         Set the type to search through. You can supply a single value or
         multiple. Values can be strings or subclasses of ``DocType``.
-        
+
         You can also pass in any keyword arguments, mapping a doc_type to a
         callback that should be used instead of the Result class.
 

--- a/test_elasticsearch_dsl/test_search.py
+++ b/test_elasticsearch_dsl/test_search.py
@@ -337,6 +337,12 @@ def test_from_dict_doesnt_need_query():
         "size": 5
     } == s.to_dict()
 
+
+def test_from_dict_accepts_additional_parameters():
+    s = search.Search.from_dict({"size": 5}, index='superCoolIndex')
+    assert(s._index == ['superCoolIndex'])
+
+
 def test_params_being_passed_to_search(mock_client):
     s = search.Search('mock')
     s = s.params(routing='42')


### PR DESCRIPTION
This PR addresses #211 by allowing additional query parameters to the `from_dict` function to make the newly created `Search` object more useful.  It may also help save the world, though I'm not 100% on that.

P.S. - I've just signed the CLA.