### PR TITLE
Corrected the datatype of DoubleRange

### DIFF
--- a/elasticsearch_dsl/field.py
+++ b/elasticsearch_dsl/field.py
@@ -414,7 +414,7 @@ class LongRange(RangeField):
     _core_field = Long()
 
 class DoubleRange(RangeField):
-    name = 'double_ranged'
+    name = 'double_range'
     _core_field = Double()
 
 class DateRange(RangeField):


### PR DESCRIPTION
Without this change, Elasticsearch will return the following exception:

elasticsearch.exceptions.RequestError: RequestError(400, 'mapper_parsing_exception', 'No handler for type [double_ranged] declared on field [my_range]’)

This is because according to the documentation, this datatype is actually called `double_range` not `double_ranged`. See: https://www.elastic.co/guide/en/elasticsearch/reference/current/range.html