### PR TITLE
Date Histogram can get int or datetime as key for lookup, lets try both.

### DIFF
--- a/elasticsearch_dsl/faceted_search.py
+++ b/elasticsearch_dsl/faceted_search.py
@@ -140,7 +140,10 @@ class DateHistogramFacet(Facet):
         super(DateHistogramFacet, self).__init__(**kwargs)
 
     def get_value(self, bucket):
-        return datetime.utcfromtimestamp(int(bucket['key']) / 1000)
+        if not isinstance(bucket['key'], datetime):
+            return datetime.utcfromtimestamp(int(bucket['key']) / 1000)
+        else:
+            return bucket['key']
 
     def get_value_filter(self, filter_value):
         return Q('range', **{


### PR DESCRIPTION
When the key for a datetimehistogram was a datetime, it would fail expecting the value to be an int.
Adding checker to check the object type and react accordingly.
Added test