### PR TITLE
[FIX]add String field to __init__

### DIFF
--- a/elasticsearch_dsl/field.py
+++ b/elasticsearch_dsl/field.py
@@ -7,7 +7,7 @@ from .utils import DslBase, _make_dsl_class, ObjectBase, AttrDict, AttrList
 from .exceptions import ValidationException
 
 __all__ = [
-    'construct_field', 'Field', 'Object', 'Nested', 'Date', 'Float', 'Double',
+    'construct_field', 'Field', 'Object', 'Nested', 'Date', 'String', 'Float', 'Double',
     'Byte', 'Short', 'Integer', 'Long', 'Boolean', 'Ip', 'Attachment',
     'GeoPoint', 'GeoShape', 'InnerObjectWrapper', 'Keyword', 'Text'
 ]


### PR DESCRIPTION
can't import string directly from elasticsearch_dsl since miss 'String' in __init__