### PR TITLE
Explicit signatures for few field types

### DIFF
--- a/elasticsearch_dsl/field.py
+++ b/elasticsearch_dsl/field.py
@@ -48,6 +48,10 @@ class Field(DslBase):
     _coerce = False
 
     def __init__(self, multi=False, required=False, *args, **kwargs):
+        """
+        :param bool multi: specifies whether field can contain array of values
+        :param bool required: specifies whether field is required
+        """
         self._multi = multi
         self._required = required
         super(Field, self).__init__(*args, **kwargs)
@@ -115,9 +119,18 @@ class Object(Field):
     _coerce = True
 
     def __init__(self, doc_class=None, dynamic=None, properties=None, **kwargs):
+        """
+        :param document.InnerDoc doc_class: base doc class that handles mapping.
+            If no `doc_class` is provided, new instance of `InnerDoc` will be created,
+            populated with `properties` and used
+        :param dynamic: whether new properties may be created dynamically.
+            Valid values are `True`, `False`, `'strict'`.
+            See https://www.elastic.co/guide/en/elasticsearch/reference/current/dynamic.html
+            for more details
+        :param dict properties: used to construct underlying mapping if no `doc_class` is provided
+        """
         if properties is None:
             properties = {}
-        self._doc_class = doc_class
         if doc_class is None:
             # FIXME import
             from .document import InnerDoc
@@ -127,6 +140,8 @@ class Object(Field):
                 self._doc_class._doc_type.mapping.field(name, field)
             if dynamic:
                 self._doc_class._doc_type.mapping.meta('dynamic', dynamic)
+        else:
+            self._doc_class = doc_class
 
         self._mapping = self._doc_class._doc_type.mapping
         super(Object, self).__init__(**kwargs)
@@ -207,6 +222,10 @@ class Date(Field):
     _coerce = True
 
     def __init__(self, default_timezone=None, *args, **kwargs):
+        """
+        :param default_timezone: timezone that will be automatically used for tz-naive values
+            May be instance of datetime.tzinfo or string containing TZ offset
+        """
         self._default_timezone = default_timezone
         if isinstance(self._default_timezone, string_types):
             self._default_timezone = tz.gettz(self._default_timezone)

--- a/elasticsearch_dsl/field.py
+++ b/elasticsearch_dsl/field.py
@@ -47,9 +47,9 @@ class Field(DslBase):
     name = None
     _coerce = False
 
-    def __init__(self, *args, **kwargs):
-        self._multi = kwargs.pop('multi', False)
-        self._required = kwargs.pop('required', False)
+    def __init__(self, multi=False, required=False, *args, **kwargs):
+        self._multi = multi
+        self._required = required
         super(Field, self).__init__(*args, **kwargs)
 
     def __getitem__(self, subfield):
@@ -114,17 +114,19 @@ class Object(Field):
     name = 'object'
     _coerce = True
 
-    def __init__(self, doc_class=None, **kwargs):
+    def __init__(self, doc_class=None, dynamic=None, properties=None, **kwargs):
+        if properties is None:
+            properties = {}
         self._doc_class = doc_class
         if doc_class is None:
             # FIXME import
             from .document import InnerDoc
             # no InnerDoc subclass, creating one instead...
             self._doc_class = type('InnerDoc', (InnerDoc, ), {})
-            for name, field in iteritems(kwargs.pop('properties', {})):
+            for name, field in iteritems(properties):
                 self._doc_class._doc_type.mapping.field(name, field)
-            if 'dynamic' in kwargs:
-                self._doc_class._doc_type.mapping.meta('dynamic', kwargs.pop('dynamic'))
+            if dynamic:
+                self._doc_class._doc_type.mapping.meta('dynamic', dynamic)
 
         self._mapping = self._doc_class._doc_type.mapping
         super(Object, self).__init__(**kwargs)
@@ -204,8 +206,8 @@ class Date(Field):
     name = 'date'
     _coerce = True
 
-    def __init__(self, *args, **kwargs):
-        self._default_timezone = kwargs.pop('default_timezone', None)
+    def __init__(self, default_timezone=None, *args, **kwargs):
+        self._default_timezone = default_timezone
         if isinstance(self._default_timezone, string_types):
             self._default_timezone = tz.gettz(self._default_timezone)
         super(Date, self).__init__(*args, **kwargs)

--- a/elasticsearch_dsl/field.py
+++ b/elasticsearch_dsl/field.py
@@ -123,7 +123,7 @@ class Object(Field):
         :arg document.InnerDoc doc_class: base doc class that handles mapping.
             If no `doc_class` is provided, new instance of `InnerDoc` will be created,
             populated with `properties` and used
-        :arg dynamic: whether new properties may be created dynamically.
+        :arg bool dynamic: whether new properties may be created dynamically.
             Valid values are `True`, `False`, `'strict'`.
             See https://www.elastic.co/guide/en/elasticsearch/reference/current/dynamic.html
             for more details
@@ -138,7 +138,7 @@ class Object(Field):
             self._doc_class = type('InnerDoc', (InnerDoc, ), {})
             for name, field in iteritems(properties):
                 self._doc_class._doc_type.mapping.field(name, field)
-            if dynamic:
+            if dynamic is not None:
                 self._doc_class._doc_type.mapping.meta('dynamic', dynamic)
         else:
             self._doc_class = doc_class
@@ -216,7 +216,6 @@ class Nested(Object):
     def __init__(self, *args, **kwargs):
         kwargs.setdefault('multi', True)
         super(Nested, self).__init__(*args, **kwargs)
-
 
 class Date(Field):
     name = 'date'

