### PR TITLE
Type check more safely

### DIFF
--- a/elasticsearch_dsl/aggs.py
+++ b/elasticsearch_dsl/aggs.py
@@ -1,3 +1,5 @@
+import collections
+
 from .utils import DslBase, _make_dsl_class
 
 __all__ = [
@@ -19,7 +21,7 @@ def A(name_or_agg, filter=None, **params):
         params['filter'] = filter
 
     # {"terms": {"field": "tags"}, "aggs": {...}}
-    if isinstance(name_or_agg, dict):
+    if isinstance(name_or_agg, collections.Mapping):
         if params:
             raise ValueError('A() cannot accept parameters when passing in a dict.')
         # copy to avoid modifying in-place

--- a/elasticsearch_dsl/document.py
+++ b/elasticsearch_dsl/document.py
@@ -1,3 +1,4 @@
+import collections
 import re
 
 from elasticsearch.exceptions import NotFoundError, RequestError
@@ -163,8 +164,12 @@ class DocType(ObjectBase):
         if missing not in ('raise', 'skip', 'none'):
             raise ValueError("'missing' must be 'raise', 'skip', or 'none'.")
         es = connections.get_connection(using or cls._doc_type.using)
-        body = {'docs': [doc if isinstance(doc, dict) else {'_id': doc}
-                         for doc in docs]}
+        body = {
+            'docs': [
+                doc if isinstance(doc, collections.Mapping) else {'_id': doc}
+                for doc in docs
+            ]
+        }
         results = es.mget(
             body,
             index=index or cls._doc_type.index,

--- a/elasticsearch_dsl/field.py
+++ b/elasticsearch_dsl/field.py
@@ -1,3 +1,5 @@
+import collections
+
 from datetime import date
 from dateutil import parser
 from six import itervalues
@@ -14,7 +16,7 @@ __all__ = [
 
 def construct_field(name_or_field, **params):
     # {"type": "string", "index": "not_analyzed"}
-    if isinstance(name_or_field, dict):
+    if isinstance(name_or_field, collections.Mapping):
         if params:
             raise ValueError('construct_field() cannot accept parameters when passing in a dict.')
         params = name_or_field.copy()

--- a/elasticsearch_dsl/function.py
+++ b/elasticsearch_dsl/function.py
@@ -1,8 +1,10 @@
+import collections
+
 from .utils import DslBase
 
 def SF(name_or_sf, **params):
     # {"script_score": {"script": "_score"}, "filter": {}}
-    if isinstance(name_or_sf, dict):
+    if isinstance(name_or_sf, collections.Mapping):
         if params:
             raise ValueError('SF() cannot accept parameters when passing in a dict.')
         kwargs = {}
@@ -21,7 +23,7 @@ def SF(name_or_sf, **params):
             raise ValueError('SF() got an unexpected fields in the dictionary: %r' % sf)
 
         # boost factor special case, see elasticsearch #6343
-        if not isinstance(params, dict):
+        if not isinstance(params, collections.Mapping):
             params = {'value': params}
 
         # mix known params (from _param_defs) and from inside the function

--- a/elasticsearch_dsl/mapping.py
+++ b/elasticsearch_dsl/mapping.py
@@ -1,3 +1,5 @@
+import collections
+
 from six import iteritems
 from itertools import chain
 
@@ -88,7 +90,7 @@ class Mapping(object):
         # metadata like _all etc
         for name, value in iteritems(raw):
             if name != 'properties':
-                if isinstance(value, dict):
+                if isinstance(value, collections.Mapping):
                     self.meta(name, **value)
                 else:
                     self.meta(name, value)

--- a/elasticsearch_dsl/query.py
+++ b/elasticsearch_dsl/query.py
@@ -1,3 +1,5 @@
+import collections
+
 from itertools import chain
 
 from .utils import DslBase, _make_dsl_class
@@ -17,7 +19,7 @@ __all__ = [
 
 def Q(name_or_query='match_all', **params):
     # {"match": {"title": "python"}}
-    if isinstance(name_or_query, dict):
+    if isinstance(name_or_query, collections.Mapping):
         if params:
             raise ValueError('Q() cannot accept parameters when passing in a dict.')
         if len(name_or_query) != 1:

--- a/elasticsearch_dsl/search.py
+++ b/elasticsearch_dsl/search.py
@@ -1,3 +1,5 @@
+import collections
+
 from six import iteritems, string_types
 
 from elasticsearch.helpers import scan
@@ -84,7 +86,7 @@ class Request(object):
         if isinstance(doc_type, (tuple, list)):
             for dt in doc_type:
                 self._add_doc_type(dt)
-        elif isinstance(doc_type, dict):
+        elif isinstance(doc_type, collections.Mapping):
             self._doc_type.extend(doc_type.keys())
             self._doc_type_map.update(doc_type)
         elif doc_type:

--- a/elasticsearch_dsl/utils.py
+++ b/elasticsearch_dsl/utils.py
@@ -1,5 +1,7 @@
 from __future__ import unicode_literals
 
+import collections
+
 from six import iteritems, add_metaclass
 from six.moves import map
 
@@ -8,7 +10,7 @@ from .exceptions import UnknownDslObject, ValidationException
 SKIP_VALUES = ('', None)
 
 def _wrap(val, obj_wrapper=None):
-    if isinstance(val, dict):
+    if isinstance(val, collections.Mapping):
         return AttrDict(val) if obj_wrapper is None else obj_wrapper(val)
     if isinstance(val, list):
         return AttrList(val)
@@ -290,7 +292,7 @@ class DslBase(object):
                 '%r object has no attribute %r' % (self.__class__.__name__, name))
 
         # wrap nested dicts in AttrDict for convenient access
-        if isinstance(value, dict):
+        if isinstance(value, collections.Mapping):
             return AttrDict(value)
         return value
 
@@ -401,12 +403,12 @@ class ObjectBase(AttrDict):
         self.clean()
 
 def merge(data, new_data):
-    if not (isinstance(data, (AttrDict, dict))
-            and isinstance(new_data, (AttrDict, dict))):
+    if not (isinstance(data, (AttrDict, collections.Mapping))
+            and isinstance(new_data, (AttrDict, collections.Mapping))):
         raise ValueError('You can only merge two dicts! Got %r and %r instead.' % (data, new_data))
 
     for key, value in iteritems(new_data):
-        if key in data and isinstance(data[key], (AttrDict, dict)):
+        if key in data and isinstance(data[key], (AttrDict, collections.Mapping)):
             merge(data[key], value)
         else:
             data[key] = value


### PR DESCRIPTION
`isinstance(var, dict)` is True only when `var` is a `dict`; not when `var` is a `collections.OrderedDict` or a `types.MappingProxyType`, for example.
