### PR TITLE
Added (de)serialisation for integer, float, ip and binary types.

### DIFF
--- a/elasticsearch_dsl/field.py
+++ b/elasticsearch_dsl/field.py
@@ -272,6 +272,7 @@ class Keyword(Field):
 
 class Boolean(Field):
     name = 'boolean'
+    _coerce = True
 
     def _deserialize(self, data):
         if data is None:
@@ -287,9 +288,9 @@ class Boolean(Field):
             raise ValidationException("Value required for this field.")
         return data
 
-
 class Float(Field):
     name = 'float'
+    _coerce = True
 
     def _deserialize(self, data):
         if data is None:
@@ -305,19 +306,17 @@ class ScaledFloat(Float):
     def __init__(self, scaling_factor, *args, **kwargs):
         super(ScaledFloat, self).__init__(scaling_factor=scaling_factor, *args, **kwargs)
 
-
 class Double(Float):
     name = 'double'
 
-
 class Integer(Field):
     name = 'integer'
+    _coerce = True
 
     def _deserialize(self, data):
         if data is None:
             return None
         return int(data)
-
 
 class Byte(Integer):
     name = 'byte'
@@ -330,6 +329,7 @@ class Long(Integer):
 
 class Ip(Field):
     name = 'ip'
+    _coerce = True
 
     def _deserialize(self, data):
         if data is None:
@@ -345,6 +345,7 @@ class Ip(Field):
 
 class Binary(Field):
     name = 'binary'
+    _coerce = True
 
     def _deserialize(self, data):
         if data is None:
@@ -391,6 +392,3 @@ class TokenCount(Field):
 
 class Murmur3:
     name = 'murmur3'
-
-class Percolator:
-    name = 'percolator'

--- a/elasticsearch_dsl/field.py
+++ b/elasticsearch_dsl/field.py
@@ -4,6 +4,8 @@ import ipaddress
 import collections
 
 from datetime import date, datetime
+
+import six
 from dateutil import parser, tz
 from six import itervalues, string_types
 from six.moves import map
@@ -332,7 +334,9 @@ class Ip(Field):
     def _deserialize(self, data):
         if data is None:
             return None
-        return ipaddress.ip_interface(data)
+
+        # the ipaddress library for pypy, python2.5 and 2.6 only accepts unicode.
+        return ipaddress.ip_interface(six.u(data))
 
     def _serialize(self, data):
         if data is None:

--- a/elasticsearch_dsl/field.py
+++ b/elasticsearch_dsl/field.py
@@ -1,3 +1,6 @@
+import base64
+import ipaddress
+
 import collections
 
 from datetime import date, datetime
@@ -282,39 +285,72 @@ class Boolean(Field):
             raise ValidationException("Value required for this field.")
         return data
 
+
 class Float(Field):
     name = 'float'
 
-class HalfFloat(Field):
+    def _deserialize(self, data):
+        if data is None:
+            return None
+        return float(data)
+
+class HalfFloat(Float):
     name = 'half_float'
 
-class ScaledFloat(Field):
+class ScaledFloat(Float):
     name = 'scaled_float'
 
     def __init__(self, scaling_factor, *args, **kwargs):
         super(ScaledFloat, self).__init__(scaling_factor=scaling_factor, *args, **kwargs)
 
 
-class Double(Field):
+class Double(Float):
     name = 'double'
 
-class Byte(Field):
-    name = 'byte'
-
-class Short(Field):
-    name = 'short'
 
 class Integer(Field):
     name = 'integer'
 
-class Long(Field):
+    def _deserialize(self, data):
+        if data is None:
+            return None
+        return int(data)
+
+
+class Byte(Integer):
+    name = 'byte'
+
+class Short(Integer):
+    name = 'short'
+
+class Long(Integer):
     name = 'long'
 
 class Ip(Field):
     name = 'ip'
 
