### PR TITLE
Create MANIFEST.in

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,4 @@
+include AUTHORS
+include LICENSE
+include README
+include CONTRIBUTING.rst


### PR DESCRIPTION
Hey-lo,

I'm updating the [`conda`](http://conda.pydata.org/) build of `elasticsearch-dsl` on [conda-forge](http://conda-forge.github.io/). When possible, we try to include a link to the license file in the `meta.yaml` specification for the build; doing so requires the license be indexed in an explicit [`MANIFEST.in`](https://docs.python.org/2/distutils/sourcedist.html#manifest-related-options) file so that it gets included in the source distribution. Adding this file guarantee that `LICENSE` gets bundled with the source.