### PR TITLE
Add year interval for DateHistogramFacet

### DIFF
--- a/elasticsearch_dsl/faceted_search.py
+++ b/elasticsearch_dsl/faceted_search.py
@@ -168,6 +168,10 @@ class HistogramFacet(Facet):
         )
 
 
+def _date_interval_year(d):
+    return (d + timedelta(days=366)).replace(day=1)
+
+
 def _date_interval_month(d):
     return (d + timedelta(days=32)).replace(day=1)
 
@@ -188,6 +192,8 @@ class DateHistogramFacet(Facet):
     agg_type = "date_histogram"
 
     DATE_INTERVALS = {
+        "year": _date_interval_year,
+        "1Y": _date_interval_year,
         "month": _date_interval_month,
         "1M": _date_interval_month,
         "week": _date_interval_week,

--- a/elasticsearch_dsl/faceted_search.py
+++ b/elasticsearch_dsl/faceted_search.py
@@ -169,7 +169,7 @@ class HistogramFacet(Facet):
 
 
 def _date_interval_year(d):
-    return (d + timedelta(days=366)).replace(day=1)
+    return d.replace(year=d.year+1, day=(28 if d.month == 2 and d.day == 29 else d.day))
 
 
 def _date_interval_month(d):

--- a/tests/test_faceted_search.py
+++ b/tests/test_faceted_search.py
@@ -151,6 +151,8 @@ def test_date_histogram_facet_with_1970_01_01_date():
 @pytest.mark.parametrize(
     ["interval_type", "interval"],
     [
+        ("interval", "year"),
+        ("calendar_interval", "year"),
         ("interval", "month"),
         ("calendar_interval", "month"),
         ("interval", "week"),
@@ -160,6 +162,8 @@ def test_date_histogram_facet_with_1970_01_01_date():
         ("fixed_interval", "day"),
         ("interval", "hour"),
         ("fixed_interval", "hour"),
+        ("interval", "1Y"),
+        ("calendar_interval", "1Y"),
         ("interval", "1M"),
         ("calendar_interval", "1M"),
         ("interval", "1w"),


### PR DESCRIPTION
Added `year` interval for DateHistogramFacet.

Closes https://github.com/elastic/elasticsearch-dsl-py/issues/1501