### PR TITLE
Added `half_float` field

### DIFF
--- a/elasticsearch_dsl/field.py
+++ b/elasticsearch_dsl/field.py
@@ -265,6 +265,9 @@ class Boolean(Field):
 class Float(Field):
     name = 'float'
 
+class HalfFloat(Field):
+    name = 'half_float'
+
 class Double(Field):
     name = 'double'
 


### PR DESCRIPTION
Added an entry in _fields.py_ for the new `half_float` type.

Fixes https://github.com/elastic/elasticsearch-dsl-py/issues/614