### PR TITLE
Fix for documentation

### DIFF
--- a/docs/search_dsl.rst
+++ b/docs/search_dsl.rst
@@ -134,7 +134,7 @@ Query objects can be combined using logical operators:
     Q("match", title='python') & Q("match", title='django')
     # {"bool": {"must": [...]}}
 
-    ~Q("match", "title"="python")
+    ~Q("match", title="python")
     # {"bool": {"must_not": [...]}}
 
 You can also use the ``+`` operator:


### PR DESCRIPTION
Running the code would result in:

SyntaxError: keyword can't be an expression