### PR TITLE
Remove standard filter

### DIFF
--- a/docs/persistence.rst
+++ b/docs/persistence.rst
@@ -28,7 +28,7 @@ settings in elasticsearch (see :ref:`life-cycle` for details).
 
     html_strip = analyzer('html_strip',
         tokenizer="standard",
-        filter=["standard", "lowercase", "stop", "snowball"],
+        filter=["lowercase", "stop", "snowball"],
         char_filter=["html_strip"]
     )
 


### PR DESCRIPTION
Standard token filter has been removed in 7.0.

https://www.elastic.co/guide/en/elasticsearch/reference/current/breaking-changes-7.0.html#standard-filter-removed