### PR TITLE
[Fix #1091] Index.document() does not set index on Document class

### DIFF
--- a/elasticsearch_dsl/document.py
+++ b/elasticsearch_dsl/document.py
@@ -39,7 +39,7 @@ class IndexMeta(DocumentMeta):
             index_opts = attrs.pop('Index', None)
             index = cls.construct_index(index_opts, bases)
             new_cls._index = index
-            if index:
+            if index._name:
                 index.document(new_cls)
         cls._document_initialized = True
         return new_cls

--- a/elasticsearch_dsl/document.py
+++ b/elasticsearch_dsl/document.py
@@ -51,8 +51,8 @@ class IndexMeta(DocumentMeta):
                 if hasattr(b, '_index'):
                     return b._index
 
-            # return None as there are no index_opts
-            return None
+            # Set None as Index name so it will set _all while making the query
+            return Index(name=None)
 
         i = Index(
             getattr(opts, 'name', '*'),

--- a/elasticsearch_dsl/document.py
+++ b/elasticsearch_dsl/document.py
@@ -37,8 +37,10 @@ class IndexMeta(DocumentMeta):
         new_cls = super(IndexMeta, cls).__new__(cls, name, bases, attrs)
         if cls._document_initialized:
             index_opts = attrs.pop('Index', None)
-            new_cls._index = cls.construct_index(index_opts, bases)
-            new_cls._index.document(new_cls)
+            index = cls.construct_index(index_opts, bases)
+            if index:
+                new_cls._index = index
+                index.document(new_cls)
         cls._document_initialized = True
         return new_cls
 
@@ -48,8 +50,9 @@ class IndexMeta(DocumentMeta):
             for b in bases:
                 if hasattr(b, '_index'):
                     return b._index
-            # create an all-matching index pattern
-            return Index('*')
+
+            # return None as there are no index_opts
+            return None
 
         i = Index(
             getattr(opts, 'name', '*'),

--- a/elasticsearch_dsl/document.py
+++ b/elasticsearch_dsl/document.py
@@ -38,8 +38,8 @@ class IndexMeta(DocumentMeta):
         if cls._document_initialized:
             index_opts = attrs.pop('Index', None)
             index = cls.construct_index(index_opts, bases)
+            new_cls._index = index
             if index:
-                new_cls._index = index
                 index.document(new_cls)
         cls._document_initialized = True
         return new_cls

--- a/elasticsearch_dsl/index.py
+++ b/elasticsearch_dsl/index.py
@@ -159,6 +159,11 @@ class Index(object):
                 'Index object cannot have multiple types, %s already set, '
                 'trying to assign %s.' % (doc_type, name))
         self._doc_types.append(document)
+
+        # If the document does not have any index, set this index as document index
+        if document._index is None:
+            document._index = self
+
         return document
     doc_type = document
 

--- a/elasticsearch_dsl/index.py
+++ b/elasticsearch_dsl/index.py
@@ -160,8 +160,10 @@ class Index(object):
                 'trying to assign %s.' % (doc_type, name))
         self._doc_types.append(document)
 
-        # If the document does not have any index, set this index as document index
-        if document._index is None:
+        # If the document index does not have any name, that means the user
+        # did not set any index already to the document.
+        # So set this index as document index
+        if document._index._name is None:
             document._index = self
 
         return document

--- a/test_elasticsearch_dsl/test_document.py
+++ b/test_elasticsearch_dsl/test_document.py
@@ -18,6 +18,9 @@ class MyDoc(document.Document):
     created_at = field.Date()
     inner = field.Object(MyInner)
 
+    class Index:
+        name = 'my-doc'
+
 class MySubDoc(MyDoc):
     name = field.Keyword()
 
@@ -118,6 +121,10 @@ def test_document_can_redefine_doc_type():
         kw = field.Keyword()
         class Meta:
             doc_type = 'not-doc'
+
+        class Index:
+            name = 'test-not-doc-index'
+
     assert D._index._get_doc_type() == 'not-doc'
     assert D._index.to_dict() == {
         'mappings': {'not-doc': {'properties': {'kw': {'type': 'keyword'}}}}
@@ -126,7 +133,8 @@ def test_document_can_redefine_doc_type():
 def test_document_cannot_specify_different_doc_type_if_index_defined():
     # this will initiate ._index with doc_type = 'doc'
     class C(document.Document):
-        pass
+        class Index:
+            name = 'test-doc-type-c'
 
     with raises(IllegalOperation):
         class D(C):
@@ -597,7 +605,8 @@ def test_from_es_respects_underscored_non_meta_fields():
     }
 
     class Company(document.Document):
-        pass
+        class Index:
+            name = 'test-company'
 
     c = Company.from_es(doc)
 

--- a/test_elasticsearch_dsl/test_document.py
+++ b/test_elasticsearch_dsl/test_document.py
@@ -37,6 +37,9 @@ class Comment(document.InnerDoc):
 class DocWithNested(document.Document):
     comments = field.Nested(Comment)
 
+    class Index:
+        name = 'test-doc-with-nested'
+
 class SimpleCommit(document.Document):
     files = field.Text(multi=True)
 
@@ -59,14 +62,26 @@ class SecretField(field.CustomField):
 class SecretDoc(document.Document):
     title = SecretField(index='no')
 
+    class Index:
+        name = 'test-secret-doc'
+
 class NestedSecret(document.Document):
     secrets = field.Nested(SecretDoc)
+
+    class Index:
+        name = 'test-nested-secret'
 
 class OptionalObjectWithRequiredField(document.Document):
     comments = field.Nested(properties={'title': field.Keyword(required=True)})
 
+    class Index:
+        name = 'test-required'
+
 class Host(document.Document):
     ip = field.Ip()
+
+    class Index:
+        name = 'test-host'
 
 def test_range_serializes_properly():
     class D(document.Document):

--- a/test_elasticsearch_dsl/test_document.py
+++ b/test_elasticsearch_dsl/test_document.py
@@ -18,9 +18,6 @@ class MyDoc(document.Document):
     created_at = field.Date()
     inner = field.Object(MyInner)
 
-    class Index:
-        name = 'my-doc'
-
 class MySubDoc(MyDoc):
     name = field.Keyword()
 
@@ -439,7 +436,7 @@ def test_to_dict_is_recursive_and_can_cope_with_multi_values():
     } == md.to_dict()
 
 def test_to_dict_ignores_empty_collections():
