### PR TITLE
Add method, test and doc for Search.delete()

### DIFF
--- a/docs/search_dsl.rst
+++ b/docs/search_dsl.rst
@@ -84,6 +84,19 @@ explicitly:
 
     print(s.to_dict())
 
+
+Delete By Query
+~~~~~~~~~~~~~~~
+You can delete the documents matching a search by calling ``delete`` on the ``Search`` object instead of
+``execute`` like this:
+
+.. code:: python
+
+    s = Search().query("match", title="python")
+    response = s.delete()
+
+
+
 Queries
 ~~~~~~~
 

--- a/elasticsearch_dsl/search.py
+++ b/elasticsearch_dsl/search.py
@@ -8,7 +8,7 @@ from elasticsearch.exceptions import TransportError
 
 from .query import Q, EMPTY_QUERY, Bool
 from .aggs import A, AggBase
-from .utils import DslBase
+from .utils import DslBase, AttrDict
 from .response import Response, Hit, SuggestResponse
 from .connections import connections
 
@@ -629,6 +629,23 @@ class Search(Request):
             callback = self._doc_type_map.get(hit['_type'], Hit)
             callback = getattr(callback, 'from_es', callback)
             yield callback(hit)
+
+    def delete(self):
+        """
+        delete() executes the query by delegating to delete_by_query()
+        """
+
+        es = connections.get_connection(self._using)
+
+        return AttrDict(
+            es.delete_by_query(
+                index=self._index,
+                body=self.to_dict(),
+                doc_type=self._doc_type,
+                **self._params
+            )
+        )
+
 
 
 class MultiSearch(Request):

--- a/test_elasticsearch_dsl/test_search.py
+++ b/test_elasticsearch_dsl/test_search.py
@@ -505,3 +505,14 @@ def test_exclude():
             }
         }
     } == s.to_dict()
+
+def test_delete_by_query(mock_client):
+    s = search.Search(using='mock') \
+        .query("match", lang="java")
+    s.delete()
+
+    mock_client.delete_by_query.assert_called_once_with(
+        doc_type=[],
+        index=None,
+        body={"query": {"match": {"lang": "java"}}}
+    )


### PR DESCRIPTION
Added Search.delete() that simply delegates to `delete_by_query()` in the low-level `elasticsearch-py` client.
This obviates #351 since delete_by_query is directly available in the low-level client (no need for a bulk delete since ES 5.x).

Added corresponding test to `test_elasticsearch_dsl/test_search.py` and doc to `docs/search_dsl.rst`.

