### PR TITLE
[WIP] Implemented OtherNested (name TBD)

### DIFF
--- a/elasticsearch_dsl/__init__.py
+++ b/elasticsearch_dsl/__init__.py
@@ -3,7 +3,7 @@ from .aggs import A
 from .function import SF
 from .search import Search, MultiSearch
 from .field import *
-from .document import DocType, MetaField
+from .document import DocType, MetaField, InnerDoc
 from .mapping import Mapping
 from .index import Index, IndexTemplate
 from .analysis import analyzer, token_filter, char_filter, tokenizer

--- a/elasticsearch_dsl/document.py
+++ b/elasticsearch_dsl/document.py
@@ -95,6 +95,13 @@ class DocTypeOptions(object):
     def refresh(self, index=None, using=None):
         self.mapping.update_from_es(index or self.index, using=using or self.using)
 
+@add_metaclass(DocTypeMeta)
+class InnerDoc(ObjectBase):
+    """
+    Common class for inner documents like Object or Nested
+    """
+    pass
+
 
 @add_metaclass(DocTypeMeta)
 class DocType(ObjectBase):

--- a/elasticsearch_dsl/document.py
+++ b/elasticsearch_dsl/document.py
@@ -6,20 +6,11 @@ from six import iteritems, add_metaclass
 
 from .field import Field
 from .mapping import Mapping
-from .utils import ObjectBase, AttrDict, merge
+from .utils import ObjectBase, AttrDict, merge, DOC_META_FIELDS, META_FIELDS
 from .response import HitMeta
 from .search import Search
 from .connections import connections
 from .exceptions import ValidationException, IllegalOperation
-
-DOC_META_FIELDS = frozenset((
-    'id', 'routing', 'version', 'version_type'
-))
-
-META_FIELDS = frozenset((
-    # Elasticsearch metadata fields, except 'type'
-    'index', 'using', 'score',
-)).union(DOC_META_FIELDS)
 
 
 class MetaField(object):
@@ -100,7 +91,6 @@ class InnerDoc(ObjectBase):
     """
     Common class for inner documents like Object or Nested
     """
-    pass
 
 
 @add_metaclass(DocTypeMeta)
@@ -256,27 +246,6 @@ class DocType(ObjectBase):
             message = 'Documents %s not found.' % ', '.join(missing_ids)
             raise NotFoundError(404, message, {'docs': missing_docs})
         return objs
-
-    @classmethod
-    def from_es(cls, hit):
-        """
-        Helper method to construct an instance from a dictionary returned by
-        elasticsearch.
-        """
-        # don't modify in place
-        meta = hit.copy()
-        doc = meta.pop('_source', {})
-
-        if 'fields' in meta:
-            for k, v in iteritems(meta.pop('fields')):
-                if k == '_source':
-                    doc.update(v)
-                if k.startswith('_') and k[1:] in META_FIELDS:
-                    meta[k] = v
-                else:
-                    doc[k] = v
-
-        return cls(meta=meta, **doc)
 
     def _get_connection(self, using=None):
         return connections.get_connection(using or self._doc_type.using)

--- a/test_elasticsearch_dsl/conftest.py
+++ b/test_elasticsearch_dsl/conftest.py
@@ -13,7 +13,7 @@ from .test_integration.test_data import DATA, FLAT_DATA, create_git_index, \
 
 
 @fixture(scope='session')
-def client(request):
+def client():
     try:
         connection = get_test_client(nowait='WAIT_FOR_ES' not in os.environ)
         connections.add_connection('default', connection)
@@ -22,13 +22,13 @@ def client(request):
         skip()
 
 @fixture
-def write_client(request, client):
+def write_client(client):
     yield client
     client.indices.delete('test-*', ignore=404)
     client.indices.delete_template('test-template', ignore=404)
 
 @fixture
-def mock_client(request):
+def mock_client():
     client = Mock()
     client.search.return_value = dummy_response()
     connections.add_connection('mock', client)
@@ -37,7 +37,7 @@ def mock_client(request):
     connections._kwargs = {}
 
 @fixture(scope='session')
-def data_client(request, client):
+def data_client(client):
     # create mappings
     create_git_index(client, 'git')
     create_flat_git_index(client, 'flat-git')

