### PR TITLE
Add test and doc for Search.exclude() in PR #530

### DIFF
--- a/README
+++ b/README
@@ -223,7 +223,7 @@ To install all of the dependencies necessary for development, run:
 
 .. code:: bash
 
-    $ pip install -e .[develop]
+    $ pip install -e '.[develop]'
 
 To run all of the tests for ``elasticsearch-dsl-py``, run:
 

--- a/docs/search_dsl.rst
+++ b/docs/search_dsl.rst
@@ -202,10 +202,17 @@ Behind the scenes this will produce a ``Bool`` query and place the specified
     s = s.query('bool', filter=[Q('terms', tags=['search', 'python'])])
 
 
-
 If you want to use the post_filter element for faceted navigation, use the
 ``.post_filter()`` method.
 
+You can also ``exclude()`` items from your query like this:
+
+.. code:: python
+
+    s = Search()
+    s = s.exclude('terms', tags=['search', 'python'])
+
+which is shorthand for: ``s = s.query('bool', filter=[~Q('terms', tags=['search', 'python'])])``
 
 Aggregations
 ~~~~~~~~~~~~

--- a/test_elasticsearch_dsl/test_search.py
+++ b/test_elasticsearch_dsl/test_search.py
@@ -485,3 +485,23 @@ def test_suggest():
             }
         }
     } == s.to_dict()
+
+def test_exclude():
+    s = search.Search()
+    s = s.exclude('match', title='python')
+
+    assert {
+        'query': {
+            'bool': {
+                'filter': [{
+                    'bool': {
+                        'must_not': [{
+                            'match': {
+                                'title': 'python'
+                            }
+                        }]
+                    }
+                }]
+            }
+        }
+    } == s.to_dict()


### PR DESCRIPTION
Added `test_exclude()` in `test_elasticsearch_dsl/test_search.py` for `Search.exclude()` added in PR #530.
Updated `docs/search_dsl.rst` with a simple example of `Search.exclude()`
Updated the `pip install` in the README to work for all shells.