### PR TITLE
Minor logic fix in is_published method

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -162,7 +162,7 @@ Let's have a simple Python class representing an article in a blogging system:
             return super(Article, self).save(** kwargs)
 
         def is_published(self):
-            return datetime.now() < self.published_from
+            return datetime.now() >= self.published_from
 
     # create the mappings in elasticsearch
     Article.init()


### PR DESCRIPTION
The check that compares `datetime.now` with `published_from` should be inverted so that any values of `datetime.now` that are greater than or equal to `published_from` result in the `is_published` method returning True.