### PR TITLE
Fix IllegalOperation when use custom analyzer

### DIFF
--- a/test_elasticsearch_dsl/test_integration/test_mapping.py
+++ b/test_elasticsearch_dsl/test_integration/test_mapping.py
@@ -37,7 +37,8 @@ def test_mapping_saved_into_es(write_client):
 def test_mapping_saved_into_es_when_index_already_exists_closed(write_client):
     m = mapping.Mapping('test-type')
     m.field('name', 'text', analyzer=analysis.analyzer('my_analyzer', tokenizer='keyword'))
-    write_client.indices.create(index='test-mapping')
+    write_client.indices.create(index='test-mapping', body={
+        'settings': {'analysis': m._collect_analysis(False)}})
 
     with raises(exceptions.IllegalOperation):
         m.save('test-mapping', using=write_client)


### PR DESCRIPTION
I have a DocType like this:

```python
from elasticsearch_dsl import (                                                                                   
     DocType, Date, Integer, Text, Float, Boolean, Keyword, SF, Q, A,                                              
     Completion, Long)


ik_analyzer = CustomAnalyzer(                                                                                     
     'ik_analyzer', tokenizer='ik_max_word',                                                                       
     filter=['lowercase']                                                                                          
 )                                                                                                                 
                                                                                                                   
                                                                                                                   
 class Live(DocType):                                                                                              
     ...
     live_suggest = Completion(analyzer=ik_analyzer)
```

The first init,it's works. but after then raise this error all the time：

```python
❯ python crawl.py
Traceback (most recent call last):
 ...
  File "/Users/dongweiming/zhihu/models/live.py", line 160, in init
    Live.init()
  File "/Users/dongweiming/zhihu/venv3/src/elasticsearch-dsl/elasticsearch_dsl/document.py", line 147, in init
    cls._doc_type.init(index, using)
  File "/Users/dongweiming/zhihu/venv3/src/elasticsearch-dsl/elasticsearch_dsl/document.py", line 94, in init
    self.mapping.save(index or self.index, using=using or self.using)
  File "/Users/dongweiming/zhihu/venv3/src/elasticsearch-dsl/elasticsearch_dsl/mapping.py", line 92, in save
    'You cannot update analysis configuration on an open index, you need to close index %s first.' % index)
elasticsearch_dsl.exceptions.IllegalOperation: You cannot update analysis configuration on an open index, you need to close index live first.
```

if i use the following method:

```python
from elasticsearch_dsl.analysis import CustomAnalyzer as _CustomAnalyzer
class CustomAnalyzer(_CustomAnalyzer):
    def get_analysis_definition(self):
        return {}
ik_analyzer = CustomAnalyzer(
    'ik_analyzer', tokenizer='ik_max_word', 
    filter=['lowercase']
```

The first time will raise this error:

```
...
File "/Users/dongweiming/zhihu/models/live.py", line 153, in init
   Live.init()
  File "/Users/dongweiming/zhihu/venv3/src/elasticsearch-dsl/elasticsearch_dsl/document.py", line 147, in init
   cls._doc_type.init(index, using)
  File "/Users/dongweiming/zhihu/venv3/src/elasticsearch-dsl/elasticsearch_dsl/document.py", line 94, in init
   self.mapping.save(index or self.index, using=using or self.using)
  File "/Users/dongweiming/zhihu/venv3/src/elasticsearch-dsl/elasticsearch_dsl/mapping.py", line 79, in save
   es.indices.create(index=index, body={'mappings': self.to_dict(), 'settings': {'analysis': self._collect_analysis()}})
  File "/Users/dongweiming/zhihu/venv3/src/elasticsearch-async/elasticsearch_async/transport.py", line 141, in main_loop
    method, url, params, body, ignore=ignore, timeout=timeout)
  File "/Users/dongweiming/zhihu/venv3/src/elasticsearch-async/elasticsearch_async/connection.py", line 82, in perform_request
    self._raise_error(response.status, raw_data)
  File "/Users/dongweiming/zhihu/venv3/lib/python3.6/site-packages/elasticsearch/connection/base.py", line 122, in _raise_error
    raise HTTP_EXCEPTIONS.get(status_code, TransportError)(status_code, error_message, additional_info)
elasticsearch.exceptions.RequestError: TransportError(400, 'mapper_parsing_exception', "Failed to parse mapping [live]: Can't find default or mapped analyzer with name [ik_analyzer]")
Unclosed client session
```

I'm not sure what I did is correct  @HonzaKral 