--- a/test_elasticsearch_dsl/conftest.py
+++ b/test_elasticsearch_dsl/conftest.py
@@ -74,7 +74,7 @@ def dummy_response():
             "_type": "employee",
             "_id": "42",
             "_score": 11.123,
-            "_parent": "elasticsearch",
+            "_routing": "elasticsearch",
 
             "_source": {
               "name": {
@@ -90,7 +90,7 @@ def dummy_response():
             "_type": "employee",
             "_id": "47",
             "_score": 1,
-            "_parent": "elasticsearch",
+            "_routing": "elasticsearch",
 
             "_source": {
               "name": {
@@ -106,7 +106,7 @@ def dummy_response():
             "_type": "employee",
             "_id": "53",
             "_score": 16.0,
-            "_parent": "elasticsearch",
+            "_routing": "elasticsearch",
           },
         ],
         "max_score": 12.0,
@@ -119,7 +119,7 @@ def dummy_response():
 @fixture
 def aggs_search():
     from elasticsearch_dsl import Search
-    s = Search(index='git', doc_type='commits')
+    s = Search(index='flat-git')
     s.aggs\
         .bucket('popular_files', 'terms', field='files', size=2)\
         .metric('line_stats', 'stats', field='stats.lines')\
@@ -156,27 +156,23 @@ def aggs_data():
                                 'hits': [
                                     {
                                         '_id': '3ca6e1e73a071a705b4babd2f581c91a2a3e5037',
-                                        '_type': 'commits',
+                                        '_type': 'doc',
                                         '_source': {
                                             'stats': {'files': 4, 'deletions': 7, 'lines': 30, 'insertions': 23},
                                             'committed_date': '2014-05-02T13:47:19'
                                         },
                                         '_score': 1.0,
-                                        '_parent': 'elasticsearch-dsl-py',
-                                        '_routing': 'elasticsearch-dsl-py',
-                                        '_index': 'git'
+                                        '_index': 'flat-git'
                                     },
                                     {
                                         '_id': 'eb3e543323f189fd7b698e66295427204fff5755',
-                                        '_type': 'commits',
+                                        '_type': 'doc',
                                         '_source': {
                                             'stats': {'files': 1, 'deletions': 0, 'lines': 18, 'insertions': 18},
                                             'committed_date': '2014-05-01T13:32:14'
                                         },
                                         '_score': 1.0,
-                                        '_parent': 'elasticsearch-dsl-py',
-                                        '_routing': 'elasticsearch-dsl-py',
-                                        '_index': 'git'
+                                        '_index': 'flat-git'
                                     }
                                 ],
                                 'max_score': 1.0
@@ -193,26 +189,22 @@ def aggs_data():
                                 'hits': [
                                     {
                                         '_id': '3ca6e1e73a071a705b4babd2f581c91a2a3e5037',
-                                        '_type': 'commits',
+                                        '_type': 'doc',
                                         '_source': {
                                             'stats': {'files': 4, 'deletions': 7, 'lines': 30, 'insertions': 23},
                                             'committed_date': '2014-05-02T13:47:19'
                                         },
                                         '_score': 1.0,
-                                        '_parent': 'elasticsearch-dsl-py',
-                                        '_routing': 'elasticsearch-dsl-py',
-                                        '_index': 'git'
+                                        '_index': 'flat-git'
                                     }, {
                                         '_id': 'dd15b6ba17dd9ba16363a51f85b31f66f1fb1157',
-                                        '_type': 'commits',
+                                        '_type': 'doc',
                                         '_source': {
                                             'stats': {'files': 3, 'deletions': 18, 'lines': 62, 'insertions': 44},
                                             'committed_date': '2014-05-01T13:30:44'
                                         },
                                         '_score': 1.0,
-                                        '_parent': 'elasticsearch-dsl-py',
-                                        '_routing': 'elasticsearch-dsl-py',
-                                        '_index': 'git'
+                                        '_index': 'flat-git'
                                     }
                                 ],
                                 'max_score': 1.0

--- a/test_elasticsearch_dsl/test_document.py
+++ b/test_elasticsearch_dsl/test_document.py
@@ -3,19 +3,19 @@ import codecs
 from hashlib import md5
 from datetime import datetime
 
-from elasticsearch_dsl import document, field, Mapping, utils
+from elasticsearch_dsl import document, field, Mapping, utils, InnerDoc
 from elasticsearch_dsl.exceptions import ValidationException, IllegalOperation
 
 from pytest import raises
 
-class MyInner(field.InnerObjectWrapper):
-    pass
+class MyInner(InnerDoc):
+    old_field = field.Text()
 
 class MyDoc(document.DocType):
     title = field.Keyword()
     name = field.Text()
     created_at = field.Date()
-    inner = field.Object(properties={'old_field': field.Text()}, doc_class=MyInner)
+    inner = field.Object(MyInner)
 
 class MySubDoc(MyDoc):
     name = field.Keyword()
@@ -35,7 +35,7 @@ class Comment(document.InnerDoc):
     tags = field.Keyword(multi=True)
 
 class DocWithNested(document.DocType):
-    comments = field.OtherNested(Comment)
+    comments = field.Nested(Comment)
 
 class SimpleCommit(document.DocType):
     files = field.Text(multi=True)
@@ -60,7 +60,7 @@ class SecretDoc(document.DocType):
     title = SecretField(index='no')
 
 class NestedSecret(document.DocType):
-    secrets = field.Nested(properties={'title': SecretField()})
+    secrets = field.Nested(SecretDoc)
 
 class OptionalObjectWithRequiredField(document.DocType):
     comments = field.Nested(properties={'title': field.Keyword(required=True)})

--- a/test_elasticsearch_dsl/test_document.py
+++ b/test_elasticsearch_dsl/test_document.py
@@ -30,13 +30,12 @@ class MyDoc2(document.DocType):
 class MyMultiSubDoc(MyDoc2, MySubDoc):
     pass
 
+class Comment(document.InnerDoc):
+    title = field.Text()
+    tags = field.Keyword(multi=True)
+
 class DocWithNested(document.DocType):
-    comments = field.Nested(
-        properties={
-            'title': field.Text(),
-            'tags': field.Keyword(multi=True)
-        }
-    )
+    comments = field.OtherNested(Comment)
 
 class SimpleCommit(document.DocType):
     files = field.Text(multi=True)
@@ -240,8 +239,10 @@ def test_nested_can_be_assigned_to():
     d2 = DocWithNested()
 
     d2.comments = d1.comments
+    assert isinstance(d1.comments[0], Comment)
     assert d2.comments == [{'title': 'First!'}]
     assert {'comments': [{'title': 'First!'}]} == d2.to_dict()
+    assert isinstance(d2.comments[0], Comment)
 
 def test_nested_can_be_none():
     d = DocWithNested(comments=None, title='Hello World!')

--- a/test_elasticsearch_dsl/test_field.py
+++ b/test_elasticsearch_dsl/test_field.py
@@ -64,20 +64,8 @@ def test_multi_fields_are_accepted_and_parsed():
         }
     } == f.to_dict()
 
