### PR TITLE
Add intellij files to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,7 @@
 .*.swp
 *~
+*.iml
+.idea
 *.py[co]
 .coverage
 *.egg-info


### PR DESCRIPTION
Adding the automatically generated files for an intellij project to the
gitignore, so that anyone developing with intellij on this project is
not introducing unwanted noise to the git commits.

Signed-off-by: mattjmcnaughton <mattjmcnaughton@gmail.com>