### PR TITLE
Implementing hook for dynamically adding fields to mapping

### DIFF
--- a/elasticsearch_dsl/document.py
+++ b/elasticsearch_dsl/document.py
@@ -24,6 +24,7 @@ class DocumentMeta(type):
         attrs['_doc_type'] = DocumentOptions(name, bases, attrs)
         return super(DocumentMeta, cls).__new__(cls, name, bases, attrs)
 
+
 class IndexMeta(DocumentMeta):
     # global flag to guard us from associating an Index with the base Document
     # class, only user defined subclasses should have an _index attr
@@ -73,6 +74,14 @@ class DocumentOptions(object):
             if isinstance(value, Field):
                 self.mapping.field(name, value)
                 del attrs[name]
+
+        # Get additional fields as defined by the extended class
+        # This hook if important to dynamically add fields to mapping
+        extra_fields_function = attrs.get('get_extra_fields')
+        if extra_fields_function:
+            extra_fields = extra_fields_function()
+            for name, value in extra_fields:
+                self.mapping.field(name, value)
 
         # add all the mappings for meta fields
         for name in dir(meta):
@@ -255,6 +264,18 @@ class Document(ObjectBase):
             message = 'Documents %s not found.' % ', '.join(missing_ids)
             raise NotFoundError(404, message, {'docs': missing_docs})
         return objs
+
+    @classmethod
+    def get_extra_fields(cls):
+        """
+        A hook to add fields dynamically to the mapping.
+
+        Its possible to use this classmethod to add any field to dynamically to
+        mapping.
+        :return: A list with name, Field tuple
+        """
+
+        return []
 
     def delete(self, using=None, index=None, **kwargs):
         """


### PR DESCRIPTION
For having the mapping dynamically generated, we need to have a hook that will get the fields dynamically. I believe, its needed by `django-elasticsearch-dsl` to generete Elasticsearch DSL mapping dynamically from Django model.
@HonzaKral As you have mentioned in your comment https://github.com/elastic/elasticsearch-dsl-py/pull/930#issuecomment-402189706, is it a correct approach to have a hook for `django-elasticsearch-dsl`? I am currently trying to upgrade it for `elasticsearch-dsl-py>6.1.0`