### PR TITLE
Classifiers fixes

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -36,8 +36,3 @@ install:
 
 script:
   - python setup.py test
-
-notifications:
-  email:
-    recipients:
-      - honza.kral@gmail.com

--- a/.travis.yml
+++ b/.travis.yml
@@ -37,3 +37,8 @@ install:
 
 script:
   - python setup.py test
+
+notifications:
+  email:
+    recipients:
+      - honza.kral@gmail.com

--- a/.travis.yml
+++ b/.travis.yml
@@ -20,6 +20,7 @@ python:
   - "3.6-dev"
   - "3.7-dev"
   - "nightly"
+  - "pypy"
 
 env:
   global:

--- a/setup.py
+++ b/setup.py
@@ -53,6 +53,8 @@ setup(
         "Programming Language :: Python :: 3.2",
         "Programming Language :: Python :: 3.3",
         "Programming Language :: Python :: 3.4",
+        "Programming Language :: Python :: 3.5",
+        "Programming Language :: Python :: 3.6",
         "Programming Language :: Python :: Implementation :: CPython",
         "Programming Language :: Python :: Implementation :: PyPy",
     ],


### PR DESCRIPTION
Added `pypy` build – as far as I remember, at some time it was building in travis. Correct me if its no longer valuable. Overall, dsl seems to work fine under `pypy`.

Added `setup.py` classifiers according to current versions being tested.