### PR TITLE
Allow custom analyzers to be set from DocType Meta

### DIFF
--- a/docs/persistence.rst
+++ b/docs/persistence.rst
@@ -378,7 +378,7 @@ in a migration:
 
 .. code:: python
 
-    from elasticsearch_dsl import Index, DocType, String
+    from elasticsearch_dsl import Index, DocType, String, analyzer
 
     blogs = Index('blogs')
 
@@ -400,6 +400,16 @@ in a migration:
     @blogs.doc_type
     class Post(DocType):
         title = String()
+
+    # You can attach custom analyzers to the index
+
+    html_strip = analyzer('html_strip',
+        tokenizer="standard",
+        filter=["standard", "lowercase", "stop", "snowball"],
+        char_filter=["html_strip"]
+    )
+
+    blog.analyzer(html_strip)
 
     # delete the index, ignore if it doesn't exist
     blogs.delete(ignore=404)

--- a/test_elasticsearch_dsl/test_index.py
+++ b/test_elasticsearch_dsl/test_index.py
@@ -1,4 +1,4 @@
-from elasticsearch_dsl import DocType, Index, String, Date
+from elasticsearch_dsl import DocType, Index, String, Date, analyzer
 
 from random import choice
 
@@ -82,3 +82,22 @@ def test_aliases_returned_from_to_dict():
     index.aliases(**alias_dict)
 
     assert index._aliases == index.to_dict()['aliases'] == alias_dict
+
+
+def test_analyzers_added_to_object():
+    random_analyzer_name = ''.join((choice(string.ascii_letters) for _ in range(100)))
+    random_analyzer = analyzer(random_analyzer_name, tokenizer="standard", filter="standard")
+
+    index = Index('i', using='alias')
+    index.analyzer(random_analyzer)
+
+    assert index._analysis["analyzer"][random_analyzer_name] == {"filter": ["standard"], "type": "custom", "tokenizer": "standard"}
+
+
+def test_analyzers_returned_from_to_dict():
+    random_analyzer_name = ''.join((choice(string.ascii_letters) for _ in range(100)))
+    random_analyzer = analyzer(random_analyzer_name, tokenizer="standard", filter="standard")
+    index = Index('i', using='alias')
+    index.analyzer(random_analyzer)
+
+    assert index.to_dict()["settings"]["analysis"]["analyzer"][random_analyzer_name] == {"filter": ["standard"], "type": "custom", "tokenizer": "standard"}


### PR DESCRIPTION
This allows you to set custom analyzers for a Index through the DocType Meta. Example

```python
html_strip = analyzer('html_strip',
    tokenizer="standard",
    filter=["standard", "lowercase", "stop", "snowball"],
    char_filter=["html_strip"]
)


class Post(DocType):
    title = String()

    class Meta:
        index = 'blog'
        analyzers = (html_strip,)
```