-def test_modifying_nested():
-    f = field.Nested()
-    f.field('name', 'text', index='not_analyzed')
-
-    assert {
-        'type': 'nested',
-        'properties': {
-            'name': {'type': 'text', 'index': 'not_analyzed'}
-        },
-    } == f.to_dict()
-
 def test_nested_provides_direct_access_to_its_fields():
-    f = field.Nested()
-    f.field('name', 'text', index='not_analyzed')
+    f = field.Nested(properties={'name': {'type': 'text', 'index': 'not_analyzed'}})
 
     assert 'name' in f
     assert f['name'] == field.Text(index='not_analyzed')

--- a/test_elasticsearch_dsl/test_integration/test_document.py
+++ b/test_elasticsearch_dsl/test_integration/test_document.py
@@ -11,16 +11,14 @@ from pytest import raises
 class User(InnerDoc):
     name = Text(fields={'raw': Keyword()})
 
-user_field = Object(User)
-
 class Wiki(DocType):
-    owner = user_field
+    owner = Object(User)
 
     class Meta:
         index = 'test-wiki'
 
 class Repository(DocType):
-    owner = user_field
+    owner = Object(User)
     created_at = Date()
     description = Text(analyzer='snowball')
     tags = Keyword()

--- a/test_elasticsearch_dsl/test_integration/test_document.py
+++ b/test_elasticsearch_dsl/test_integration/test_document.py
@@ -72,6 +72,15 @@ def test_nested_inner_hits_are_wrapped_properly(pull_request):
     comment = pr.meta.inner_hits.comments.hits[0]
     assert isinstance(comment, Comment)
 
