### PR TITLE
Drop deprecated DocType

### DIFF
--- a/elasticsearch_dsl/__init__.py
+++ b/elasticsearch_dsl/__init__.py
@@ -4,7 +4,7 @@ from .function import SF
 from .search import Search, MultiSearch
 from .update_by_query import UpdateByQuery
 from .field import *
-from .document import Document, DocType, MetaField, InnerDoc
+from .document import Document, MetaField, InnerDoc
 from .mapping import Mapping
 from .index import Index, IndexTemplate
 from .analysis import analyzer, char_filter, normalizer, token_filter, tokenizer

--- a/elasticsearch_dsl/document.py
+++ b/elasticsearch_dsl/document.py
@@ -454,6 +454,3 @@ class Document(ObjectBase):
 
         return meta['result']
 
-# limited backwards compatibility, to be removed in 7.0.0
-DocType = Document
-


### PR DESCRIPTION
As mentioned in the docs and the comment in the code, `DocType` is meant to be dropped in 7.0.0, but still exists at the moment.