### PR TITLE
Restores old DocType interface

### DIFF
--- a/elasticsearch_dsl/__init__.py
+++ b/elasticsearch_dsl/__init__.py
@@ -3,7 +3,7 @@ from .aggs import A
 from .function import SF
 from .search import Search, MultiSearch
 from .field import *
-from .document import Document, MetaField, InnerDoc
+from .document import Document, DocType, MetaField, InnerDoc
 from .mapping import Mapping
 from .index import Index, IndexTemplate
 from .analysis import analyzer, char_filter, normalizer, token_filter, tokenizer


### PR DESCRIPTION
DocType was refactored to Document, DocType as class was added to backaward compat, but its missing from high-level interface.
@HonzaKral  `from elasticsearch_dsl import DocType` is broken in latest PyPI release (6.2.0). Taking into account that this is minor one, I guess, this should be merged and re-uploaded to PyPI asap.