### PR TITLE
Fix RangeFacet value filtering

### DIFF
--- a/elasticsearch_dsl/faceted_search.py
+++ b/elasticsearch_dsl/faceted_search.py
@@ -106,9 +106,9 @@ class RangeFacet(Facet):
         f, t = self._ranges[filter_value]
         limits = {}
         if f is not None:
-            limits['from'] = f
+            limits['gte'] = f
         if t is not None:
-            limits['to'] = t
+            limits['lt'] = t
 
         return Q('range', **{
             self._params['field']: limits


### PR DESCRIPTION
According to [official documentation](https://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl-range-query.html) (and to usage), Range Query expect `gte` and `lt` (to be consistent with the aggregation) instead of `from` and `to` (which are only used in aggregation).
