### PR TITLE
Closes issue #1427

### DIFF
--- a/elasticsearch_dsl/document.py
+++ b/elasticsearch_dsl/document.py
@@ -299,8 +299,9 @@ class Document(ObjectBase):
 
         :arg include_meta: if set to ``True`` will include all the metadata
             (``_index``, ``_id`` etc). Otherwise just the document's
-            data is serialized. This is useful when passing multiple instances into
-            ``elasticsearch.helpers.bulk``.
+            data is serialized. This is useful when passing multiple instances into 
+            ``elasticsearch.helpers.bulk``. 
+            `Read more about Elasticsearch bulk helper <https://elasticsearch-py.readthedocs.io/en/master/helpers.html#bulk-helpers>`_
         :arg skip_empty: if set to ``False`` will cause empty values (``None``,
             ``[]``, ``{}``) to be left on the document. Those values will be
             stripped out otherwise as they make no difference in elasticsearch.


### PR DESCRIPTION
add Elasticsearch bulk helper link in docs for `Document.to_dict`