### PR TITLE
Added 'year' to possible date intervals for DateHistogramFacet

### DIFF
--- a/elasticsearch_dsl/faceted_search.py
+++ b/elasticsearch_dsl/faceted_search.py
@@ -130,7 +130,7 @@ class DateHistogramFacet(Facet):
     agg_type = 'date_histogram'
 
     DATE_INTERVALS = {
-        'year': lambda d: (d+timedelta(days=366)).replace(day=1),
+        'year': lambda d: d.replace(year=d.year+1),
         'month': lambda d: (d+timedelta(days=32)).replace(day=1),
         'week': lambda d: d+timedelta(days=7),
         'day': lambda d: d+timedelta(days=1),

--- a/elasticsearch_dsl/faceted_search.py
+++ b/elasticsearch_dsl/faceted_search.py
@@ -130,6 +130,7 @@ class DateHistogramFacet(Facet):
     agg_type = 'date_histogram'
 
     DATE_INTERVALS = {
+        'year': lambda d: (d+timedelta(days=366)).replace(day=1),
         'month': lambda d: (d+timedelta(days=32)).replace(day=1),
         'week': lambda d: d+timedelta(days=7),
         'day': lambda d: d+timedelta(days=1),


### PR DESCRIPTION
I feel like `year` got left out in the date intervals in `DateHistogramFacet`. Following the style of the month (adding enough days and replacing with 1) I added `year`. Probably the other possible intervals should be mapped at some point, that is `quarter`,  `minute` and `second`.

Thanks for this nice library btw.
