### PR TITLE
Update hit.py

### DIFF
--- a/elasticsearch_dsl/response/hit.py
+++ b/elasticsearch_dsl/response/hit.py
@@ -3,7 +3,7 @@ from six import iteritems
 from ..utils import AttrDict
 
 class HitMeta(AttrDict):
-    def __init__(self, document, exclude=('_source', '_fields')):
+    def __init__(self, document, exclude=('_source', 'fields')):
         d = dict((k[1:] if k.startswith('_') else k, v) for (k, v) in iteritems(document) if k not in exclude)
         if 'type' in d:
             # make sure we are consistent everywhere in python


### PR DESCRIPTION
There is not `_fields` key in `hit` dictionary, there is `fields`:
For example right know:
```python
for hit in response:
    print(hit.meta.fields)
```
You get:
``` bash
{'_percolator_document_slot': [0]}
{'_percolator_document_slot': [0]}
{'_percolator_document_slot': [0]}
{'_percolator_document_slot': [0]}
{'_percolator_document_slot': [0]}
{'_percolator_document_slot': [0]}
{'_percolator_document_slot': [0]}
{'_percolator_document_slot': [0]}
{'_percolator_document_slot': [0]}
{'_percolator_document_slot': [0]}
``` 
And that is normal, because:
```json
  "hits" : {
    "total" : 279,
    "max_score" : 0.7911257,
    "hits" : [
      {
        "_index" : "titles",
        "_type" : "_doc",
        "_id" : "FSygA2MBuEo1MpJOM-jJ",
        "_score" : 0.7911257,
        "_source" : {
          "query" : {
            "span_near" : {
              "clauses" : [
                {
                  "span_term" : {
                    "title" : "sistematik"
                  }
                },
                {
                  "span_term" : {
                    "title" : "gÃ¶zlem"
                  }
                }
              ],
              "slop" : 0,
              "in_order" : true
            }
          }
        },
        "fields" : {
          "_percolator_document_slot" : [
            0
          ]
        },
        "highlight" : {
          "title" : [
            "barÄ±ndÄ±rdÄ±ÄŸÄ± sorunlara dikkat Ã§ekmek, teorik bulgularÄ± Ä°zmir kenti MaviÅŸehir Ã¶rnekleminde gerÃ§ekleÅŸtirilen ve <em>sistematik</em>",
            "<em>gÃ¶zlem</em> Ã§alÄ±ÅŸmasÄ±na dayanan bir alan Ã§alÄ±ÅŸmasÄ± ile test etmektir.",
            "ve farklÄ± tasarÄ±m niteliklerine sahip iki site karÅŸÄ±laÅŸtÄ±rmalÄ± olarak incelendiÄŸinde teorik bulgular <em>sistematik</em>",
            "<em>gÃ¶zlem</em> verileriyle de desteklenmiÅŸtir."
          ]
        }
      },
```