### PR TITLE
Add many missing queries and aggs

### DIFF
--- a/elasticsearch_dsl/aggs.py
+++ b/elasticsearch_dsl/aggs.py
@@ -247,6 +247,13 @@ class Range(Bucket):
     name = "range"
 
 
+class RareTerms(Bucket):
+    name = "rare_terms"
+
+    def result(self, search, data):
+        return FieldBucketData(self, search, data)
+
+
 class ReverseNested(Bucket):
     name = "reverse_nested"
 
@@ -280,6 +287,13 @@ class Composite(Bucket):
         "sources": {"type": "agg", "hash": True, "multi": True},
         "aggs": {"type": "agg", "hash": True},
     }
+
+
+class VariableWidthHistogram(Bucket):
+    name = "variable_width_histogram"
+
+    def result(self, search, data):
+        return FieldBucketData(self, search, data)
 
 
 # metric aggregations
@@ -318,6 +332,10 @@ class Max(Agg):
     name = "max"
 
 
+class MedianAbsoluteDeviation(Agg):
+    name = "median_absolute_deviation"
+
+
 class Min(Agg):
     name = "min"
 
@@ -342,6 +360,10 @@ class Sum(Agg):
     name = "sum"
 
 
+class TTest(Agg):
+    name = "t_test"
+
+
 class ValueCount(Agg):
     name = "value_count"
 
@@ -363,12 +385,20 @@ class CumulativeSum(Pipeline):
     name = "cumulative_sum"
 
 
+class CumulativeCardinality(Pipeline):
+    name = "cumulative_cardinality"
+
+
 class Derivative(Pipeline):
     name = "derivative"
 
 
 class ExtendedStatsBucket(Pipeline):
     name = "extended_stats_bucket"
+
+
+class Inference(Pipeline):
+    name = "inference"
 
 
 class MaxBucket(Pipeline):
@@ -385,6 +415,14 @@ class MovingFn(Pipeline):
 
 class MovingAvg(Pipeline):
     name = "moving_avg"
+
+
+class MovingPercentiles(Pipeline):
+    name = "moving_percentiles"
+
+
+class Normalize(Pipeline):
+    name = "normalize"
 
 
 class PercentilesBucket(Pipeline):

--- a/elasticsearch_dsl/query.py
+++ b/elasticsearch_dsl/query.py
@@ -335,9 +335,14 @@ class FieldMaskingSpan(Query):
     _param_defs = {"query": {"type": "query"}}
 
 
-class SpanContainining(Query):
+class SpanContaining(Query):
     name = "span_containing"
     _param_defs = {"little": {"type": "query"}, "big": {"type": "query"}}
+
+
+# Original implementation contained
+# a typo: remove in v8.0.
+SpanContainining = SpanContaining
 
 
 class SpanWithin(Query):
@@ -398,6 +403,10 @@ class Ids(Query):
     name = "ids"
 
 
+class Intervals(Query):
+    name = "intervals"
+
+
 class Limit(Query):
     name = "limit"
 
@@ -450,6 +459,10 @@ class Regexp(Query):
     name = "regexp"
 
 
+class Shape(Query):
+    name = "shape"
+
+
 class SimpleQueryString(Query):
     name = "simple_query_string"
 
@@ -488,3 +501,7 @@ class Type(Query):
 
 class ParentId(Query):
     name = "parent_id"
+
+
+class Wrapper(Query):
+    name = "wrapper"


### PR DESCRIPTION
Adds the following aggs:
- rare_terms
- variable_width_histogram
- median_absolute_deviation
- t_test
- cumulative_cardinality
- moving_percentiles
- normalize

Adds the following queries:
- Intervals
- Shape
- Wrapper

Fixes the spelling of `SpanContainining` to `SpanContaining`