+def test_nested_top_hits_are_wrapped_properly(pull_request):
+    s = PullRequest.search()
+    s.aggs.bucket('comments', 'nested', path='comments').metric('hits', 'top_hits', size=1)
+
+    r = s.execute()
+
+    print(r._d_)
+    assert isinstance(r.aggregations.comments.hits.hits[0], Comment)
+
 
 def test_update_object_field(write_client):
     Wiki.init()

--- a/test_elasticsearch_dsl/test_integration/test_document.py
+++ b/test_elasticsearch_dsl/test_integration/test_document.py
@@ -3,13 +3,15 @@ from pytz import timezone
 
 from elasticsearch import ConflictError, NotFoundError, RequestError
 
-from elasticsearch_dsl import DocType, Date, Text, Keyword, construct_field, Mapping
+from elasticsearch_dsl import DocType, Date, Text, Keyword, Mapping, InnerDoc, Object
 from elasticsearch_dsl.utils import AttrList
 
 from pytest import raises
 
-user_field = construct_field('object')
-user_field.field('name', 'text', fields={'raw': construct_field('keyword')})
+class User(InnerDoc):
+    name = Text(fields={'raw': Keyword()})
+
+user_field = Object(User)
 
 class Wiki(DocType):
     owner = user_field

--- a/test_elasticsearch_dsl/test_mapping.py
+++ b/test_elasticsearch_dsl/test_mapping.py
@@ -20,17 +20,16 @@ def test_mapping_update_is_recursive():
     m1 = mapping.Mapping('article')
     m1.field('title', 'text')
     m1.field('author', 'object')
-    m1['author'].field('name', 'text')
+    m1.field('author', 'object', properties={'name': {'type': 'text'}})
     m1.meta('_all', enabled=False)
     m1.meta('dynamic', False)
 
     m2 = mapping.Mapping('article')
     m2.field('published_from', 'date')
-    m2.field('author', 'object')
+    m2.field('author', 'object', properties={'email': {'type': 'text'}})
     m2.field('title', 'text')
     m2.field('lang', 'keyword')
     m2.meta('_analyzer', path='lang')
-    m2['author'].field('email', 'text')
 
     m1.update(m2, update_only=True)
 

--- a/test_elasticsearch_dsl/test_result.py
+++ b/test_elasticsearch_dsl/test_result.py
@@ -90,7 +90,7 @@ def test_iterating_over_response_gives_you_hits(dummy_response):
     assert 'elasticsearch' == h.meta.id
     assert 12 == h.meta.score
 
-    assert hits[1].meta.parent == 'elasticsearch'
+    assert hits[1].meta.routing == 'elasticsearch'
 
 def test_hits_get_wrapped_to_contain_additional_attrs(dummy_response):
     res = response.Response(Search(), dummy_response)

--- a/test_elasticsearch_dsl/test_validation.py
+++ b/test_elasticsearch_dsl/test_validation.py
@@ -1,25 +1,21 @@
 from datetime import datetime
 
-from elasticsearch_dsl import DocType, Nested, Text, Date, Object, Boolean, Integer
-from elasticsearch_dsl.field import InnerObjectWrapper
+from elasticsearch_dsl import DocType, Nested, Text, Date, Object, Boolean, Integer, InnerDoc
 from elasticsearch_dsl.exceptions import ValidationException
 
 from pytest import raises
 
-class Author(InnerObjectWrapper):
+class Author(InnerDoc):
+    name = Text(required=True)
+    email = Text(required=True)
+
     def clean(self):
+        print(self, type(self), self.name)
         if self.name.lower() not in self.email:
             raise ValidationException('Invalid email!')
 
 class BlogPost(DocType):
-    authors = Nested(
-        required=True,
-        doc_class=Author,
-        properties={
-            'name': Text(required=True),
-            'email': Text(required=True)
-        }
-    )
+    authors = Nested(Author, required=True)
     created = Date()
     inner = Object()
 


### PR DESCRIPTION
Proof of concept only for now, more code, tests, and docs forthcoming...

Implementing a better interface for `Nested` fields which would allow easier, and more consistent, mapping definitions like:
```python
from elasticsearch_dsl import InnerDoc, DocType, Text, Keyword, Nested
class Comment(InnerDoc):
    title = Text()                                                        
    tags = Keyword(multi=True)                                            
                                                                                
class BlogPost(DocType):                                          
    comments = Nested(Comment)   
```