### PR TITLE
repr Response object for more details

### DIFF
--- a/elasticsearch_dsl/response/__init__.py
+++ b/elasticsearch_dsl/response/__init__.py
@@ -25,7 +25,7 @@ class Response(AttrDict):
     __bool__ = __nonzero__
 
     def __repr__(self):
-        return '<Response: %r>' % self.hits
+        return '<Response: %r>' % (self.hits or self.aggregations)
 
     def __len__(self):
         return len(self.hits)


### PR DESCRIPTION
Some results of aggregations like cardinality  may not contains hits, and print result will show `<Response: []>`, which make user think the result is empty, but in fact, `response.aggregations` contains results.