### PR TITLE
Allow extra field parameters to be serialized in JSON mapping

### DIFF
--- a/elasticsearch_dsl/field.py
+++ b/elasticsearch_dsl/field.py
@@ -169,7 +169,7 @@ class Object(Field):
     def to_dict(self):
         d = self._mapping.to_dict()
         _, d = d.popitem()
-        d["type"] = self.name
+        d.update(super(Object, self).to_dict())
         return d
 
     def _collect_fields(self):

--- a/test_elasticsearch_dsl/test_document.py
+++ b/test_elasticsearch_dsl/test_document.py
@@ -63,6 +63,13 @@ class SecretDoc(document.DocType):
 class NestedSecret(document.DocType):
     secrets = field.Nested(SecretDoc)
 
+class NestedWithParams(document.DocType):
+    my_nested = field.Nested(
+        include_in_parent=True,
+        dynamic=False,
+        properties={'title': field.Text()})
+
+
 class OptionalObjectWithRequiredField(document.DocType):
     comments = field.Nested(properties={'title': field.Keyword(required=True)})
 
@@ -140,6 +147,25 @@ def test_custom_field_mapping():
             }
         }
     } == SecretDoc._doc_type.mapping.to_dict()
+
+def test_nested_with_params():
+    my_mapping = NestedWithParams._doc_type.mapping.to_dict()
+    assert {
+        'doc': {
+            'properties': {
+                'my_nested': {
+                    'type': 'nested',
+                    'include_in_parent': True,
+                    'dynamic': False,
+                    'properties': {
+                        'title': {
+                            'type': 'text'
+                        }
+                    }
+                }
+            }
+        }
+    } == my_mapping
 
 def test_custom_field_in_nested():
     s = NestedSecret()


### PR DESCRIPTION
In some cases, a field definition has extra parameters. For example, the
"nested" field type can have the extra parameter "include_in_parent". We
want to include these extra parameters when serializing the objects to
the JSON object we send to Elasticsearch.

This adds a class with a nested field with a couple field parameters set
and then makes sure that the option appears in the dictionary
serialization of that class's mapping.