### PR TITLE
import normalizer shortcut

### DIFF
--- a/elasticsearch_dsl/__init__.py
+++ b/elasticsearch_dsl/__init__.py
@@ -6,7 +6,7 @@ from .field import *
 from .document import DocType, MetaField, InnerDoc
 from .mapping import Mapping
 from .index import Index, IndexTemplate
-from .analysis import analyzer, token_filter, char_filter, tokenizer
+from .analysis import *
 from .faceted_search import *
 
 VERSION = (6, 1, 0)


### PR DESCRIPTION
think this should've been included with: https://github.com/elastic/elasticsearch-dsl-py/pull/679