### PR TITLE
Error when getting result facets 

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,22 +11,23 @@ before_install:
   - java -version
 
 python:
-  - "2.6"
-  - "2.7"
-  - "3.3"
-  - "3.4"
+#  - "2.6"
+#  - "2.7"
+#  - "3.3"
+#  - "3.4"
   - "3.5"
-  - "3.6"
-  - "3.6-dev"
-  - "3.7-dev"
-  - "nightly"
+#  - "3.6"
+#  - "3.6-dev"
+#  - "3.7-dev"
+#  - "nightly"
 
 env:
   global:
     - WAIT_FOR_ES=1
   matrix:
-    - ES_VERSION=5.0.2
-    - ES_VERSION=5.1.1
+    #- ES_VERSION=5.0.2
+    #- ES_VERSION=5.1.1
+    - ES_VERSION=5.4.1
 
 install:
   - mkdir /tmp/elasticsearch

--- a/test_elasticsearch_dsl/test_faceted_search.py
+++ b/test_elasticsearch_dsl/test_faceted_search.py
@@ -131,3 +131,10 @@ def test_filters_are_applied_to_search_ant_relevant_facets():
         'highlight': {'fields': {'body': {}, 'title': {}}}
     } == d
 
+
+def test_response_facets():
+    bs = BlogSearch('python search', filters={'category': 'elastic', 'tags': ['python', 'django']})
+    s = bs.build_search()
+    r = s.execute()
+    facets = r.facets()
+    assert facets == {'category': 'elastic', 'tags': ['python', 'django']}

--- a/test_elasticsearch_dsl/test_faceted_search.py
+++ b/test_elasticsearch_dsl/test_faceted_search.py
@@ -130,11 +130,3 @@ def test_filters_are_applied_to_search_ant_relevant_facets():
         },
         'highlight': {'fields': {'body': {}, 'title': {}}}
     } == d
-
-
-def test_response_facets():
-    bs = BlogSearch('python search', filters={'category': 'elastic', 'tags': ['python', 'django']})
-    s = bs.build_search()
-    r = s.execute()
-    facets = r.facets()
-    assert facets == {'category': 'elastic', 'tags': ['python', 'django']}

--- a/test_elasticsearch_dsl/test_integration/test_faceted_search.py
+++ b/test_elasticsearch_dsl/test_integration/test_faceted_search.py
@@ -36,6 +36,8 @@ def test_boolean_facet(data_client):
     rs = RepoSearch()
     r = rs.execute()
 
+    assert r.facets == {}
+
     assert r.hits.total == 1
     assert [(True, 1, False)] == r.facets.public
 


### PR DESCRIPTION
I recently upgraded from v2 and I have an error while trying to access to facets attribute:
`AttributeError: 'FacetedResponse' object has no attribute 'facets'`

And when accessing again it doesn't crash anymore but returns an empty dictionary instead of the expected result I had with v2.

Trying to reproduce the error on a more minimal setup here.