### PR TITLE
Fix collections.abc deprecation warning in python 3.7.

### DIFF
--- a/elasticsearch_dsl/aggs.py
+++ b/elasticsearch_dsl/aggs.py
@@ -1,4 +1,7 @@
-import collections
+try:
+    import collections.abc as collections_abc  # only works on python 3.3+
+except ImportError:
+    import collections as collections_abc
 
 from .utils import DslBase
 from .response.aggs import BucketData, FieldBucketData, AggResponse, TopHitsData
@@ -10,7 +13,7 @@ def A(name_or_agg, filter=None, **params):
         params['filter'] = filter
 
     # {"terms": {"field": "tags"}, "aggs": {...}}
-    if isinstance(name_or_agg, collections.Mapping):
+    if isinstance(name_or_agg, collections_abc.Mapping):
         if params:
             raise ValueError('A() cannot accept parameters when passing in a dict.')
         # copy to avoid modifying in-place

--- a/elasticsearch_dsl/document.py
+++ b/elasticsearch_dsl/document.py
@@ -1,4 +1,8 @@
-import collections
+try:
+    import collections.abc as collections_abc  # only works on python 3.3+
+except ImportError:
+    import collections as collections_abc
+
 from fnmatch import fnmatch
 
 from elasticsearch.exceptions import NotFoundError, RequestError
@@ -212,7 +216,7 @@ class Document(ObjectBase):
         es = cls._get_connection(using)
         body = {
             'docs': [
-                doc if isinstance(doc, collections.Mapping) else {'_id': doc}
+                doc if isinstance(doc, collections_abc.Mapping) else {'_id': doc}
                 for doc in docs
             ]
         }

--- a/elasticsearch_dsl/field.py
+++ b/elasticsearch_dsl/field.py
@@ -1,7 +1,10 @@
 import base64
 import ipaddress
 
-import collections
+try:
+    import collections.abc as collections_abc  # only works on python 3.3+
+except ImportError:
+    import collections as collections_abc
 
 from datetime import date, datetime
 
@@ -17,7 +20,7 @@ unicode = type(u'')
 
 def construct_field(name_or_field, **params):
     # {"type": "text", "analyzer": "snowball"}
-    if isinstance(name_or_field, collections.Mapping):
+    if isinstance(name_or_field, collections_abc.Mapping):
         if params:
             raise ValueError('construct_field() cannot accept parameters when passing in a dict.')
         params = name_or_field.copy()
@@ -191,7 +194,7 @@ class Object(Field):
             return None
 
         # somebody assigned raw dict to the field, we should tolerate that
-        if isinstance(data, collections.Mapping):
+        if isinstance(data, collections_abc.Mapping):
             return data
 
         return data.to_dict()

--- a/elasticsearch_dsl/function.py
+++ b/elasticsearch_dsl/function.py
@@ -1,10 +1,13 @@
-import collections
+try:
+    import collections.abc as collections_abc  # only works on python 3.3+
+except ImportError:
+    import collections as collections_abc
 
 from .utils import DslBase
 
 def SF(name_or_sf, **params):
     # {"script_score": {"script": "_score"}, "filter": {}}
-    if isinstance(name_or_sf, collections.Mapping):
+    if isinstance(name_or_sf, collections_abc.Mapping):
         if params:
             raise ValueError('SF() cannot accept parameters when passing in a dict.')
         kwargs = {}
@@ -23,7 +26,7 @@ def SF(name_or_sf, **params):
             raise ValueError('SF() got an unexpected fields in the dictionary: %r' % sf)
 
         # boost factor special case, see elasticsearch #6343
-        if not isinstance(params, collections.Mapping):
+        if not isinstance(params, collections_abc.Mapping):
             params = {'value': params}
 
         # mix known params (from _param_defs) and from inside the function

--- a/elasticsearch_dsl/mapping.py
+++ b/elasticsearch_dsl/mapping.py
@@ -1,4 +1,7 @@
-import collections
+try:
+    import collections.abc as collections_abc  # only works on python 3.3+
+except ImportError:
+    import collections as collections_abc
 
 from six import iteritems, itervalues
 from itertools import chain
@@ -133,7 +136,7 @@ class Mapping(object):
         # metadata like _all etc
         for name, value in iteritems(raw):
             if name != 'properties':