-    md = MyDoc(name='', address={}, count=0, valid=False, tags=[])
+    md = MySubDoc(name='', address={}, count=0, valid=False, tags=[])
 
     assert {'name': '', 'count': 0, 'valid': False} == md.to_dict()
 

--- a/test_elasticsearch_dsl/test_integration/test_faceted_search.py
+++ b/test_elasticsearch_dsl/test_integration/test_faceted_search.py
@@ -21,9 +21,16 @@ class Repos(Document):
     is_public = Boolean()
     created_at = Date()
 
+    class Index:
+        name = 'git'
+
+
 class Commit(Document):
     files = Keyword()
     committed_date = Date()
+
+    class Index:
+        name = 'git'
 
 class RepoSearch(FacetedSearch):
     index = 'git'

--- a/test_elasticsearch_dsl/test_result.py
+++ b/test_elasticsearch_dsl/test_result.py
@@ -150,6 +150,10 @@ def test_bucket_response_can_be_iterated_over(agg_response):
 def test_bucket_keys_get_deserialized(aggs_data, aggs_search):
     class Commit(Document):
         info = Object(properties={'committed_date': Date()})
+
+        class Index:
+            name = 'test-commit'
+
     aggs_search = aggs_search.doc_type(Commit)
     agg_response = response.Response(aggs_search, aggs_data)
 


### PR DESCRIPTION
This will fix  #1091

In the previous versions, the [`Index.document()`](https://elasticsearch-dsl.readthedocs.io/en/latest/api.html#elasticsearch_dsl.Index.document) method added the `Index` to the `Document` class. But it was removed in 69f5ca2dc7657c26a19f11d75b7c2080afcfcdd6 in order to implement the inheritance document.

This patch will add `Index` to the `Document` class moreover also set `None` to `Document._index` property if `Index` Innesclass is not in set.

@HonzaKral r?