### PR TITLE
[Fix #1084] Fix Hit object to pickle the meta member

### DIFF
--- a/elasticsearch_dsl/response/hit.py
+++ b/elasticsearch_dsl/response/hit.py
@@ -12,6 +12,14 @@ class Hit(AttrDict):
         # assign meta as attribute and not as key in self._d_
         super(AttrDict, self).__setattr__('meta', HitMeta(document))
 
+    def __getstate__(self):
+        # add self.meta since it is not in self.__dict__
+        return super(Hit, self).__getstate__() + (self.meta, )
+
+    def __setstate__(self, state):
+        super(AttrDict, self).__setattr__('meta', state[-1])
+        super(Hit, self).__setstate__(state[:-1])
+
     def __dir__(self):
         # be sure to expose meta in dir(self)
         return super(Hit, self).__dir__() + ['meta']

--- a/test_elasticsearch_dsl/test_result.py
+++ b/test_elasticsearch_dsl/test_result.py
@@ -32,6 +32,7 @@ def test_hit_is_pickleable(dummy_response):
     hits = pickle.loads(pickle.dumps(res.hits))
 
     assert hits == res.hits
+    assert hits[0].meta == res.hits[0].meta
 
 def test_response_stores_search(dummy_response):
     s = Search()


### PR DESCRIPTION
This fixes [#1084](https://github.com/elastic/elasticsearch-dsl-py/issues/1084).

I would also like to to the same for the 5.x branch as this is the branch we use in our company, I'll open a new PR once this one is merged.

Thanks :)