### PR TITLE
added boost_mode to function_score #702

### DIFF
--- a/elasticsearch_dsl/query.py
+++ b/elasticsearch_dsl/query.py
@@ -162,6 +162,7 @@ class FunctionScore(Query):
         'query': {'type': 'query'},
         'filter': {'type': 'query'},
         'functions': {'type': 'score_function', 'multi': True},
+        'boost_mode': {},
     }
 
     def __init__(self, **kwargs):


### PR DESCRIPTION
ability to set `boost_mode` in a function_score

example:

```
GET /_search
{
    "query": {
        "function_score": {
            "query": { "match_all": {} },
            "boost": "5",
            "random_score": {}, 
            "boost_mode":"multiply"
        }
    }
}
```

more:
https://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl-function-score-query.html#score-functions