-class Attachment(Field):
-    name = 'attachment'
+    def _deserialize(self, data):
+        if data is None:
+            return None
+        return ipaddress.ip_interface(data)
+
+    def _serialize(self, data):
+        if data is None:
+            return None
+        return str(data)
+
+class Binary(Field):
+    name = 'binary'
+
+    def _deserialize(self, data):
+        if data is None:
+            return None
+        return base64.b64decode(data)
+
+    def _serialize(self, data):
+        if data is None:
+            return None
+        return base64.b64encode(data)
 
 class GeoPoint(Field):
     name = 'geo_point'
@@ -345,3 +381,12 @@ class DateRange(Field):
 
 class Join(Field):
     name = 'join'
+
+class TokenCount(Field):
+    name = 'token_count'
+
+class Murmur3:
+    name = 'murmur3'
+
+class Percolator:
+    name = 'percolator'

--- a/setup.py
+++ b/setup.py
@@ -14,6 +14,7 @@ f.close()
 install_requires = [
     'six',
     'python-dateutil',
+    'ipaddress',
     'elasticsearch>=6.0.0,<7.0.0'
 ]
 tests_require = [

--- a/test_elasticsearch_dsl/test_field.py
+++ b/test_elasticsearch_dsl/test_field.py
@@ -1,3 +1,4 @@
+import base64
 from datetime import datetime
 from dateutil import tz
 
@@ -111,3 +112,44 @@ def test_scaled_float():
         field.ScaledFloat()
     f = field.ScaledFloat(123)
     assert f.to_dict() == {'scaling_factor': 123, 'type': 'scaled_float'}
+
+
+def test_ipaddress():
+    import ipaddress
+    f = field.Ip()
+    assert f.deserialize('127.0.0.1/32') == ipaddress.ip_interface('127.0.0.1/32')
+    assert f.deserialize('::1/128') == ipaddress.ip_interface('::1/128')
+    assert f.serialize(f.deserialize('::1/128')) == '::1/128'
+    assert f.deserialize(None) is None
+    with pytest.raises(ValueError):
+        assert f.deserialize('not_an_ipaddress')
+
+
+def test_float():
+    f = field.Float()
+    assert f.deserialize('42') == 42.0
+    assert f.deserialize(None) is None
+    with pytest.raises(ValueError):
+        assert f.deserialize('not_a_float')
+
+
+def test_integer():
+    f = field.Integer()
+    assert f.deserialize('42') == 42
+    assert f.deserialize(None) is None
+    with pytest.raises(ValueError):
+        assert f.deserialize('not_an_integer')
+
+
+def test_binary():
+    f = field.Binary()
+    assert f.deserialize(base64.b64encode(b'42')) == b'42'
+    assert f.deserialize(f.serialize(b'42')) == b'42'
+    assert f.deserialize(None) is None
+
+
+
+
+
+
+

--- a/test_elasticsearch_dsl/test_field.py
+++ b/test_elasticsearch_dsl/test_field.py
@@ -117,8 +117,8 @@ def test_scaled_float():
 def test_ipaddress():
     import ipaddress
     f = field.Ip()
-    assert f.deserialize('127.0.0.1/32') == ipaddress.ip_interface('127.0.0.1/32')
-    assert f.deserialize('::1/128') == ipaddress.ip_interface('::1/128')
+    assert f.deserialize('127.0.0.1/32') == ipaddress.ip_interface(u'127.0.0.1/32')
+    assert f.deserialize('::1/128') == ipaddress.ip_interface(u'::1/128')
     assert f.serialize(f.deserialize('::1/128')) == '::1/128'
     assert f.deserialize(None) is None
     with pytest.raises(ValueError):


### PR DESCRIPTION
Replaced 'Attachment' type (which was removed in 2.0) with 'Binary', added binary (de)serialization.

Casting the IP type to a `ipaddress.ip_interface` which is the closest to the elasticsearch type.

It's debatable whether the `float()` and `int()` casts are helpful, because the _source field should contain a float/integer whenever the right type was input anyway.

Discussed in #785.