### PR TITLE
document save with skip_empty parameter in to_dict

### DIFF
--- a/elasticsearch_dsl/document.py
+++ b/elasticsearch_dsl/document.py
@@ -384,7 +384,7 @@ class Document(ObjectBase):
             if '_' + k in meta:
                 setattr(self.meta, k, meta['_' + k])
 
-    def save(self, using=None, index=None, validate=True, **kwargs):
+    def save(self, using=None, index=None, validate=True, skip_empty=True, **kwargs):
         """
         Save the document into elasticsearch. If the document doesn't exist it
         is created, it is overwritten otherwise. Returns ``True`` if this
@@ -394,6 +394,9 @@ class Document(ObjectBase):
             associated with an index this can be omitted.
         :arg using: connection alias to use, defaults to ``'default'``
         :arg validate: set to ``False`` to skip validating the document
+        :arg skip_empty: if set to ``False`` will cause empty values (``None``,
+            ``[]``, ``{}``) to be left on the document. Those values will be
+            stripped out otherwise as they make no difference in elasticsearch.
 
         Any additional keyword arguments will be passed to
         ``Elasticsearch.index`` unchanged.
@@ -412,7 +415,7 @@ class Document(ObjectBase):
         meta = es.index(
             index=self._get_index(index),
             doc_type=self._doc_type.name,
-            body=self.to_dict(),
+            body=self.to_dict(skip_empty=skip_empty),
             **doc_meta
         )
         # update meta information from ES


### PR DESCRIPTION
Document `save` method allows the parameter `skip_empty` to be set to `False` and passed to the method `to_dict`. 

Therefore the empty values (``None``, ``[]``, ``{}``) will be left on the document, and so indexed into the elasticsearch.