### PR TITLE
Prevent datetimes from dropping milliseconds

### DIFF
--- a/elasticsearch_dsl/faceted_search.py
+++ b/elasticsearch_dsl/faceted_search.py
@@ -145,7 +145,8 @@ class DateHistogramFacet(Facet):
             # so we need to set key to 0 to avoid TypeError exception
             if bucket['key'] is None:
                 bucket['key'] = 0
-            return datetime.utcfromtimestamp(int(bucket['key']) / 1000)
+            # Preserve milliseconds in the datetime
+            return datetime.utcfromtimestamp(int(bucket['key']) / 1000.0)
         else:
             return bucket['key']
 

--- a/elasticsearch_dsl/field.py
+++ b/elasticsearch_dsl/field.py
@@ -218,7 +218,8 @@ class Date(Field):
         if isinstance(data, date):
             return data
         if isinstance(data, int):
-            return datetime.utcfromtimestamp(data / 1000)
+            # Divide by a float to preserve milliseconds on the datetime.
+            return datetime.utcfromtimestamp(data / 1000.0)
 
         try:
             # TODO: add format awareness


### PR DESCRIPTION
Fix #750

Fix an issue inwhich dates in elasticsearch which have
milliseconds may lose these milliseconds when retrieved,
because of how we manipulate the timestamp.