### PR TITLE
docs: fix typos

### DIFF
--- a/Changelog.rst
+++ b/Changelog.rst
@@ -100,7 +100,7 @@ Changelog
 * Improved behavior of ``Index.save`` where it does a better job when index
   already exists
 * Composite aggregations now correctly support multiple ``sources`` aggs
-* ``UpdateByQuery`` implementated by @emarcey
+* ``UpdateByQuery`` implemented by @emarcey
 
 6.2.1 (2018-07-03)
 ------------------
@@ -226,7 +226,7 @@ Breaking changes:
 
 2.2.0 (2016-11-04)
 ------------------
- * accessing missing string fields no longer returnd ``''`` but returns
+ * accessing missing string fields no longer returned ``''`` but returns
    ``None`` instead.
  * fix issues with bool's ``|`` and ``&`` operators and ``minimum_should_match``
 

--- a/docs/faceted_search.rst
+++ b/docs/faceted_search.rst
@@ -83,7 +83,7 @@ of the methods responsible for the class' functions:
   filter for published articles only).
 
 ``query(self, search)``
-  adds the query postion of the search (if search input specified), by default
+  adds the query position of the search (if search input specified), by default
   using ``MultiField`` query. Override this if you want to modify the query type used.
 
 ``highlight(self, search)``

--- a/docs/persistence.rst
+++ b/docs/persistence.rst
@@ -228,7 +228,7 @@ If the document is not found in elasticsearch an exception
     p = Post.get(id='not-in-es', ignore=404)
     p is None
 
-When you wish to retrive multiple documents at the same time by their ``id``
+When you wish to retrieve multiple documents at the same time by their ``id``
 you can use the ``mget`` method:
 
 .. code:: python

--- a/elasticsearch_dsl/update_by_query.py
+++ b/elasticsearch_dsl/update_by_query.py
@@ -35,7 +35,7 @@ class UpdateByQuery(Request):
         :arg doc_type: only query this type.
 
         All the parameters supplied (or omitted) at creation type can be later
-        overriden by methods (`using`, `index` and `doc_type` respectively).
+        overridden by methods (`using`, `index` and `doc_type` respectively).
 
         """
         super(UpdateByQuery, self).__init__(**kwargs)


### PR DESCRIPTION
Hi,

This PR will fix : 

- 2 typos in `Changelog.rst`
- 1 typo in `docs/faceted_search.rst`
- 1 typo in `docs/persistence.rst`
- 1 typo in `elasticsearch_dsl/update_by_query.py`

Bye! :robot: