### PR TITLE
Add support for preserving empty fields

### DIFF
--- a/elasticsearch_dsl/document.py
+++ b/elasticsearch_dsl/document.py
@@ -248,8 +248,8 @@ class DocType(ObjectBase):
             **doc_meta
         )
 
-    def to_dict(self, include_meta=False):
-        d = super(DocType, self).to_dict()
+    def to_dict(self, include_meta=False, include_empty=False):
+        d = super(DocType, self).to_dict(include_empty=include_empty)
         if not include_meta:
             return d
 
@@ -317,4 +317,3 @@ class DocType(ObjectBase):
 
         # return True/False if the document has been created/updated
         return meta['created']
-

--- a/elasticsearch_dsl/utils.py
+++ b/elasticsearch_dsl/utils.py
@@ -358,7 +358,7 @@ class ObjectBase(AttrDict):
             value = self._doc_type.mapping[name].deserialize(value)
         super(ObjectBase, self).__setattr__(name, value)
 
-    def to_dict(self):
+    def to_dict(self, include_empty=False):
         out = {}
         for k, v in iteritems(self._d_):
             try:
@@ -370,7 +370,7 @@ class ObjectBase(AttrDict):
 
             # don't serialize empty values
             # careful not to include numeric zeros
-            if v in ([], {}, None):
+            if not include_empty and v in ([], {}, None):
                 continue
 
             out[k] = v
@@ -410,5 +410,3 @@ def merge(data, new_data):
             merge(data[key], value)
         else:
             data[key] = value
-
-

--- a/test_elasticsearch_dsl/test_document.py
+++ b/test_elasticsearch_dsl/test_document.py
@@ -253,6 +253,11 @@ def test_to_dict_ignores_empty_collections():
     assert {'name': '', 'count': 0, 'valid': False} == md.to_dict()
 
 
+def test_to_dict_can_include_empty_values():
+    md = MyDoc(name=None, address={}, count=0, valid=False, tags=[])
+
+    assert {'name': None, 'count': 0, 'valid': False, 'address': {}, 'tags': []} == md.to_dict(include_empty=True)
+
 def test_declarative_mapping_definition():
     assert issubclass(MyDoc, document.DocType)
     assert hasattr(MyDoc, '_doc_type')


### PR DESCRIPTION
Currently, when calling `DocType#to_dict`, any empty collections or `None` will be omitted from the resulting dictionary. The intention of this behavior is to prevent the case where accessing a field with `multi=True` actually changes it as a side-effect. However, for my use case, I wish to preserve the fact that there's an empty collection, as I recreate all documents from scratch at index time.

This change will allow the caller to override this behavior when calling `DocType#to_dict`. It could also be extended to `DocType#save` if desired, but I use the bulk helper so I have no need for this functionality in `save`.

If this change is not desired, there is a workaround, but it's pretty ugly and relies on accessing a private attribute on the document:

```python
dct = document.to_dict()
for key, value in document._d_.iteritems():
    if value in ([], {}, None):
        dct[key] = value
```