### PR TITLE
Fix docstring typo for Index.search()

### DIFF
--- a/elasticsearch_dsl/index.py
+++ b/elasticsearch_dsl/index.py
@@ -133,7 +133,7 @@ class Index(object):
 
     def search(self):
         """
-        Rteurn a :class:`~elasticsearch_dsl.Search` object searching over this
+        Return a :class:`~elasticsearch_dsl.Search` object searching over this
         index and its ``DocType``\s.
         """
         return Search(


### PR DESCRIPTION
Sorry, this was bugging me!