### PR TITLE
Explicit `scaling_factor` arg in `__init__`

### DIFF
--- a/elasticsearch_dsl/field.py
+++ b/elasticsearch_dsl/field.py
@@ -276,6 +276,10 @@ class HalfFloat(Field):
 class ScaledFloat(Field):
     name = 'scaled_float'
 
+    def __init__(self, scaling_factor, *args, **kwargs):
+        super(ScaledFloat, self).__init__(scaling_factor=scaling_factor, *args, **kwargs)
+
+
 class Double(Field):
     name = 'double'
 

--- a/test_elasticsearch_dsl/test_field.py
+++ b/test_elasticsearch_dsl/test_field.py
@@ -1,4 +1,7 @@
+import pytest
+
 from elasticsearch_dsl import field
+
 
 def test_custom_field_car_wrap_other_field():
     class MyField(field.CustomField):
@@ -73,3 +76,11 @@ def test_multifield_supports_multiple_analyzers():
        },
        'type': 'text'
     } == f.to_dict()
+
+
+def test_scaled_float():
+    with pytest.raises(TypeError) as exc:
+        field.ScaledFloat()
+    assert "required positional argument: 'scaling_factor'" in str(exc.value)
+    f = field.ScaledFloat(123)
+    assert f.to_dict() == {'scaling_factor': 123, 'type': 'scaled_float'}

--- a/test_elasticsearch_dsl/test_field.py
+++ b/test_elasticsearch_dsl/test_field.py
@@ -79,8 +79,7 @@ def test_multifield_supports_multiple_analyzers():
 
 
 def test_scaled_float():
-    with pytest.raises(TypeError) as exc:
+    with pytest.raises(TypeError):
         field.ScaledFloat()
-    assert "required positional argument: 'scaling_factor'" in str(exc.value)
     f = field.ScaledFloat(123)
     assert f.to_dict() == {'scaling_factor': 123, 'type': 'scaled_float'}


### PR DESCRIPTION
Rationale for this: ability to get exception before putting the mapping in actual ES. `scaling_factor` is mandatory anyway.