### PR TITLE
Add support for the "boxplot" aggregation

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -24,6 +24,8 @@ matrix:
         - python -m pip install nox
       script:
         - nox -s lint
+  allow_failures:
+    - { python: "nightly" }
 
 install:
   - mkdir /tmp/elasticsearch

--- a/elasticsearch_dsl/aggs.py
+++ b/elasticsearch_dsl/aggs.py
@@ -298,6 +298,10 @@ class WeightedAvg(Agg):
     name = "weighted_avg"
 
 
+class BoxPlot(Agg):
+    name = "boxplot"
+
+
 class Cardinality(Agg):
     name = "cardinality"
 

--- a/elasticsearch_dsl/index.py
+++ b/elasticsearch_dsl/index.py
@@ -264,7 +264,7 @@ class Index(object):
         For more information, see here:
         https://www.elastic.co/guide/en/elasticsearch/reference/current/docs-update-by-query.html
         """
-        return UpdateByQuery(using=using or self._using, index=self._name,)
+        return UpdateByQuery(using=using or self._using, index=self._name)
 
     def create(self, using=None, **kwargs):
         """

--- a/elasticsearch_dsl/utils.py
+++ b/elasticsearch_dsl/utils.py
@@ -32,7 +32,7 @@ from .exceptions import UnknownDslObject, ValidationException
 SKIP_VALUES = ("", None)
 EXPAND__TO_DOT = True
 
-DOC_META_FIELDS = frozenset(("id", "routing",))
+DOC_META_FIELDS = frozenset(("id", "routing"))
 
 META_FIELDS = frozenset(
     (

--- a/test_elasticsearch_dsl/test_integration/test_document.py
+++ b/test_elasticsearch_dsl/test_integration/test_document.py
@@ -437,7 +437,7 @@ def test_delete(write_client):
     test_repo.meta.index = "test-document"
     test_repo.delete()
 
-    assert not write_client.exists(index="test-document", id="elasticsearch-dsl-py",)
+    assert not write_client.exists(index="test-document", id="elasticsearch-dsl-py")
 
 
 def test_search(data_client):

--- a/test_elasticsearch_dsl/test_integration/test_document.py
+++ b/test_elasticsearch_dsl/test_integration/test_document.py
@@ -43,9 +43,7 @@ from elasticsearch_dsl.utils import AttrList
 
 from pytest import raises
 
-snowball = analyzer(
-    "my_snow", tokenizer="standard", filter=["lowercase", "snowball"]
-)
+snowball = analyzer("my_snow", tokenizer="standard", filter=["lowercase", "snowball"])
 
 
 class User(InnerDoc):

--- a/test_elasticsearch_dsl/test_integration/test_document.py
+++ b/test_elasticsearch_dsl/test_integration/test_document.py
@@ -44,7 +44,7 @@ from elasticsearch_dsl.utils import AttrList
 from pytest import raises
 
 snowball = analyzer(
-    "my_snow", tokenizer="standard", filter=["standard", "lowercase", "snowball"]
+    "my_snow", tokenizer="standard", filter=["lowercase", "snowball"]
 )
 
 

--- a/test_elasticsearch_dsl/test_search.py
+++ b/test_elasticsearch_dsl/test_search.py
@@ -429,17 +429,14 @@ def test_source():
 
 
 def test_source_on_clone():
-    assert (
-        {
-            "_source": {"includes": ["foo.bar.*"], "excludes": ["foo.one"]},
-            "query": {"bool": {"filter": [{"term": {"title": "python"}}]}},
-        }
-        == search.Search()
-        .source(includes=["foo.bar.*"])
-        .source(excludes=["foo.one"])
-        .filter("term", title="python")
-        .to_dict()
-    )
+    assert {
+        "_source": {"includes": ["foo.bar.*"], "excludes": ["foo.one"]},
+        "query": {"bool": {"filter": [{"term": {"title": "python"}}]}},
+    } == search.Search().source(includes=["foo.bar.*"]).source(
+        excludes=["foo.one"]
+    ).filter(
+        "term", title="python"
+    ).to_dict()
     assert {
         "_source": False,
         "query": {"bool": {"filter": [{"term": {"title": "python"}}]}},


### PR DESCRIPTION
This commit adds a new Agg subclass called BoxPlot, which passes the name "boxplot" as the aggregation type.

See https://www.elastic.co/guide/en/elasticsearch/reference/7.x/search-aggregations-metrics-boxplot-aggregation.html#_syntax

Fixes #1411 