### PR TITLE
[Fix #1084]Fix Hit object to pickle the meta member in 5.x versions

### DIFF
--- a/elasticsearch_dsl/response/hit.py
+++ b/elasticsearch_dsl/response/hit.py
@@ -22,6 +22,14 @@ class Hit(AttrDict):
         # assign meta as attribute and not as key in self._d_
         super(AttrDict, self).__setattr__('meta', HitMeta(document))
 
+    def __getstate__(self):
+        # add self.meta since it is not in self.__dict__
+        return super(Hit, self).__getstate__() + (self.meta, )
+
+    def __setstate__(self, state):
+        super(AttrDict, self).__setattr__('meta', state[-1])
+        super(Hit, self).__setstate__(state[:-1])
+
     def __dir__(self):
         # be sure to expose meta in dir(self)
         return super(Hit, self).__dir__() + ['meta']

--- a/test_elasticsearch_dsl/test_result.py
+++ b/test_elasticsearch_dsl/test_result.py
@@ -32,6 +32,7 @@ def test_hit_is_pickleable(dummy_response):
     hits = pickle.loads(pickle.dumps(res.hits))
 
     assert hits == res.hits
+    assert hits[0].meta == res.hits[0].meta
 
 def test_response_stores_search(dummy_response):
     s = Search()


### PR DESCRIPTION
As stated [here](https://github.com/elastic/elasticsearch-dsl-py/pull/1131) I'm opening a similar PR to fix the [issue ](https://github.com/elastic/elasticsearch-dsl-py/issues/1084) for 5.x since we use this version in our company.

Thanks :)