### PR TITLE
Do not use "standard" filter when testing against 7.x

### DIFF
--- a/test_elasticsearch_dsl/test_integration/test_document.py
+++ b/test_elasticsearch_dsl/test_integration/test_document.py
@@ -15,10 +15,12 @@
 #  specific language governing permissions and limitations
 #  under the License.
 
+import os
 from datetime import datetime
 from ipaddress import ip_address
 
 from elasticsearch import ConflictError, NotFoundError
+from elasticsearch.helpers.test import get_test_client
 from pytest import raises
 from pytz import timezone
 
@@ -42,9 +44,17 @@ from elasticsearch_dsl import (
 )
 from elasticsearch_dsl.utils import AttrList
 
-snowball = analyzer(
-    "my_snow", tokenizer="standard", filter=["standard", "lowercase", "snowball"]
-)
+connection = get_test_client(nowait="WAIT_FOR_ES" not in os.environ)
+info = connection.info()
+
+if info["version"]["number"] >= "7.0.0":
+    snowball = analyzer(
+        "my_snow", tokenizer="standard", filter=["lowercase", "snowball"]
+    )
+else:
+    snowball = analyzer(
+        "my_snow", tokenizer="standard", filter=["standard", "lowercase", "snowball"]
+    )
 
 
 class User(InnerDoc):


### PR DESCRIPTION
The "standard" filter has been removed in 7.x and causes the integration tests to fail when run against Elasticsearch 7.x.

Per @HonzaKral's comment on #1288, 7.x clusters can still have indices created in 6.x, when the "standard" filter was valid. To continue supporting this until an 8.x release, this commit checks the Elasticsearch version the tests are being run against before constructing the analyzer that currently uses the "standard" filter. If the Elasticsearch version is >= 7, the "standard" filter is not used.