### PR TITLE
Add support for Binary fields

### DIFF
--- a/elasticsearch_dsl/field.py
+++ b/elasticsearch_dsl/field.py
@@ -289,3 +289,6 @@ class GeoShape(Field):
 
 class Completion(Field):
     name = 'completion'
+
+class Binary(Field):
+    name = 'binary'


### PR DESCRIPTION
Fix #539 

Add support for a binary type, which accepts a binary value as a Base64
encoded string.

Signed-off-by: mattjmcnaughton <mattjmcnaughton@gmail.com>