### PR TITLE
Added .keys and .items to AttrDict so Marshmallow 3+ will work.

### DIFF
--- a/elasticsearch_dsl/utils.py
+++ b/elasticsearch_dsl/utils.py
@@ -158,6 +158,12 @@ class AttrDict(object):
     def to_dict(self):
         return self._d_
 
+    def keys(self):
+        return self._d_.keys()
+
+    def items(self):
+        return self._d_.items()
+
 
 class DslMeta(type):
     """

--- a/test_elasticsearch_dsl/test_utils.py
+++ b/test_elasticsearch_dsl/test_utils.py
@@ -10,6 +10,17 @@ def test_attrdict_pickle():
     pickled_ad = pickle.dumps(ad)
     assert ad == pickle.loads(pickled_ad)
 
+def test_attrdict_keys():
+    d = {'a': 1, 'b': 42}
+    ad = utils.AttrDict(d)
+
+    assert ad.keys() == d.keys()
+
+def test_attrdict_items():
+    d = {'a': 1, 'b': 42}
+    ad = utils.AttrDict(d)
+
+    assert ad.items() == d.items()
 
 def test_attrlist_pickle():
     al = utils.AttrList([])


### PR DESCRIPTION
Fixes #1250 

If have added a `.keys` and `.items` method to AttrDict that simply returns those methods called on `_d_`. This satisfies marshmallow. Unit tests included.

This is pointed at master right now, but I can change that if you want since it effects all versions at least down to v2.x of elasticsearch_dsl. If merged into master, I'd personally appreciate it also merged on down to the other versions (2 specifically) and made into a patch release :)

Also, I probably would have signed the CLA, but the link is broken. #1251 You have my consent to distribute this patch.

Thanks!