### PR TITLE
Add custom validation method to Boolean field type.

### DIFF
--- a/elasticsearch_dsl/field.py
+++ b/elasticsearch_dsl/field.py
@@ -236,6 +236,18 @@ class String(Field):
     def _empty(self):
         return ''
 
+
+class Boolean(Field):
+    name = 'boolean'
+
+    def clean(self, data):
+        if data is not None:
+            data = self.deserialize(data)
+        if data is None and self._required:
+            raise ValidationException("Value required for this field.")
+        return data
+
+
 FIELDS = (
     'float',
     'double',
@@ -243,7 +255,6 @@ FIELDS = (
     'short',
     'integer',
     'long',
-    'boolean',
     'ip',
     'attachment',
     'geo_point',

--- a/test_elasticsearch_dsl/test_validation.py
+++ b/test_elasticsearch_dsl/test_validation.py
@@ -1,6 +1,6 @@
 from datetime import datetime
 
-from elasticsearch_dsl import DocType, Nested, String, Date, Object
+from elasticsearch_dsl import DocType, Nested, String, Date, Object, Boolean
 from elasticsearch_dsl.field import InnerObjectWrapper
 from elasticsearch_dsl.exceptions import ValidationException
 
@@ -22,6 +22,11 @@ class BlogPost(DocType):
     )
     created = Date()
     inner = Object()
+
+
+class BlogPostWithStatus(DocType):
+    published = Boolean(required=True)
+
 
 class AutoNowDate(Date):
     def clean(self, data):
@@ -58,6 +63,15 @@ def test_missing_required_field_raises_validation_exception():
     d = BlogPost()
     d.authors.append({'name': 'Honza', 'email': 'honza@elastic.co'})
     d.full_clean()
+
+    d = BlogPostWithStatus()
+    with raises(ValidationException):
+        d.full_clean()
+    d.published = False
+    d.full_clean()
+    d.published = True
+    d.full_clean()
+
 
 def test_custom_validation_on_nested_gets_run():
     d = BlogPost(authors=[{'name': 'Honza', 'email': 'king@example.com'}], created=None)


### PR DESCRIPTION
Validation failed for boolean fields when `required` was set to `True` and
the field value was `False`.