### PR TITLE
Payloads is deprecated.

### DIFF
--- a/docs/persistence.rst
+++ b/docs/persistence.rst
@@ -123,7 +123,7 @@ If you want to create a model-like wrapper around your documents, use the
 
     class Post(DocType):
         title = Text()
-        title_suggest = Completion(payloads=True)
+        title_suggest = Completion()
         created_at = Date()
         published = Boolean()
         category = Text(
@@ -433,4 +433,3 @@ create specific copies:
     dev_blogs = blogs.clone('blogs', using='dev')
     # and change its settings
     dev_blogs.setting(number_of_shards=1)
-


### PR DESCRIPTION
Fixes: #627

Payloads is no longer supported, see [breaking changes](https://www.elastic.co/guide/en/elasticsearch/reference/5.2/breaking_50_suggester.html#_completion_suggester_is_document_oriented).

> Previously, context and completion suggesters supported an index-time payloads option, which was used to store and return metadata with suggestions. Now metadata can be stored as part of the the same document as the suggestion for retrieval at query-time. The support for index-time payloads has been removed to avoid bloating the in-memory index with suggestion metadata.