### PR TITLE
Drop support for EOL Python 2.6, 3.2 and 3.3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,6 @@ before_install:
   - java -version
 
 python:
-  - "2.6"
   - "2.7"
   - "3.4"
   - "3.5"

--- a/elasticsearch_dsl/analysis.py
+++ b/elasticsearch_dsl/analysis.py
@@ -45,13 +45,13 @@ class CustomAnalysisDefinition(CustomAnalysis):
         if 'tokenizer' in self._param_defs and hasattr(t, 'get_definition'):
             out['tokenizer'] = {t._name: t.get_definition()}
 
-        filters = dict((f._name, f.get_definition())
-                       for f in self.filter if hasattr(f, 'get_definition'))
+        filters = {f._name: f.get_definition()
+                   for f in self.filter if hasattr(f, 'get_definition')}
         if filters:
             out['filter'] = filters
 
-        char_filters = dict((f._name, f.get_definition())
-                            for f in self.char_filter if hasattr(f, 'get_definition'))
+        char_filters = {f._name: f.get_definition()
+                        for f in self.char_filter if hasattr(f, 'get_definition')}
         if char_filters:
             out['char_filter'] = char_filters
 

--- a/elasticsearch_dsl/document.py
+++ b/elasticsearch_dsl/document.py
@@ -149,9 +149,9 @@ class Document(ObjectBase):
         return index
 
     def __repr__(self):
