### PR TITLE
Fix suggest() example in persistence doc

### DIFF
--- a/docs/persistence.rst
+++ b/docs/persistence.rst
@@ -318,7 +318,7 @@ If you want to run suggestions, just use the ``suggest`` method on the
 .. code:: python
 
     s = Post.search()
-    s.suggest('title_suggestions', 'pyth', completion={'field': 'title_suggest'})
+    s = s.suggest('title_suggestions', 'pyth', completion={'field': 'title_suggest'})
 
     # you can even execute just the suggestions via the _suggest API
     suggestions = s.execute_suggest()


### PR DESCRIPTION
s.suggest() returns an elasticsearch_dsl.search.Search object, which is what you want to run execute_suggest() on. 

The previous implementation of this example doesn't store this object, so the example doesn't work (title_suggestions will not exist), and the program will crash.