### PR TITLE
fix retry_on_conflict causing errors on document update for elasticsearch-dsl 6.x

### DIFF
--- a/elasticsearch_dsl/document.py
+++ b/elasticsearch_dsl/document.py
@@ -391,8 +391,9 @@ class Document(ObjectBase):
             if k in self.meta
         }
 
-        if retry_on_conflict is not None:
+        if retry_on_conflict not in (0, None):
             doc_meta['retry_on_conflict'] = retry_on_conflict
+            doc_meta['version'] = None
 
         meta = self._get_connection(using).update(
             index=self._get_index(index),


### PR DESCRIPTION
discussed in https://github.com/elastic/elasticsearch-dsl-py/pull/1461 since said PR only fixes 7.x

Fixes issues in https://github.com/elastic/elasticsearch-dsl-py/issues/1316 (closed) that seems to be using elasticsearch 6.x