### PR TITLE
Fix connection configuration example syntax

### DIFF
--- a/elasticsearch_dsl/connections.py
+++ b/elasticsearch_dsl/connections.py
@@ -23,7 +23,7 @@ class Connections(object):
 
             connections.configure(
                 default={'hosts': 'localhost'},
-                dev={'hosts': ['esdev1.example.com:9200'], sniff_on_start=True}
+                dev={'hosts': ['esdev1.example.com:9200'], 'sniff_on_start': True},
             )
 
         Connections will only be constructed lazily when requested through


### PR DESCRIPTION
Updates the example code with correct syntax. This change now aligns with example documentation in the docs that was updated [here](https://github.com/elastic/elasticsearch-dsl-py/commit/a81d1288e2d51c6d9003d913f283646352fe0255)