### PR TITLE
Reintroduce Attachment Field

### DIFF
--- a/elasticsearch_dsl/field.py
+++ b/elasticsearch_dsl/field.py
@@ -359,6 +359,9 @@ class Binary(Field):
             return None
         return base64.b64encode(data).decode()
 
+class Attachment(Field):
+    name = 'attachment'
+
 class GeoPoint(Field):
     name = 'geo_point'
 


### PR DESCRIPTION
This change fixes #1114, which seemed to arise from the (unintentional?) removal of the Attachment field in a merge commit 21a620d758d13d1ca3d20c36d6db0fead0e8b5fe