### PR TITLE
Change DslBase._clone to be shallow

### DIFF
--- a/Changelog.rst
+++ b/Changelog.rst
@@ -12,6 +12,8 @@ Changelog
   a backwards incompatible change for custom aggregations that redefine that
   method.
 * ``DocType.update`` now supports ``refresh`` kwarg
+* ``DslBase._clone`` now produces a shallow copy, this means that modifying an
+  existing query can have effects on existing ``Search`` objects.
 
 6.1.0 (2018-01-09)
 ------------------

--- a/docs/search_dsl.rst
+++ b/docs/search_dsl.rst
@@ -23,9 +23,10 @@ The ``Search`` object represents the entire search request:
 
 The API is designed to be chainable. With the exception of the
 aggregations functionality this means that the ``Search`` object is immutable -
-all changes to the object will result in a copy being created which contains
-the changes. This means you can safely pass the ``Search`` object to foreign
-code without fear of it modifying your objects.
+all changes to the object will result in a shallow copy being created which
+contains the changes. This means you can safely pass the ``Search`` object to
+foreign code without fear of it modifying your objects as long as it sticks to
+the ``Search`` object APIs.
 
 You can pass an instance of the low-level `elasticsearch client <https://elasticsearch-py.readthedocs.io/>`_ when
 instantiating the ``Search`` object:

--- a/elasticsearch_dsl/utils.py
+++ b/elasticsearch_dsl/utils.py
@@ -1,6 +1,7 @@
 from __future__ import unicode_literals
 
 import collections
+from copy import copy
 
 from six import iteritems, add_metaclass
 from six.moves import map
@@ -198,7 +199,7 @@ class DslBase(object):
 
     Provides several feature:
         - attribute access to the wrapped dictionary (.field instead of ['field'])
-        - _clone method returning a deep copy of self
+        - _clone method returning a copy of self
         - to_dict method to serialize into dict (to be sent via elasticsearch-py)
         - basic logical operators (&, | and ~) using a Bool(Filter|Query) TODO:
           move into a class specific for Query/Filter
@@ -330,8 +331,10 @@ class DslBase(object):
         return {self.name: d}
 
     def _clone(self):
-        return self._type_shortcut(self.to_dict())
-
+        c = self.__class__()
+        for attr in self._params:
+            c._params[attr] = copy(self._params[attr])
+        return c
 
 class ObjectBase(AttrDict):
     def __init__(self, **kwargs):

--- a/test_elasticsearch_dsl/test_query.py
+++ b/test_elasticsearch_dsl/test_query.py
@@ -52,7 +52,6 @@ def test_query_clone():
 
     assert bool == bool_clone
     assert bool is not bool_clone
-    assert bool.must[0] is not bool_clone.must[0]
 
 def test_bool_converts_its_init_args_to_queries():
     q = query.Bool(must=[{"match": {"f": "value"}}])


### PR DESCRIPTION
Fixes #885 

This is a backwards incompatible change in that copies are now shallow, it shouldn't break any APIs