### PR TITLE
Fix tiny typo in documentation

### DIFF
--- a/docs/search_dsl.rst
+++ b/docs/search_dsl.rst
@@ -408,7 +408,7 @@ Enabling highlighting for individual fields is done using the ``highlight`` meth
     # or, including parameters:
     s = s.highlight('title', fragment_size=50)
 
-The fragments in the response will then be available on reach ``Result`` object
+The fragments in the response will then be available on each ``Result`` object
 as ``.meta.highlight.FIELD`` which will contain the list of fragments:
 
 .. code:: python


### PR DESCRIPTION
Says "reach" where it should say "each".