### PR TITLE
Ensure empty fields are cloned

### DIFF
--- a/elasticsearch_dsl/search.py
+++ b/elasticsearch_dsl/search.py
@@ -297,7 +297,7 @@ class Search(Request):
         s._response_class = self._response_class
         s._sort = self._sort[:]
         s._source = self._source.copy() if self._source else None
-        s._fields = self._fields[:] if self._fields else None
+        s._fields = self._fields[:] if self._fields is not None else None
         s._partial_fields = self._partial_fields.copy()
         s._highlight = self._highlight.copy()
         s._highlight_opts = self._highlight_opts.copy()

--- a/test_elasticsearch_dsl/test_search.py
+++ b/test_elasticsearch_dsl/test_search.py
@@ -453,6 +453,16 @@ def test_fields_on_clone():
         'fields': ['title']
     } == search.Search().fields(['title']).filter('term', title='python').to_dict()
 
+def test_empty_fields_on_clone():
+    assert {
+        'query': {
+            'bool': {
+                'filter': [{'term': {'title': 'python'}}],
+            }
+        },
+        'fields': []
+    } == search.Search().fields([]).filter('term', title='python').to_dict()
+
 def test_partial_fields():
     assert {
         'query': {


### PR DESCRIPTION
Right now, when `Search._fields` is set to be empty (ie. `s.fields([])`), it's lost on clone and it's not posssible to only require metadata.
This pull-request fix this case.
