### PR TITLE
Fix suggest query names for Completion suggestor.

### DIFF
--- a/elasticsearch_dsl/field.py
+++ b/elasticsearch_dsl/field.py
@@ -365,6 +365,7 @@ class GeoShape(Field):
 class Completion(Field):
     _param_defs = {
         'analyzer': {'type': 'analyzer'},
+        'search_analyzer': {'type': 'analyzer'},
     }
     name = 'completion'
 

--- a/elasticsearch_dsl/search.py
+++ b/elasticsearch_dsl/search.py
@@ -605,7 +605,7 @@ class Search(Request):
             s._highlight[f] = kwargs
         return s
 
-    def suggest(self, name, text, **kwargs):
+    def suggest(self, name, text=None, regex=None, **kwargs):
         """
         Add a suggestions request to the search.
 
@@ -616,9 +616,23 @@ class Search(Request):
 
             s = Search()
             s = s.suggest('suggestion-1', 'Elasticsearch', term={'field': 'body'})
+
         """
+        if text is None and regex is None:
+            raise ValueError('You have to pass "text" or "regex" argument.')
+
         s = self._clone()
-        s._suggest[name] = {'text': text}
+
+        query_name = 'text'
+        query_text = text
+        if 'completion' in kwargs:
+            if text:
+                query_name= 'prefix'
+            elif regex:
+                query_name= 'regex'
+                query_text = regex
+
+        s._suggest[name] = {query_name: query_text}
         s._suggest[name].update(kwargs)
         return s
 

--- a/test_elasticsearch_dsl/test_search.py
+++ b/test_elasticsearch_dsl/test_search.py
@@ -522,35 +522,34 @@ def test_suggest_completion():
 
 def test_suggest_regex_query():
     s = search.Search()
-    s = s.suggest('my_suggestion', regex='py[hton|py]', completion={'field': 'title'})
+    s = s.suggest('my_suggestion', regex='py[thon|py]', completion={'field': 'title'})
 
     assert {
         'suggest': {
             'my_suggestion': {
                 'completion': {'field': 'title'},
-                'regex': 'py[hton|py]'
+                'regex': 'py[thon|py]'
             }
         }
     } == s.to_dict()
 
 
-def test_suggest_ignroe_regex_query():
-    s = search.Search()
-    s = s.suggest('my_suggestion', text='python', regex='py[hton|py]', completion={'field': 'title'})
-
-    assert {
-        'suggest': {
-            'my_suggestion': {
-                'completion': {'field': 'title'},
-                'prefix': 'python'
-            }
-        }
-    } == s.to_dict()
-
-def test_suggest_value_error():
+def test_suggest_must_pass_text_or_regex():
     s = search.Search()
     with raises(ValueError):
-        s.suggest('my_suggestion', completion={'field': 'title'})
+        s.suggest('my_suggestion')
+
+
+def test_suggest_can_only_pass_text_or_regex():
+    s = search.Search()
+    with raises(ValueError):
+        s.suggest('my_suggestion', text='python', regex='py[hton|py]')
+
+
+def test_suggest_regex_must_be_wtih_completion():
+    s = search.Search()
+    with raises(ValueError):
+        s.suggest('my_suggestion', regex='py[thon|py]')
 
 
 def test_exclude():

--- a/test_elasticsearch_dsl/test_search.py
+++ b/test_elasticsearch_dsl/test_search.py
@@ -505,6 +505,54 @@ def test_suggest():
         }
     } == s.to_dict()
 
+
+def test_suggest_completion():
+    s = search.Search()
+    s = s.suggest('my_suggestion', 'pyhton', completion={'field': 'title'})
+
+    assert {
+        'suggest': {
+            'my_suggestion': {
+                'completion': {'field': 'title'},
+                'prefix': 'pyhton'
+            }
+        }
+    } == s.to_dict()
+
+
+def test_suggest_regex_query():
+    s = search.Search()
+    s = s.suggest('my_suggestion', regex='py[hton|py]', completion={'field': 'title'})
+
+    assert {
+        'suggest': {
+            'my_suggestion': {
+                'completion': {'field': 'title'},
+                'regex': 'py[hton|py]'
+            }
+        }
+    } == s.to_dict()
+
+
+def test_suggest_ignroe_regex_query():
+    s = search.Search()
+    s = s.suggest('my_suggestion', text='python', regex='py[hton|py]', completion={'field': 'title'})
+
+    assert {
+        'suggest': {
+            'my_suggestion': {
+                'completion': {'field': 'title'},
+                'prefix': 'python'
+            }
+        }
+    } == s.to_dict()
+
+def test_suggest_value_error():
+    s = search.Search()
+    with raises(ValueError):
+        s.suggest('my_suggestion', completion={'field': 'title'})
+
+
 def test_exclude():
     s = search.Search()
     s = s.exclude('match', title='python')


### PR DESCRIPTION
According to [official documentation,](https://www.elastic.co/guide/en/elasticsearch/reference/current/search-suggesters-completion.html) Completion Suggester seems to be using correct `prefix` rather than `text`.

```
POST music/_search?pretty
{
    "suggest": {
        "song-suggest" : {
            "prefix" : "nir", 
            "completion" : { 
                "field" : "suggest" 
            }
        }
    }
}
```

In the `Search.suggest` method, however, it always becomes `text`, so I fixed it.

In Completion Suggestor you can also specify `regex`.

```
POST music/_search?pretty
{
    "suggest": {
        "song-suggest" : {
            "regex" : "n[ever|i]r",
            "completion" : {
                "field" : "suggest"
            }
        }
    }
}
```
I also modified it so that the user can select it.


```python
# Sample of use

# Term Suggester
s = s.suggest('song-suggest', 'nir', term={'field': 'suggest'})

# Completion Suggester + prefix query
s = s.suggest('song-suggest', 'nir', completion={'field': 'suggest'})

# Completion Suggester + regex query
s = s.suggest('song-suggest', regex='n[ever|i]r', completion={'field': 'suggest'})
# "regex"  must be keyword argument.
```

Please feel free to merge it. thx.