--- a/elasticsearch_dsl/field.py
+++ b/elasticsearch_dsl/field.py
@@ -123,7 +123,7 @@ class Object(Field):
         :arg document.InnerDoc doc_class: base doc class that handles mapping.
             If no `doc_class` is provided, new instance of `InnerDoc` will be created,
             populated with `properties` and used. Can not be provided together with `properties`
-        :arg bool dynamic: whether new properties may be created dynamically.
+        :arg dynamic: whether new properties may be created dynamically.
             Valid values are `True`, `False`, `'strict'`.
             Can not be provided together with `doc_class`.
             See https://www.elastic.co/guide/en/elasticsearch/reference/current/dynamic.html

--- a/elasticsearch_dsl/field.py
+++ b/elasticsearch_dsl/field.py
@@ -224,7 +224,7 @@ class Date(Field):
     def __init__(self, default_timezone=None, *args, **kwargs):
         """
         :param default_timezone: timezone that will be automatically used for tz-naive values
-            May be instance of datetime.tzinfo or string containing TZ offset
+            May be instance of `datetime.tzinfo` or string containing TZ offset
         """
         self._default_timezone = default_timezone
         if isinstance(self._default_timezone, string_types):

--- a/elasticsearch_dsl/field.py
+++ b/elasticsearch_dsl/field.py
@@ -49,8 +49,8 @@ class Field(DslBase):
 
     def __init__(self, multi=False, required=False, *args, **kwargs):
         """
-        :param bool multi: specifies whether field can contain array of values
-        :param bool required: specifies whether field is required
+        :arg bool multi: specifies whether field can contain array of values
+        :arg bool required: specifies whether field is required
         """
         self._multi = multi
         self._required = required
@@ -120,14 +120,14 @@ class Object(Field):
 
     def __init__(self, doc_class=None, dynamic=None, properties=None, **kwargs):
         """
-        :param document.InnerDoc doc_class: base doc class that handles mapping.
+        :arg document.InnerDoc doc_class: base doc class that handles mapping.
             If no `doc_class` is provided, new instance of `InnerDoc` will be created,
             populated with `properties` and used
-        :param dynamic: whether new properties may be created dynamically.
+        :arg dynamic: whether new properties may be created dynamically.
             Valid values are `True`, `False`, `'strict'`.
             See https://www.elastic.co/guide/en/elasticsearch/reference/current/dynamic.html
             for more details
-        :param dict properties: used to construct underlying mapping if no `doc_class` is provided
+        :arg dict properties: used to construct underlying mapping if no `doc_class` is provided
         """
         if properties is None:
             properties = {}
@@ -217,13 +217,14 @@ class Nested(Object):
         kwargs.setdefault('multi', True)
         super(Nested, self).__init__(*args, **kwargs)
 
+
 class Date(Field):
     name = 'date'
     _coerce = True
 
     def __init__(self, default_timezone=None, *args, **kwargs):
         """
-        :param default_timezone: timezone that will be automatically used for tz-naive values
+        :arg default_timezone: timezone that will be automatically used for tz-naive values
             May be instance of `datetime.tzinfo` or string containing TZ offset
         """
         self._default_timezone = default_timezone

--- a/test_elasticsearch_dsl/test_field.py
+++ b/test_elasticsearch_dsl/test_field.py
@@ -5,7 +5,8 @@ from dateutil import tz
 
 import pytest
 
-from elasticsearch_dsl import field
+from elasticsearch_dsl import field, InnerDoc, ValidationException
+
 
 def test_boolean_deserialization():
     bf = field.Boolean()
@@ -136,8 +137,26 @@ def test_binary():
     assert f.deserialize(None) is None
 
 
-@pytest.mark.parametrize('value', [True, False, 'strict'])
-def test_object_dynamic_values(value):
-    f = field.Object(dynamic=value)
-    assert f.to_dict()['dynamic'] == value
+def test_object_dynamic_values():
+    for dynamic in True, False, 'strict':
+        f = field.Object(dynamic=dynamic)
+        assert f.to_dict()['dynamic'] == dynamic
 
+
+def test_object_constructor():
+    expected = {'type': 'object', 'properties': {'inner_int': {'type': 'integer'}}}
+
+    class Inner(InnerDoc):
+        inner_int = field.Integer()
+
+    obj_from_doc = field.Object(doc_class=Inner)
+    assert obj_from_doc.to_dict() == expected
+
+    obj_from_props = field.Object(properties={'inner_int': field.Integer()})
+    assert obj_from_props.to_dict() == expected
+
+    with pytest.raises(ValidationException):
+        field.Object(doc_class=Inner, properties={'inner_int': field.Integer()})
+
+    with pytest.raises(ValidationException):
+        field.Object(doc_class=Inner, dynamic=False)

--- a/test_elasticsearch_dsl/test_field.py
+++ b/test_elasticsearch_dsl/test_field.py
@@ -134,3 +134,10 @@ def test_binary():
     assert f.deserialize(base64.b64encode(b'42')) == b'42'
     assert f.deserialize(f.serialize(b'42')) == b'42'
     assert f.deserialize(None) is None
+
+
+@pytest.mark.parametrize('value', [True, False, 'strict'])
+def test_object_dynamic_values(value):
+    f = field.Object(dynamic=value)
+    assert f.to_dict()['dynamic'] == value
+


### PR DESCRIPTION
This should provide better inspection for IDEs/IPython, etc.

Not sure on docstring format tho. I'm happy to document some/all existing fields/functions, but there's not too much of existing doc in codebase. I propose to use [napoleon/google docstrings](http://sphinxcontrib-napoleon.readthedocs.io/en/latest/example_google.html). This approach seem to works quite well for real-world docs with params clarification/examples.

Pls share your thoughts on this