### PR TITLE
Remove deprecated String from field.py

### DIFF
--- a/elasticsearch_dsl/field.py
+++ b/elasticsearch_dsl/field.py
@@ -223,14 +223,6 @@ class Date(Field):
         except Exception as e:
             raise ValidationException('Could not parse date from the value (%r)' % data, e)
 
-class String(Field):
-    _param_defs = {
-        'fields': {'type': 'field', 'hash': True},
-        'analyzer': {'type': 'analyzer'},
-        'search_analyzer': {'type': 'analyzer'},
-    }
-    name = 'string'
-
 class Text(Field):
     _param_defs = {
         'fields': {'type': 'field', 'hash': True},


### PR DESCRIPTION
Fix #537 

As all use of `String` has been deprecated, we no longer need the class
in `field.py`. This commit removes the class definition.

Relates to #536. I figured since all of the code/documentation references to `String` are gone, its safe to go ahead and delete it.

Signed-off-by: mattjmcnaughton <mattjmcnaughton@gmail.com>