### PR TITLE
Remove extra nesting level in generated query for Search.exclude

### DIFF
--- a/elasticsearch_dsl/search.py
+++ b/elasticsearch_dsl/search.py
@@ -314,7 +314,7 @@ class Search(Request):
         return self.query(Bool(filter=[Q(*args, **kwargs)]))
 
     def exclude(self, *args, **kwargs):
-        return self.query(Bool(filter=[~Q(*args, **kwargs)]))
+        return self.query(~Q(*args, **kwargs))
 
     def __iter__(self):
         """

--- a/test_elasticsearch_dsl/test_search.py
+++ b/test_elasticsearch_dsl/test_search.py
@@ -503,13 +503,9 @@ def test_exclude():
     assert {
         'query': {
             'bool': {
-                'filter': [{
-                    'bool': {
-                        'must_not': [{
-                            'match': {
-                                'title': 'python'
-                            }
-                        }]
+                'must_not': [{
+                    'match': {
+                        'title': 'python'
                     }
                 }]
             }


### PR DESCRIPTION
As you can see from the updated test, `Search.exclude` previously generated a query that had a `bool` nested inside a `bool`, instead of using `must_not`. This makes the generated queries much easier to read, especially when you've made multiple calls to `Search.filter` first.