### PR TITLE
Allow multiple queries and filters for ConstantScore

### DIFF
--- a/elasticsearch_dsl/query.py
+++ b/elasticsearch_dsl/query.py
@@ -179,7 +179,10 @@ class Boosting(Query):
 
 class ConstantScore(Query):
     name = 'constant_score'
-    _param_defs = {'query': {'type': 'query'}, 'filter': {'type': 'query'}}
+    _param_defs = {
+        'query': {'type': 'query', 'multi': True},
+        'filter': {'type': 'query', 'multi': True}
+    }
 
 class DisMax(Query):
     name = 'dis_max'

--- a/test_elasticsearch_dsl/test_query.py
+++ b/test_elasticsearch_dsl/test_query.py
@@ -212,6 +212,17 @@ def test_two_bool_queries_append_one_to_should_if_possible():
     assert (q1 | q2) == query.Bool(should=[query.Match(f='v'), query.Bool(must=[query.Match(f='v')])])
     assert (q2 | q1) == query.Bool(should=[query.Match(f='v'), query.Bool(must=[query.Match(f='v')])])
 
+def test_allow_multiple_queries_for_constant_score_issue_599():
+    # Construct a number of ConstantScore queries each with different
+    # combinations of queries and filters.
+    q1 = query.ConstantScore(query=[query.Match(f=1), query.Match(f=2)])
+    q2 = query.ConstantScore(filter=[query.Match(f=1), query.Match(f=2)])
+    q3 = query.ConstantScore(query=query.Match(f=1))
+    q4 = query.ConstantScore(filter=query.Match(f=1))
+
+    for q in [q1, q2, q3, q4]:
+        assert isinstance(q.to_dict(), dict)
+
 def test_queries_are_registered():
     assert 'match' in query.Query._classes
     assert query.Query._classes['match'] is query.Match


### PR DESCRIPTION
Fix #599 

Fix a user reported error in which a ConstantScore query with
multiple queries/filters was possible when using `elasticsearch-py`,
but resulted in `TypeError unhashable type: 'list'` when attempted
from `elasticsearch-dsl`. Specify that the `query` and `filter` params
have `multi: True`.

Signed-off-by: mattjmcnaughton <mattjmcnaughton@gmail.com>