### PR TITLE
fix error on aggregation over nested field

### DIFF
--- a/elasticsearch_dsl/mapping.py
+++ b/elasticsearch_dsl/mapping.py
@@ -47,6 +47,8 @@ class Mapping(object):
                 field = field[step]
             except KeyError:
                 return
+            except TypeError:
+                return field
         return field
 
     def _collect_analysis(self):

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ import sys
 from os.path import join, dirname
 from setuptools import setup, find_packages
 
-VERSION = (5, 1, 0)
+VERSION = (5, 1, 1)
 __version__ = VERSION
 __versionstr__ = '.'.join(map(str, VERSION))
 


### PR DESCRIPTION
mapping: 
`
    "tabs": {

    "type": "text",
    "fields": {
        "keyword": {
            "type": "keyword"
        }
    }

}`

`
      q.aggs.bucket('test', 'terms', field='tabs.keyword')

      r = q.execute()

      q.aggregation.test.buckets
`
raises:
exceptions:TypeError: 'String' object has no attribute '__getitem__' 


