### PR TITLE
Add analysis to attributes copied by Index clone

### DIFF
--- a/elasticsearch_dsl/index.py
+++ b/elasticsearch_dsl/index.py
@@ -31,7 +31,8 @@ class Index(object):
         :arg using: connection alias to use, defaults to ``'default'``
         """
         i = Index(name, using=using or self._using)
-        for attr in ('_doc_types', '_mappings', '_settings', '_aliases'):
+        for attr in ('_doc_types', '_mappings', '_settings', '_aliases',
+                     '_analysis'):
             setattr(i, attr, getattr(self, attr).copy())
         return i
 

--- a/test_elasticsearch_dsl/test_index.py
+++ b/test_elasticsearch_dsl/test_index.py
@@ -27,6 +27,24 @@ def test_cloned_index_has_copied_settings_and_using():
     assert i._settings == i2._settings
     assert i._settings is not i2._settings
 
+def test_cloned_index_has_analysis_attribute():
+    """
+    Regression test for Issue #582 in which `Index.clone()` was not copying
+    over the `_analysis` attribute.
+    """
+    client = object()
+    i = Index('my-index', using=client)
+
+    random_analyzer_name = ''.join((choice(string.ascii_letters) for _ in range(100)))
+    random_analyzer = analyzer(random_analyzer_name, tokenizer="standard", filter="standard")
+
+    i.analyzer(random_analyzer)
+
+    i2 = i.clone('my-clone-index')
+
+    assert i.to_dict()['settings']['analysis'] == i2.to_dict()['settings']['analysis']
+
+
 def test_settings_are_saved():
     i = Index('i')
     i.settings(number_of_replicas=0)


### PR DESCRIPTION
Fix #582 

Add `_analysis` to the attributes copied when running `Index.clone()`.
This change ensures that `Index.clone` copies all of the relevant
attributes.

Signed-off-by: mattjmcnaughton <mattjmcnaughton@gmail.com>