### PR TITLE
Loading aggregation with metadata from dictionary

### DIFF
--- a/Changelog.rst
+++ b/Changelog.rst
@@ -3,6 +3,10 @@
 Changelog
 =========
 
+master
+------
+ * fix bug in loading an aggregation with meta data from dict
+
 5.3.0 (2017-05-18)
 ------------------
  * fix constant score query definition

--- a/elasticsearch_dsl/aggs.py
+++ b/elasticsearch_dsl/aggs.py
@@ -17,6 +17,8 @@ def A(name_or_agg, filter=None, **params):
         agg = name_or_agg.copy()
         # pop out nested aggs
         aggs = agg.pop('aggs', None)
+        # pop out meta data
+        meta = agg.pop('meta', None)
         # should be {"terms": {"field": "tags"}}
         if len(agg) != 1:
             raise ValueError('A() can only accept dict with an aggregation ({"terms": {...}}). '
@@ -25,6 +27,9 @@ def A(name_or_agg, filter=None, **params):
         if aggs:
             params = params.copy()
             params['aggs'] = aggs
+        if meta:
+            params = params.copy()
+            params['meta'] = meta
         return Agg.get_dsl_class(agg_type)(_expand__to_dot=False, **params)
 
     # Terms(...) just return the nested agg

--- a/test_elasticsearch_dsl/test_aggs.py
+++ b/test_elasticsearch_dsl/test_aggs.py
@@ -18,6 +18,12 @@ def test_meta():
         'meta': {'some': 'metadata'}
     } == a.to_dict()
 
+def test_meta_from_dict():
+    max_score = aggs.Max(field='score')
+    a = aggs.A('terms', field='tags', aggs={'max_score': max_score}, meta={'some': 'metadata'})
+
+    assert aggs.A(a.to_dict()) == a
+
 def test_A_creates_proper_agg():
     a = aggs.A('terms', field='tags')
 


### PR DESCRIPTION
Hi,

We got an error while using an aggregation with meta data.
This code:
```
agg_as_dict = {
        'terms': {'field': 'tags'},
        'aggs': {'max_score': {'max': {'field': 'score'}}},
        'meta': {'some': 'metadata'}
}
agg = A(agg_as_dict)
```
Fails with `ValueError: A() can only accept dict with an aggregation`.

I added a test and implemented a fix.

Thanks!
Ohad