### PR TITLE
Use simplified 'And' filter syntax

### DIFF
--- a/elasticsearch_dsl/filter.py
+++ b/elasticsearch_dsl/filter.py
@@ -1,3 +1,5 @@
+from six.moves import map
+
 from .utils import DslBase, BoolMixin, _make_dsl_class
 
 __all__ = [
@@ -121,6 +123,12 @@ class AndOrFilter(object):
         if filters is not None:
             kwargs['filters'] = filters
         super(AndOrFilter, self).__init__(**kwargs)
+
+    def to_dict(self):
+        # 'And' and 'Or' filters are serialized differently from most filters
+        # See: https://www.elastic.co/guide/en/elasticsearch/reference/1.4/query-dsl-or-filter.html
+        value = list(map(lambda x: x.to_dict(), self._params['filters']))
+        return {self.name: value}
 
     # compound filters
 class And(AndOrFilter, Filter):

--- a/test_elasticsearch_dsl/test_filter.py
+++ b/test_elasticsearch_dsl/test_filter.py
@@ -9,7 +9,6 @@ def test_repr():
 
 def test_and_can_be_created_from_list():
     f = filter.F({'and': [{'term': {'f': 'v'}}, {'term': {'f2': 42}}]})
-
     assert f == filter.And([filter.F('term', f='v'), filter.F('term', f2=42)])
 
 def test_empty_F_is_match_all():
@@ -42,7 +41,7 @@ def test_query_can_use_positional_arg():
     assert f.query == Q('match_all')
     assert {'query': {'match_all': {}}} == f.to_dict()
 
-def test_and_filter_outputs_list():
+def test_and_filter_to_dict():
     f = filter.F('and', [filter.F('range', postDate={'to': '2010-04-01', 'from': '2010-03-01'}),
                          filter.F('prefix', name__second='ba')])
 

--- a/test_elasticsearch_dsl/test_filter.py
+++ b/test_elasticsearch_dsl/test_filter.py
@@ -41,3 +41,23 @@ def test_query_can_use_positional_arg():
 
     assert f.query == Q('match_all')
     assert {'query': {'match_all': {}}} == f.to_dict()
+
+def test_and_filter_outputs_list():
+    f = filter.F('and', [filter.F('range', postDate={'to': '2010-04-01', 'from': '2010-03-01'}),
+                         filter.F('prefix', name__second='ba')])
+
+    assert f.to_dict() == {
+        "and" : [
+            {
+                "range" : {
+                    "postDate" : {
+                        "from" : "2010-03-01",
+                        "to" : "2010-04-01"
+                    }
+                }
+            },
+            {
+                "prefix" : { "name.second" : "ba" }
+            }
+        ]
+    }


### PR DESCRIPTION
Fix for https://github.com/elastic/elasticsearch-dsl-py/issues/286

As far as I can tell, support for the more verbose syntax was removed in Elasticsearch 2.0: https://www.elastic.co/guide/en/elasticsearch/reference/2.0/query-dsl-or-query.html
