### PR TITLE
added convenience fields()/keys() method to the AttrDict

### DIFF
--- a/elasticsearch_dsl/utils.py
+++ b/elasticsearch_dsl/utils.py
@@ -130,6 +130,9 @@ class AttrDict(object):
     def __iter__(self):
         return iter(self._d_)
 
+    def fields(self):
+        return self._d_.keys()
+
     def to_dict(self):
         return self._d_
 


### PR DESCRIPTION
Hi,

When I am working with results I am very much missing something like `keys()` method in the standard Python dict.

To prevent confusion that `AttrDict` is in fact not standard dict I named it for now `fields()`, but I am open to rename it `keys()`, I am open to discussion, I would very appreciate to have this in the library.