### PR TITLE
Add index to Delete By Query example

### DIFF
--- a/docs/search_dsl.rst
+++ b/docs/search_dsl.rst
@@ -95,7 +95,7 @@ You can delete the documents matching a search by calling ``delete`` on the ``Se
 
 .. code:: python
 
-    s = Search().query("match", title="python")
+    s = Search(index='i').query("match", title="python")
     response = s.delete()
 
 


### PR DESCRIPTION
The Delete By Query API requires one more indices to be specified. Leaving it out results in an exception [here](https://github.com/elastic/elasticsearch-py/blob/3f2b1b925ac343500b2de0e75dd2e6fca4277631/elasticsearch/client/__init__.py#L884):

```
ValueError: Empty value passed for a required argument.
```