### PR TITLE
Fix Binary field in Python 3.

### DIFF
--- a/elasticsearch_dsl/field.py
+++ b/elasticsearch_dsl/field.py
@@ -345,7 +345,7 @@ class Binary(Field):
     def _serialize(self, data):
         if data is None:
             return None
-        return base64.b64encode(data)
+        return base64.b64encode(data).decode()
 
 class GeoPoint(Field):
     name = 'geo_point'

--- a/elasticsearch_dsl/field.py
+++ b/elasticsearch_dsl/field.py
@@ -339,6 +339,11 @@ class Binary(Field):
     name = 'binary'
     _coerce = True
 
+    def clean(self, data):
+        # Binary fields are opaque, so there's not much cleaning
+        # that can be done.
+        return data
+
     def _deserialize(self, data):
         return base64.b64decode(data)
 

--- a/test_elasticsearch_dsl/test_integration/test_document.py
+++ b/test_elasticsearch_dsl/test_integration/test_document.py
@@ -95,7 +95,7 @@ def test_serialization(write_client):
 
     assert sd.to_dict() == {
         'b': [True, False, True, False, None],
-        'bin': [b'SGVsbG8gV29ybGQ=', None],
+        'bin': ['SGVsbG8gV29ybGQ=', None],
         'd': [0.1, -0.1, None],
         'i': [1, 2, 3, None],
         'ip': ['::1', '127.0.0.1', None]


### PR DESCRIPTION
The `base64` module was changed in Python 3 to return `bytes` rather than `str`. This change caused elasticsearch-dsl to fail with a `TypeError` when trying to serialize Binary fields in Python 3. Adding a call to `.decode()` changes the return type back to `str`; in Python 2, this is a no-op.

Similarly, the default behavior of `Field.clean()` attempted to deserialize the Binary field data on `DocType.save()`, which naturally failed (with an 'incorrect padding' error) because the binary data wasn't base64-encoded yet. Since the Binary data is opaque, I assume it's acceptable to simply return the raw data from `.clean()`.

These two changes make it possible to correctly save and load documents containing Binary fields in Python 3.