### PR TITLE
Update index.rst

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -30,7 +30,7 @@ Compatibility
 The library is compatible with all Elasticsearch versions since ``2.x`` but you
 **have to use a matching major version**:
 
-For **Elasticsearch 6.0** and later, use the major version 7 (``7.x.y``) of the
+For **Elasticsearch 7.0** and later, use the major version 7 (``7.x.y``) of the
 library.
 
 For **Elasticsearch 6.0** and later, use the major version 6 (``6.x.y``) of the


### PR DESCRIPTION
Changed Elasticsearch typo '6.0' to 7.0.