-        return '%s(%s)' % (
+        return '{}({})'.format(
             self.__class__.__name__,
-            ', '.join('%s=%r' % (key, getattr(self.meta, key)) for key in
+            ', '.join('{}={!r}'.format(key, getattr(self.meta, key)) for key in
                       ('index', 'doc_type', 'id') if key in self.meta)
         )
 
@@ -194,7 +194,7 @@ class Document(ObjectBase):
     @classmethod
     def mget(cls, docs, using=None, index=None, raise_on_error=True,
              missing='none', **kwargs):
-        """
+        r"""
         Retrieve multiple document by their ``id``\s. Returns a list of instances
         in the same order as requested.
 
@@ -273,11 +273,11 @@ class Document(ObjectBase):
         """
         es = self._get_connection(using)
         # extract routing etc from meta
-        doc_meta = dict(
-            (k, self.meta[k])
+        doc_meta = {
+            k: self.meta[k]
             for k in DOC_META_FIELDS
             if k in self.meta
-        )
+        }
         doc_meta.update(kwargs)
         es.delete(
             index=self._get_index(index),
@@ -301,11 +301,11 @@ class Document(ObjectBase):
         if not include_meta:
             return d
 
-        meta = dict(
-            ('_' + k, self.meta[k])
+        meta = {
+            '_' + k: self.meta[k]
             for k in DOC_META_FIELDS
             if k in self.meta
-        )
+        }
 
         # in case of to_dict include the index unlike save/update/delete
         index = self._get_index(required=False)
@@ -377,17 +377,17 @@ class Document(ObjectBase):
             values = self.to_dict()
 
             # if fields were given: partial update
-            body['doc'] = dict(
-                (k, values.get(k))
+            body['doc'] = {
+                k: values.get(k)
                 for k in fields.keys()
-            )
+            }
 
         # extract routing etc from meta
-        doc_meta = dict(
-            (k, self.meta[k])
+        doc_meta = {
+            k: self.meta[k]
             for k in DOC_META_FIELDS
             if k in self.meta
-        )
+        }
 
         if retry_on_conflict is not None:
             doc_meta['retry_on_conflict'] = retry_on_conflict
@@ -426,11 +426,11 @@ class Document(ObjectBase):
 
         es = self._get_connection(using)
         # extract routing etc from meta
-        doc_meta = dict(
-            (k, self.meta[k])
+        doc_meta = {
+            k: self.meta[k]
             for k in DOC_META_FIELDS
             if k in self.meta
-        )
+        }
         doc_meta.update(kwargs)
         meta = es.index(
             index=self._get_index(index),

--- a/elasticsearch_dsl/field.py
+++ b/elasticsearch_dsl/field.py
@@ -331,7 +331,7 @@ class Ip(Field):
     _coerce = True
 
     def _deserialize(self, data):
-        # the ipaddress library for pypy, python2.5 and 2.6 only accepts unicode.
+        # the ipaddress library for pypy only accepts unicode.
         return ipaddress.ip_address(unicode(data))
 
     def _serialize(self, data):

--- a/elasticsearch_dsl/mapping.py
+++ b/elasticsearch_dsl/mapping.py
@@ -39,7 +39,7 @@ class Properties(DslBase):
         return self
 
     def _collect_fields(self):
-        " Iterate over all Field objects within, including multi fields. "
+        """ Iterate over all Field objects within, including multi fields. """
         for f in itervalues(self.properties.to_dict()):
             yield f
             # multi fields

--- a/elasticsearch_dsl/response/__init__.py
+++ b/elasticsearch_dsl/response/__init__.py
@@ -28,7 +28,7 @@ class Response(AttrDict):
         return len(self.hits)
 
     def __getstate__(self):
-        return (self._d_, self._search, self._doc_class)
+        return self._d_, self._search, self._doc_class
 
     def __setstate__(self, state):
         super(AttrDict, self).__setattr__('_d_', state[0])

--- a/elasticsearch_dsl/response/aggs.py
+++ b/elasticsearch_dsl/response/aggs.py
@@ -38,7 +38,7 @@ class BucketData(AggResponse):
             if isinstance(bs, list):
                 bs = AttrList(bs, obj_wrapper=self._wrap_bucket)
             else:
-                bs = AttrDict(dict((k, self._wrap_bucket(bs[k])) for k in bs))
+                bs = AttrDict({k: self._wrap_bucket(bs[k]) for k in bs})
             super(AttrDict, self).__setattr__('_buckets', bs)
         return self._buckets
 

--- a/elasticsearch_dsl/response/hit.py
+++ b/elasticsearch_dsl/response/hit.py
@@ -17,7 +17,7 @@ class Hit(AttrDict):
         return super(Hit, self).__dir__() + ['meta']
 
     def __repr__(self):
-        return '<Hit(%s): %s>' % (
+        return '<Hit({}): {}>'.format(
             '/'.join(
                 getattr(self.meta, key)
                 for key in ('index', 'doc_type', 'id')

--- a/elasticsearch_dsl/search.py
+++ b/elasticsearch_dsl/search.py
@@ -173,7 +173,7 @@ class Request(object):
         """
         Return a list of doc_type names to be used
         """
-        return list(set(dt._doc_type.name if hasattr(dt, '_doc_type') else dt for dt in self._doc_type))
+        return list({dt._doc_type.name if hasattr(dt, '_doc_type') else dt for dt in self._doc_type})
 
     def _resolve_field(self, path):
         for dt in self._doc_type:
@@ -427,8 +427,8 @@ class Search(Request):
         aggs = d.pop('aggs', d.pop('aggregations', {}))
         if aggs:
             self.aggs._params = {
-                'aggs': dict(
-                    (name, A(value)) for (name, value) in iteritems(aggs))
+                'aggs': {
+                    name: A(value) for (name, value) in iteritems(aggs)}
             }
         if 'sort' in d:
             self._sort = d.pop('sort')

--- a/elasticsearch_dsl/search.py
+++ b/elasticsearch_dsl/search.py
@@ -56,7 +56,7 @@ class QueryProxy(object):
         super(QueryProxy, self).__setattr__(attr_name, value)
 
     def __getstate__(self):
-        return (self._search, self._proxied, self._attr_name)
+        return self._search, self._proxied, self._attr_name
 
     def __setstate__(self, state):
         self._search, self._proxied, self._attr_name = state

--- a/elasticsearch_dsl/utils.py
+++ b/elasticsearch_dsl/utils.py
@@ -127,14 +127,14 @@ class AttrDict(object):
             return self.__getitem__(attr_name)
         except KeyError:
             raise AttributeError(
-                '%r object has no attribute %r' % (self.__class__.__name__, attr_name))
+                '{!r} object has no attribute {!r}'.format(self.__class__.__name__, attr_name))
 
     def __delattr__(self, attr_name):
         try:
             del self._d_[attr_name]
         except KeyError:
             raise AttributeError(
-                '%r object has no attribute %r' % (self.__class__.__name__, attr_name))
+                '{!r} object has no attribute {!r}'.format(self.__class__.__name__, attr_name))
 
     def __getitem__(self, key):
         return _wrap(self._d_[key])
@@ -218,7 +218,7 @@ class DslBase(object):
         try:
             return cls._classes[name]
         except KeyError:
-            raise UnknownDslObject('DSL class `%s` does not exist in %s.' % (name, cls._type_name))
+            raise UnknownDslObject('DSL class `{}` does not exist in {}.'.format(name, cls._type_name))
 
     def __init__(self, _expand__to_dot=EXPAND__TO_DOT, **params):
         self._params = {}
@@ -230,14 +230,14 @@ class DslBase(object):
     def _repr_params(self):
         """ Produce a repr of all our parameters to be used in __repr__. """
         return ', '.join(
-            '%s=%r' % (n.replace('.', '__'), v)
+            '{}={!r}'.format(n.replace('.', '__'), v)
             for (n, v) in sorted(iteritems(self._params))
             # make sure we don't include empty typed params
             if 'type' not in self._param_defs.get(n, {}) or v
         )
 
     def __repr__(self):
-        return '%s(%s)' % (
+        return '{}({})'.format(
             self.__class__.__name__,
             self._repr_params()
         )
@@ -266,7 +266,7 @@ class DslBase(object):
                 if pinfo.get('multi') and pinfo.get('hash'):
                     if not isinstance(value, (tuple, list)):
                         value = (value, )
-                    value = list(dict((k, shortcut(v)) for (k, v) in iteritems(obj)) for obj in value)
+                    value = list({k: shortcut(v) for (k, v) in iteritems(obj)} for obj in value)
                 elif pinfo.get('multi'):
                     if not isinstance(value, (tuple, list)):
                         value = (value, )
@@ -274,7 +274,7 @@ class DslBase(object):
 
                 # dict(name -> DslBase), make sure we pickup all the objs
                 elif pinfo.get('hash'):
-                    value = dict((k, shortcut(v)) for (k, v) in iteritems(value))
+                    value = {k: shortcut(v) for (k, v) in iteritems(value)}
 
                 # single value object, just convert
                 else:
@@ -284,7 +284,7 @@ class DslBase(object):
     def __getattr__(self, name):
         if name.startswith('_'):
             raise AttributeError(
-                '%r object has no attribute %r' % (self.__class__.__name__, name))
+                '{!r} object has no attribute {!r}'.format(self.__class__.__name__, name))
 
         value = None
         try:
@@ -300,7 +300,7 @@ class DslBase(object):
                     value = self._params.setdefault(name, {})
         if value is None:
             raise AttributeError(
-                '%r object has no attribute %r' % (self.__class__.__name__, name))
+                '{!r} object has no attribute {!r}'.format(self.__class__.__name__, name))
 
         # wrap nested dicts in AttrDict for convenient access
         if isinstance(value, collections_abc.Mapping):
@@ -324,7 +324,7 @@ class DslBase(object):
                 # list of dict(name -> DslBase)
                 if pinfo.get('multi') and pinfo.get('hash'):
                     value = list(
-                        dict((k, v.to_dict()) for k, v in iteritems(obj))
+                        {k: v.to_dict() for k, v in iteritems(obj)}
                         for obj in value
                     )
 
@@ -334,7 +334,7 @@ class DslBase(object):
 
                 # squash all the hash values into one dict
                 elif pinfo.get('hash'):
-                    value = dict((k, v.to_dict()) for k, v in iteritems(value))
+                    value = {k: v.to_dict() for k, v in iteritems(value)}
 
                 # serialize single values
                 else:
@@ -355,7 +355,7 @@ class DslBase(object):
 
 class HitMeta(AttrDict):
     def __init__(self, document, exclude=('_source', '_fields')):
-        d = dict((k[1:] if k.startswith('_') else k, v) for (k, v) in iteritems(document) if k not in exclude)
+        d = {k[1:] if k.startswith('_') else k: v for (k, v) in iteritems(document) if k not in exclude}
         if 'type' in d:
             # make sure we are consistent everywhere in python
             d['doc_type'] = d.pop('type')
@@ -494,7 +494,7 @@ class ObjectBase(AttrDict):
 def merge(data, new_data, raise_on_conflict=False):
     if not (isinstance(data, (AttrDict, collections_abc.Mapping))
             and isinstance(new_data, (AttrDict, collections_abc.Mapping))):
-        raise ValueError('You can only merge two dicts! Got %r and %r instead.' % (data, new_data))
+        raise ValueError('You can only merge two dicts! Got {!r} and {!r} instead.'.format(data, new_data))
 
     for key, value in iteritems(new_data):
         if key in data and isinstance(data[key], (AttrDict, collections_abc.Mapping)) and \

--- a/elasticsearch_dsl/utils.py
+++ b/elasticsearch_dsl/utils.py
@@ -74,7 +74,7 @@ class AttrList(object):
         return getattr(self._l_, name)
 
     def __getstate__(self):
-        return (self._l_, self._obj_wrapper)
+        return self._l_, self._obj_wrapper
 
     def __setstate__(self, state):
         self._l_, self._obj_wrapper = state
@@ -117,7 +117,7 @@ class AttrDict(object):
         return r
 
     def __getstate__(self):
-        return (self._d_, )
+        return self._d_,
 
     def __setstate__(self, state):
         super(AttrDict, self).__setattr__('_d_', state[0])
@@ -425,7 +425,7 @@ class ObjectBase(AttrDict):
         return doc
 
     def __getstate__(self):
-        return (self.to_dict(), self.meta._d_)
+        return self.to_dict(), self.meta._d_
 
     def __setstate__(self, state):
         data, meta = state

--- a/examples/parent_child.py
+++ b/examples/parent_child.py
@@ -92,7 +92,7 @@ class Question(Post):
 
     @classmethod
     def _matches(cls, hit):
-        " Use Question class for parent documents "
+        """ Use Question class for parent documents """
         return hit['_source']['question_answer'] == 'question'
 
     @classmethod
@@ -146,7 +146,7 @@ class Answer(Post):
 
     @classmethod
     def _matches(cls, hit):
-        " Use Answer class for child documents with child name 'answer' "
+        """ Use Answer class for child documents with child name 'answer' """
         return isinstance(hit['_source']['question_answer'], dict) \
             and hit['_source']['question_answer'].get('name') == 'answer'
 
@@ -170,7 +170,7 @@ class Answer(Post):
 
 
 def setup():
-    " Create an IndexTemplate and save it into elasticsearch. "
+    """ Create an IndexTemplate and save it into elasticsearch. """
     index_template = Post._index.as_template('base')
     index_template.save()
 

--- a/setup.py
+++ b/setup.py
@@ -1,5 +1,4 @@
 # -*- coding: utf-8 -*-
-import sys
 from os.path import join, dirname
 from setuptools import setup, find_packages
 
@@ -26,10 +25,6 @@ tests_require = [
     "pytz"
 ]
 
-# use external unittest for 2.6
-if sys.version_info[:2] == (2, 6):
-    tests_require.append('unittest2')
-
 setup(
     name = "elasticsearch-dsl",
     description = "Python client for Elasticsearch",
@@ -50,11 +45,8 @@ setup(
         "Operating System :: OS Independent",
         "Programming Language :: Python",
         "Programming Language :: Python :: 2",
-        "Programming Language :: Python :: 2.6",
         "Programming Language :: Python :: 2.7",
         "Programming Language :: Python :: 3",
-        "Programming Language :: Python :: 3.2",
-        "Programming Language :: Python :: 3.3",
         "Programming Language :: Python :: 3.4",
         "Programming Language :: Python :: 3.5",
         "Programming Language :: Python :: 3.6",

--- a/setup.py
+++ b/setup.py
@@ -38,6 +38,7 @@ setup(
         where='.',
         exclude=('test_elasticsearch_dsl*', )
     ),
+    python_requires='>=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*',
     classifiers = [
         "Development Status :: 4 - Beta",
         "License :: OSI Approved :: Apache Software License",

--- a/test_elasticsearch_dsl/test_integration/test_examples/test_percolate.py
+++ b/test_elasticsearch_dsl/test_integration/test_examples/test_percolate.py
@@ -10,4 +10,4 @@ def test_post_gets_tagged_automatically(write_client):
     bp_py.save()
 
     assert [] == bp.tags
-    assert set(('programming', 'development', 'python')) == set(bp_py.tags)
+    assert {'programming', 'development', 'python'} == set(bp_py.tags)

--- a/test_elasticsearch_dsl/test_integration/test_search.py
+++ b/test_elasticsearch_dsl/test_integration/test_search.py
@@ -74,7 +74,7 @@ def test_scan_iterates_through_all_docs(data_client):
     commits = list(s.scan())
 
     assert 52 == len(commits)
-    assert set(d['_id'] for d in FLAT_DATA) == set(c.meta.id for c in commits)
+    assert {d['_id'] for d in FLAT_DATA} == {c.meta.id for c in commits}
 
 def test_response_is_cached(data_client):
     s = Repository.search()

--- a/test_elasticsearch_dsl/test_mapping.py
+++ b/test_elasticsearch_dsl/test_mapping.py
@@ -59,7 +59,7 @@ def test_properties_can_iterate_over_all_the_fields():
     m.field('f3', Nested(test_attr='f3', properties={
             'f4': Text(test_attr='f4')}))
 
-    assert set(('f1', 'f2', 'f3', 'f4')) == set(f.test_attr for f in m.properties._collect_fields())
+    assert {'f1', 'f2', 'f3', 'f4'} == {f.test_attr for f in m.properties._collect_fields()}
 
 def test_mapping_can_collect_all_analyzers_and_normalizers():
     a1 = analysis.analyzer('my_analyzer1',

--- a/test_elasticsearch_dsl/test_result.py
+++ b/test_elasticsearch_dsl/test_result.py
@@ -53,16 +53,16 @@ def test_interactive_helpers(dummy_response):
     hits = res.hits
     h = hits[0]
 
-    rhits = "[<Hit(test-index/company/elasticsearch): %s>, <Hit(test-index/employee/42): %s...}>, <Hit(test-index/employee/47): %s...}>, <Hit(test-index/employee/53): {}>]" % (
-            repr(dummy_response['hits']['hits'][0]['_source']),
-            repr(dummy_response['hits']['hits'][1]['_source'])[:60],
-            repr(dummy_response['hits']['hits'][2]['_source'])[:60],
-            )
+    rhits = "[<Hit(test-index/company/elasticsearch): {}>, <Hit(test-index/employee/42): {}...}}>, <Hit(test-index/employee/47): {}...}}>, <Hit(test-index/employee/53): {{}}>]".format(
+        repr(dummy_response['hits']['hits'][0]['_source']),
+        repr(dummy_response['hits']['hits'][1]['_source'])[:60],
+        repr(dummy_response['hits']['hits'][2]['_source'])[:60],
+    )
 
     assert res
     assert '<Response: %s>' % rhits == repr(res)
     assert rhits == repr(hits)
-    assert set(['meta', 'city', 'name']) == set(dir(h))
+    assert {'meta', 'city', 'name'} == set(dir(h))
     assert "<Hit(test-index/company/elasticsearch): %r>" % dummy_response['hits']['hits'][0]['_source'] == repr(h)
 
 def test_empty_response_is_false(dummy_response):


### PR DESCRIPTION
Python 2.6, 3.2 and 3.3 are EOL and no longer receiving security updates (or any updates) from the core Python team.

Version | Release date | Supported until
--- | ---------- | ----------
2.5 | 2006-09-19 | 2011-05-26
2.6 | 2008-10-01 | 2013-10-29
3.0 | 2008-12-03 | 2009-06-27
3.1 | 2009-06-27 | 2012-04-09
3.2 | 2011-02-20 | 2016-02-27
3.3 | 2012-09-29 | 2017-09-29

Source: https://en.wikipedia.org/wiki/CPython#Version_history

They're also little used. Here's the pip installs for elasticsearch-dsl from PyPI for last month:

| category | percent | downloads |
|----------|--------:|----------:|
|      3.5 |  90.19% | 2,874,079 |
|      2.7 |   5.85% |   186,311 |
|      3.6 |   3.01% |    95,827 |
|      3.4 |   0.54% |    17,107 |
|      3.7 |   0.33% |    10,460 |
| null     |   0.06% |     1,854 |
|      3.8 |   0.03% |       813 |
|      2.6 |   0.00% |        39 |
|      3.2 |   0.00% |        30 |
|      3.3 |   0.00% |        24 |
| Total    |         | 3,186,544 |

Source: `pypistats python_minor --last-month elasticsearch-dsl`

Also fix a couple of code inspection things, and add `python_requires` to help pip.
