### PR TITLE
Remove deprecated String field from docs

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -135,16 +135,16 @@ Let's have a simple Python class representing an article in a blogging system:
 .. code:: python
 
     from datetime import datetime
-    from elasticsearch_dsl import DocType, String, Date, Integer
+    from elasticsearch_dsl import DocType, Date, Integer, Keyword, Text
     from elasticsearch_dsl.connections import connections
 
     # Define a default Elasticsearch client
     connections.create_connection(hosts=['localhost'])
 
     class Article(DocType):
-        title = String(analyzer='snowball', fields={'raw': String(index='not_analyzed')})
-        body = String(analyzer='snowball')
-        tags = String(index='not_analyzed')
+        title = Text(analyzer='snowball', fields={'raw': Keyword()})
+        body = Text(analyzer='snowball')
+        tags = Keyword()
         published_from = Date()
         lines = Integer()
 

--- a/docs/persistence.rst
+++ b/docs/persistence.rst
@@ -13,20 +13,20 @@ The mapping definition follows a similar pattern to the query dsl:
 
 .. code:: python
 
-    from elasticsearch_dsl import Mapping, String, Nested
+    from elasticsearch_dsl import Keyword, Mapping, Nested, Text
 
     # name your type
     m = Mapping('my-type')
 
     # add fields
-    m.field('title', 'string')
+    m.field('title', 'text')
 
     # you can use multi-fields easily
-    m.field('category', 'string', fields={'raw': String(index='not_analyzed')})
+    m.field('category', 'text', fields={'raw': Keyword()})
 
     # you can also create a field manually
     comment = Nested()
-    comment.field('author', String())
+    comment.field('author', Text())
     comment.field('created_at', Date())
 
     # and attach it to the mapping
@@ -43,7 +43,7 @@ The mapping definition follows a similar pattern to the query dsl:
     By default all fields (with the exception of ``Nested``) will expect single
     values. You can always override this expectation during the field
     creation/definition by passing in ``multi=True`` into the constructor
-    (``m.field('tags', String(index='not_analyzed', multi=True))``). Then the
+    (``m.field('tags', Keyword(multi=True))``). Then the
     value of the field, even if the field hasn't been set, will be an empty
     list enabling you to write ``doc.tags.append('search')``.
 
@@ -73,7 +73,7 @@ Common field options:
 Analysis
 --------
 
-To specify ``analyzer`` values for ``String`` fields you can just use the name
+To specify ``analyzer`` values for ``Text`` fields you can just use the name
 of the analyzer (as a string) and either rely on the analyzer being defined
 (like built-in analyzers) or define the analyzer yourself manually.
 
@@ -108,8 +108,8 @@ If you want to create a model-like wrapper around your documents, use the
 .. code:: python
 
     from datetime import datetime
-    from elasticsearch_dsl import DocType, String, Date, Nested, Boolean, \
-        analyzer, InnerObjectWrapper, Completion
+    from elasticsearch_dsl import DocType, Date, Nested, Boolean, \
+        analyzer, InnerObjectWrapper, Completion, Keyword, Text
 
     html_strip = analyzer('html_strip',
         tokenizer="standard",
@@ -122,20 +122,20 @@ If you want to create a model-like wrapper around your documents, use the
             return datetime.now() - self.created_at
 
     class Post(DocType):
-        title = String()
+        title = Text()
         title_suggest = Completion(payloads=True)
         created_at = Date()
         published = Boolean()
-        category = String(
+        category = Text(
             analyzer=html_strip,
-            fields={'raw': String(index='not_analyzed')}
+            fields={'raw': Keyword()}
         )
 
         comments = Nested(
             doc_class=Comment,
             properties={
-                'author': String(fields={'raw': String(index='not_analyzed')}),
-                'content': String(analyzer='snowball'),
+                'author': Text(fields={'raw': Keyword()}),
+                'content': Text(analyzer='snowball'),
                 'created_at': Date()
             }
         )
@@ -358,7 +358,7 @@ to map and pass any parameters to the ``MetaField`` class:
 .. code:: python
 
     class Post(DocType):
-        title = String()
+        title = Text()
 
         class Meta:
             all = MetaField(enabled=False)
@@ -378,7 +378,7 @@ in a migration:
 
 .. code:: python
 
-    from elasticsearch_dsl import Index, DocType, String, analyzer
+    from elasticsearch_dsl import Index, DocType, Text, analyzer
 
     blogs = Index('blogs')
 
@@ -399,7 +399,7 @@ in a migration:
     # can also be used as class decorator when defining the DocType
     @blogs.doc_type
     class Post(DocType):
-        title = String()
+        title = Text()
 
     # You can attach custom analyzers to the index
 


### PR DESCRIPTION
Fix #534 

Version 5.0 deprecated the `String` field in favor of `Text` (if analyzed) and
`Keyword` (if not analyzed). This commit updates the remainder of the
documentation to reflect the new fields.

Signed-off-by: mattjmcnaughton <mattjmcnaughton@gmail.com>