### PR TITLE
Fix #692: Can't create custom stemming filter

### DIFF
--- a/elasticsearch_dsl/analysis.py
+++ b/elasticsearch_dsl/analysis.py
@@ -19,9 +19,9 @@ class AnalysisBase(object):
 
 class CustomAnalysis(object):
     name = 'custom'
-    def __init__(self, name, builtin_type='custom', **kwargs):
+    def __init__(self, filter_name, builtin_type='custom', **kwargs):
         self._builtin_type = builtin_type
-        self._name = name
+        self._name = filter_name
         super(CustomAnalysis, self).__init__(**kwargs)
 
     def to_dict(self):

--- a/test_elasticsearch_dsl/test_analysis.py
+++ b/test_elasticsearch_dsl/test_analysis.py
@@ -79,3 +79,11 @@ def test_custom_analyzer_can_collect_custom_items():
         }
     } == a.get_analysis_definition()
 
+def test_stemmer_analyzer_can_pass_name():
+    t = analysis.token_filter('my_english_filter', name="minimal_english", type="stemmer")
+    assert t.to_dict() == 'my_english_filter'
+    assert {
+        "type" : "stemmer",
+        "name" : "minimal_english"
+    } == t.get_definition()
+


### PR DESCRIPTION
A default positional parameter in CustomAnalysis is called name which
conflicts with a parameter needed by the stemmer type filter. The parameter
 is renamed to filter_name instead of name to avoid conflict.