### PR TITLE
Refactores usage of connection singeton to exposed functions

### DIFF
--- a/elasticsearch_dsl/analysis.py
+++ b/elasticsearch_dsl/analysis.py
@@ -1,7 +1,7 @@
 import six
 
-from .connections import connections
-from .utils import DslBase, AttrDict
+from .connections import get_connection
+from .utils import AttrDict, DslBase
 
 __all__ = [
     'tokenizer', 'analyzer', 'char_filter', 'token_filter', 'normalizer'
@@ -94,7 +94,7 @@ class CustomAnalyzer(CustomAnalysisDefinition, Analyzer):
         :arg attributes: if ``explain`` is specified, filter the token
             attributes to return.
         """
-        es = connections.get_connection(using)
+        es = get_connection(using)
 
         body = {'text': text, 'explain': explain}
         if attributes:

--- a/elasticsearch_dsl/document.py
+++ b/elasticsearch_dsl/document.py
@@ -6,15 +6,15 @@ except ImportError:
 from fnmatch import fnmatch
 
 from elasticsearch.exceptions import NotFoundError, RequestError
-from six import iteritems, add_metaclass
+from six import add_metaclass, iteritems
 
+from .connections import get_connection
+from .exceptions import IllegalOperation, ValidationException
 from .field import Field
-from .mapping import Mapping
-from .utils import ObjectBase, merge, DOC_META_FIELDS, META_FIELDS
-from .search import Search
-from .connections import connections
-from .exceptions import ValidationException, IllegalOperation
 from .index import Index
+from .mapping import Mapping
+from .search import Search
+from .utils import DOC_META_FIELDS, META_FIELDS, ObjectBase, merge
 
 
 class MetaField(object):
@@ -121,7 +121,7 @@ class Document(ObjectBase):
 
     @classmethod
     def _get_connection(cls, using=None):
-        return connections.get_connection(cls._get_using(using))
+        return get_connection(cls._get_using(using))
 
     @classmethod
     def _default_index(cls, index=None):

--- a/elasticsearch_dsl/index.py
+++ b/elasticsearch_dsl/index.py
@@ -1,10 +1,10 @@
-from .connections import connections
-from .search import Search
-from .update_by_query import UpdateByQuery
+from . import analysis
+from .connections import get_connection
 from .exceptions import IllegalOperation
 from .mapping import Mapping
+from .search import Search
+from .update_by_query import UpdateByQuery
 from .utils import merge
-from . import analysis
 
 DEFAULT_DOC_TYPE = 'doc'
 
@@ -32,7 +32,7 @@ class IndexTemplate(object):
         return d
 
     def save(self, using=None):
-        es = connections.get_connection(using or self._index._using)
+        es = get_connection(using or self._index._using)
         es.indices.put_template(name=self._template_name, body=self.to_dict())
 
 class Index(object):
@@ -110,7 +110,7 @@ class Index(object):
         if self._name is None:
             raise ValueError(
                 "You cannot perform API calls on the default index.")
-        return connections.get_connection(using or self._using)
+        return get_connection(using or self._using)
     connection = property(_get_connection)
 
     def mapping(self, mapping):

--- a/elasticsearch_dsl/mapping.py
+++ b/elasticsearch_dsl/mapping.py
@@ -3,12 +3,13 @@ try:
 except ImportError:
     import collections as collections_abc
 
-from six import iteritems, itervalues
 from itertools import chain
 
+from six import iteritems, itervalues
+
+from .connections import get_connection
+from .field import Nested, Text, construct_field
 from .utils import DslBase
-from .field import Text, construct_field, Nested
-from .connections import connections
 
 META_FIELDS = frozenset((
     'dynamic', 'transform', 'dynamic_date_formats', 'date_detection',
@@ -135,7 +136,7 @@ class Mapping(object):
         return index.save()
 
     def update_from_es(self, index, using='default'):
-        es = connections.get_connection(using)
+        es = get_connection(using)
         raw = es.indices.get_mapping(index=index)
         _, raw = raw.popitem()
         self._update_from_dict(raw['mappings'])

--- a/elasticsearch_dsl/search.py
+++ b/elasticsearch_dsl/search.py
@@ -14,7 +14,7 @@ from .query import Q, Bool
 from .aggs import A, AggBase
 from .utils import DslBase, AttrDict
 from .response import Response, Hit
-from .connections import connections
+from .connections import get_connection
 from .exceptions import IllegalOperation
 
 
@@ -669,7 +669,7 @@ class Search(Request):
         if hasattr(self, '_response'):
             return self._response.hits.total
 
-        es = connections.get_connection(self._using)
+        es = get_connection(self._using)
 
         d = self.to_dict(count=True)
         # TODO: failed shards detection
@@ -688,7 +688,7 @@ class Search(Request):
             ES, while cached result will be ignored. Defaults to `False`
         """
         if ignore_cache or not hasattr(self, '_response'):
-            es = connections.get_connection(self._using)
+            es = get_connection(self._using)
 
             self._response = self._response_class(
                 self,
@@ -710,7 +710,7 @@ class Search(Request):
         https://elasticsearch-py.readthedocs.io/en/master/helpers.html#elasticsearch.helpers.scan
 
         """
-        es = connections.get_connection(self._using)
+        es = get_connection(self._using)
 
         for hit in scan(
                 es,
@@ -725,7 +725,7 @@ class Search(Request):
         delete() executes the query by delegating to delete_by_query()
         """
 
-        es = connections.get_connection(self._using)
+        es = get_connection(self._using)
 
         return AttrDict(
             es.delete_by_query(
@@ -786,7 +786,7 @@ class MultiSearch(Request):
         Execute the multi search request and return a list of search results.
         """
         if ignore_cache or not hasattr(self, '_response'):
-            es = connections.get_connection(self._using)
+            es = get_connection(self._using)
 
             responses = es.msearch(
                 index=self._index,

--- a/elasticsearch_dsl/update_by_query.py
+++ b/elasticsearch_dsl/update_by_query.py
@@ -1,9 +1,8 @@
-import copy
-
-from .search import Request, QueryProxy, ProxyDescriptor
-from .query import Q, Bool
+from .connections import get_connection
+from .query import Bool, Q
 from .response import UpdateByQueryResponse
-from .connections import connections
+from .search import ProxyDescriptor, QueryProxy, Request
+
 
 class UpdateByQuery(Request):
 
@@ -134,7 +133,7 @@ class UpdateByQuery(Request):
         Execute the search and return an instance of ``Response`` wrapping all
         the data.
         """
-        es = connections.get_connection(self._using)
+        es = get_connection(self._using)
 
         self._response = self._response_class(
             self,

--- a/test_elasticsearch_dsl/conftest.py
+++ b/test_elasticsearch_dsl/conftest.py
@@ -8,7 +8,7 @@ from elasticsearch.helpers.test import SkipTest, get_test_client
 from mock import Mock
 from pytest import fixture, skip
 
-from elasticsearch_dsl.connections import connections
+from elasticsearch_dsl.connections import connections, add_connection
 from .test_integration.test_data import DATA, FLAT_DATA, TEST_GIT_DATA, \
     create_git_index, create_flat_git_index
 from .test_integration.test_document import PullRequest, Comment, User, History
@@ -18,7 +18,7 @@ from .test_integration.test_document import PullRequest, Comment, User, History
 def client():
     try:
         connection = get_test_client(nowait='WAIT_FOR_ES' not in os.environ)
-        connections.add_connection('default', connection)
+        add_connection('default', connection)
         return connection
     except SkipTest:
         skip()
@@ -33,7 +33,7 @@ def write_client(client):
 def mock_client(dummy_response):
     client = Mock()
     client.search.return_value = dummy_response
-    connections.add_connection('mock', client)
+    add_connection('mock', client)
     yield client
     connections._conn = {}
     connections._kwargs = {}


### PR DESCRIPTION
Since refactoring interface of `connections`, we now have more clean way to use connections machinery.

PR provides small refactoring on this, plus import order fixes for affected fields.

AFAIK, this is fully backward-compatible change, can be released with next minor version.