### PR TITLE
Optimistic concurrent control for Document.delete

### DIFF
--- a/elasticsearch_dsl/document.py
+++ b/elasticsearch_dsl/document.py
@@ -274,6 +274,12 @@ class Document(ObjectBase):
             for k in DOC_META_FIELDS
             if k in self.meta
         }
+
+        # Optimistic concurrency control
+        if 'seq_no' in self.meta and 'primary_term' in self.meta:
+            doc_meta['if_seq_no'] = self.meta['seq_no']
+            doc_meta['if_primary_term'] = self.meta['primary_term']
+
         doc_meta.update(kwargs)
         es.delete(
             index=self._get_index(index),

--- a/test_elasticsearch_dsl/test_integration/test_document.py
+++ b/test_elasticsearch_dsl/test_integration/test_document.py
@@ -288,6 +288,13 @@ def test_save_automatically_uses_seq_no_and_primary_term(data_client):
     with raises(ConflictError):
         elasticsearch_repo.save()
 
+def test_delete_automatically_uses_seq_no_and_primary_term(data_client):
+    elasticsearch_repo = Repository.get('elasticsearch-dsl-py')
+    elasticsearch_repo.meta.seq_no += 1
+
+    with raises(ConflictError):
+        elasticsearch_repo.delete()
+
 def assert_doc_equals(expected, actual):
     for f in expected:
         assert f in actual


### PR DESCRIPTION
Optimistic concurrency is also available with the Delete API. Not sure if it was skipped on purpose or simply an oversight.