### PR TITLE
Don't override existing extras in update_from_dict

### DIFF
--- a/docs/update_by_query.rst
+++ b/docs/update_by_query.rst
@@ -105,7 +105,7 @@ the data from the dict:
 
   ubq = UpdateByQuery.from_dict({"query": {"match": {"title": "python"}}})
 
-If you wish to modify an existing ``Update By Query`` object, overriding it'ubq
+If you wish to modify an existing ``Update By Query`` object, overriding it's
 properties, instead use the ``update_from_dict`` method that alters an instance
 **in-place**:
 

--- a/elasticsearch_dsl/search.py
+++ b/elasticsearch_dsl/search.py
@@ -441,7 +441,7 @@ class Search(Request):
                     s.setdefault('text', text)
         if 'script_fields' in d:
             self._script_fields = d.pop('script_fields')
-        self._extra = d
+        self._extra.update(d)
         return self
 
     def script_fields(self, **kwargs):

--- a/elasticsearch_dsl/update_by_query.py
+++ b/elasticsearch_dsl/update_by_query.py
@@ -85,7 +85,7 @@ class UpdateByQuery(Request):
             self.query._proxied = Q(d.pop('query'))
         if 'script' in d:
             self._script = d.pop('script')
-        self._extra = d
+        self._extra.update(d)
         return self
 
     def script(self, **kwargs):

--- a/test_elasticsearch_dsl/test_search.py
+++ b/test_elasticsearch_dsl/test_search.py
@@ -530,3 +530,18 @@ def test_delete_by_query(mock_client):
         index=None,
         body={"query": {"match": {"lang": "java"}}}
     )
+
+def test_update_from_dict():
+    s = search.Search()
+    s.update_from_dict({"indices_boost": [{"important-documents": 2}]})
+    s.update_from_dict({"_source": ["id", "name"]})
+
+    assert {
+        'indices_boost': [{
+            'important-documents': 2
+        }],
+        '_source': [
+            'id',
+            'name'
+        ]
+    } == s.to_dict()


### PR DESCRIPTION
Previously, update_from_dict would discard existing extras, e.g. 
```
from elasticsearch_dsl import Search
search = Search()
search.update_from_dict({"indices_boost": [{"important-documents": 2}]})
search.update_from_dict({"_source": ["id", "name"]})
```
made `search.to_dict()` equal `{'_source': ['id', 'name']}`. With this change, `indices_boost` is kept in extras together with `_source`.