### PR TITLE
Add support for percolator type

### DIFF
--- a/elasticsearch_dsl/field.py
+++ b/elasticsearch_dsl/field.py
@@ -289,3 +289,6 @@ class GeoShape(Field):
 
 class Completion(Field):
     name = 'completion'
+
+class Percolator(Field):
+    name = 'percolator'


### PR DESCRIPTION
Fix #572 

Add the Percolator type to the list of supported field types.

Signed-off-by: mattjmcnaughton <mattjmcnaughton@gmail.com>