-                if isinstance(value, collections.Mapping):
+                if isinstance(value, collections_abc.Mapping):
                     self.meta(name, **value)
                 else:
                     self.meta(name, value)

--- a/elasticsearch_dsl/query.py
+++ b/elasticsearch_dsl/query.py
@@ -1,4 +1,7 @@
-import collections
+try:
+    import collections.abc as collections_abc  # only works on python 3.3+
+except ImportError:
+    import collections as collections_abc
 
 from itertools import chain
 
@@ -8,7 +11,7 @@ from .function import SF, ScoreFunction
 
 def Q(name_or_query='match_all', **params):
     # {"match": {"title": "python"}}
-    if isinstance(name_or_query, collections.Mapping):
+    if isinstance(name_or_query, collections_abc.Mapping):
         if params:
             raise ValueError('Q() cannot accept parameters when passing in a dict.')
         if len(name_or_query) != 1:

--- a/elasticsearch_dsl/search.py
+++ b/elasticsearch_dsl/search.py
@@ -1,5 +1,9 @@
 import copy
-import collections
+
+try:
+    import collections.abc as collections_abc  # only works on python 3.3+
+except ImportError:
+    import collections as collections_abc
 
 from six import iteritems, string_types
 
@@ -100,7 +104,7 @@ class Request(object):
         self._doc_type_map = {}
         if isinstance(doc_type, (tuple, list)):
             self._doc_type.extend(doc_type)
-        elif isinstance(doc_type, collections.Mapping):
+        elif isinstance(doc_type, collections_abc.Mapping):
             self._doc_type.extend(doc_type.keys())
             self._doc_type_map.update(doc_type)
         elif doc_type:

--- a/elasticsearch_dsl/utils.py
+++ b/elasticsearch_dsl/utils.py
@@ -1,6 +1,10 @@
 from __future__ import unicode_literals
 
-import collections
+try:
+    import collections.abc as collections_abc  # only works on python 3.3+
+except ImportError:
+    import collections as collections_abc
+
 from copy import copy
 
 from six import iteritems, add_metaclass
@@ -21,7 +25,7 @@ META_FIELDS = frozenset((
 )).union(DOC_META_FIELDS)
 
 def _wrap(val, obj_wrapper=None):
-    if isinstance(val, collections.Mapping):
+    if isinstance(val, collections_abc.Mapping):
         return AttrDict(val) if obj_wrapper is None else obj_wrapper(val)
     if isinstance(val, list):
         return AttrList(val)
@@ -293,7 +297,7 @@ class DslBase(object):
                 '%r object has no attribute %r' % (self.__class__.__name__, name))
 
         # wrap nested dicts in AttrDict for convenient access
-        if isinstance(value, collections.Mapping):
+        if isinstance(value, collections_abc.Mapping):
             return AttrDict(value)
         return value
 
@@ -475,13 +479,13 @@ class ObjectBase(AttrDict):
         self.clean()
 
 def merge(data, new_data, raise_on_conflict=False):
-    if not (isinstance(data, (AttrDict, collections.Mapping))
-            and isinstance(new_data, (AttrDict, collections.Mapping))):
+    if not (isinstance(data, (AttrDict, collections_abc.Mapping))
+            and isinstance(new_data, (AttrDict, collections_abc.Mapping))):
         raise ValueError('You can only merge two dicts! Got %r and %r instead.' % (data, new_data))
 
     for key, value in iteritems(new_data):
-        if key in data and isinstance(data[key], (AttrDict, collections.Mapping)) and \
-                isinstance(value, (AttrDict, collections.Mapping)):
+        if key in data and isinstance(data[key], (AttrDict, collections_abc.Mapping)) and \
+                isinstance(value, (AttrDict, collections_abc.Mapping)):
             merge(data[key], value, raise_on_conflict)
         elif key in data and data[key] != value and raise_on_conflict:
             raise ValueError('Incompatible data for key %r, cannot be merged.' % key)


### PR DESCRIPTION
I'm using Python 3.7, and in my library I was getting a deprecation warning about the usage of collections in this library that I would like to fix. I think this library is supporting Python 2 and 3, so having the try / except will support the different Python version.

I did not see an existing issue for this so I'll create one.