### PR TITLE
added len method to Response object

### DIFF
--- a/elasticsearch_dsl/result.py
+++ b/elasticsearch_dsl/result.py
@@ -21,6 +21,9 @@ class Response(AttrDict):
     def __repr__(self):
         return '<Response: %r>' % self.hits
 
+    def __len__(self):
+        return len(self.hits)
+
     def success(self):
         return not (self.timed_out or self._shards.failed)
 

--- a/test_elasticsearch_dsl/test_result.py
+++ b/test_elasticsearch_dsl/test_result.py
@@ -25,6 +25,10 @@ def test_enpty_response_is_false(dummy_response):
 
     assert not res
 
+def test_len_response(dummy_response):
+    res = result.Response(dummy_response)
+    assert len(dummy_response) == 4
+
 def test_iterating_over_response_gives_you_hits(dummy_response):
     res = result.Response(dummy_response)
     hits = list(h for h in res)


### PR DESCRIPTION
I missed possibility to directly call `len()` on response.

This PR implements this functionality. 