### PR TITLE
6.0 - fix to look for 'result' key in es response

### DIFF
--- a/elasticsearch_dsl/document.py
+++ b/elasticsearch_dsl/document.py
@@ -434,4 +434,4 @@ class DocType(ObjectBase):
                 setattr(self.meta, k, meta['_' + k])
 
         # return True/False if the document has been created/updated
-        return meta['created']
+        return 'created' in meta['result']


### PR DESCRIPTION
6.0 uses a 'result' key with the response type vs 'created'. This obviously doesn't resolve issues for 6.0, but was enough for me to move forward given i have have single types per index.