### PR TITLE
Allows doc values to be empty strings in faceted search

### DIFF
--- a/elasticsearch_dsl/faceted_search.py
+++ b/elasticsearch_dsl/faceted_search.py
@@ -204,7 +204,7 @@ class FacetedSearch(object):
         """
         # normalize the value into a list
         if not isinstance(filter_values, (tuple, list)):
-            if filter_values in (None, ''):
+            if filter_values is None:
                 return
             filter_values = [filter_values, ]
 


### PR DESCRIPTION
After #202 this check should have been updated to allow empty strings.