### PR TITLE
Documentation: docs for script_fields are out of date

### DIFF
--- a/elasticsearch_dsl/search.py
+++ b/elasticsearch_dsl/search.py
@@ -481,7 +481,8 @@ class Search(Request):
             s = s.script_fields(
                 times_three={
                     'script': {
-                        'inline': "doc['field'].value * params.n",
+                        'lang': 'painless',
+                        'source': "doc['field'].value * params.n",
                         'params': {'n': 3}
                     }
                 }


### PR DESCRIPTION
The documented example for `script_fields` is out of date, and will log `ElasticsearchDeprecationWarning: Deprecated field [inline] used, expected [source] instead` if followed