### PR TITLE
fix random score function with s/random/random_score

### DIFF
--- a/elasticsearch_dsl/function.py
+++ b/elasticsearch_dsl/function.py
@@ -69,18 +69,18 @@ class BoostFactor(ScoreFunction):
             del d[self.name]
         return d
 
-class Random(ScoreFunction):
-    name = 'random'
+class RandomScore(ScoreFunction):
+    name = 'random_score'
 
 class FieldValueFactor(ScoreFunction):
     name = 'field_value_factor'
 
 class Linear(ScoreFunction):
     name = 'linear'
-    
+
 class Gauss(ScoreFunction):
     name = 'gauss'
-    
+
 class Exp(ScoreFunction):
     name = 'exp'
-    
+

--- a/test_elasticsearch_dsl/test_query.py
+++ b/test_elasticsearch_dsl/test_query.py
@@ -243,7 +243,7 @@ def test_function_score_to_dict():
         'function_score',
         query=query.Q('match', title='python'),
         functions=[
-            query.SF('random'),
+            query.SF('random_score'),
             query.SF('field_value_factor', field='comment_count', filter=filter.F('term', tags='python'))
         ]
     )
@@ -252,7 +252,7 @@ def test_function_score_to_dict():
       'function_score': {
         'query': {'match': {'title': 'python'}},
         'functions': [
-          {'random': {}},
+          {'random_score': {}},
           {
             'filter': {'term': {'tags': 'python'}},
             'field_value_factor': {


### PR DESCRIPTION
In the docs, it's called [random_score](https://www.elastic.co/guide/en/elasticsearch/guide/current/random-scoring.html), not ```random```.

I applied this patch locally, and it gets me past the error ```No function with the name [random] is registered.]``` on ES v1.3.9