### PR TITLE
Prevent Object/Nested from mutating the inner doc_class' mapping

### DIFF
--- a/elasticsearch_dsl/field.py
+++ b/elasticsearch_dsl/field.py
@@ -1,4 +1,5 @@
 import base64
+import copy
 import ipaddress
 
 try:
@@ -151,7 +152,7 @@ class Object(Field):
             if dynamic is not None:
                 self._doc_class._doc_type.mapping.meta('dynamic', dynamic)
 
-        self._mapping = self._doc_class._doc_type.mapping
+        self._mapping = copy.deepcopy(self._doc_class._doc_type.mapping)
         super(Object, self).__init__(**kwargs)
 
     def __getitem__(self, name):

--- a/test_elasticsearch_dsl/test_document.py
+++ b/test_elasticsearch_dsl/test_document.py
@@ -588,5 +588,14 @@ def test_nested_and_object_inner_doc():
         nested_inner = field.Nested(MyInner)
 
     props = MySubDocWithNested._doc_type.mapping.to_dict()['properties']
-    assert props['nested_inner']['type'] == 'nested'
-    assert props['inner']['type'] == 'object'
+    assert props == {
+        "created_at": {"type": "date"},
+        "inner": {"properties": {"old_field": {"type": "text"}}, "type": "object"},
+        "name": {"type": "text"},
+        "nested_inner": {
+            "properties": {"old_field": {"type": "text"}},
+            "type": "nested",
+        },
+        "title": {"type": "keyword"},
+    }
+

--- a/test_elasticsearch_dsl/test_document.py
+++ b/test_elasticsearch_dsl/test_document.py
@@ -582,3 +582,11 @@ def test_from_es_respects_underscored_non_meta_fields():
     assert c.meta.fields._tags == ['search']
     assert c.meta.fields._routing == 'es'
     assert c._tagline == 'You know, for search'
+
+def test_nested_and_object_inner_doc():
+    class MySubDocWithNested(MyDoc):
+        nested_inner = field.Nested(MyInner)
+
+    props = MySubDocWithNested._doc_type.mapping.to_dict()['properties']
+    assert props['nested_inner']['type'] == 'nested'
+    assert props['inner']['type'] == 'object'


### PR DESCRIPTION
If the same inner doc is used with both Object and Nested they override each other's mapping type, as shown in the test.