### PR TITLE
Document using track_total_hits to ensure a true document count

### DIFF
--- a/docs/search_dsl.rst
+++ b/docs/search_dsl.rst
@@ -390,10 +390,6 @@ If you want to access all the documents matched by your query you can use the
 
 Note that in this case the results won't be sorted.
 
-.. note::
-
-  If you are only seeing partial results, consider using the option ``s.extra(track_total_hits=True)`` to get a full document count.
-
 Highlighting
 ~~~~~~~~~~~~
 
@@ -561,6 +557,9 @@ just iterate over the ``Response`` object:
     for h in response:
         print(h.title, h.body)
 
+.. note::
+
+  If you are only seeing partial results (e.g. 10000 or even 10 results), consider using the option ``s.extra(track_total_hits=True)`` to get a full hit count.
 
 Result
 ~~~~~~

--- a/docs/search_dsl.rst
+++ b/docs/search_dsl.rst
@@ -390,6 +390,10 @@ If you want to access all the documents matched by your query you can use the
 
 Note that in this case the results won't be sorted.
 
+.. note::
+
+  If you are only seeing partial results, consider using the option ``s.extra(track_total_hits=True)`` to get a full document count.
+
 Highlighting
 ~~~~~~~~~~~~
 


### PR DESCRIPTION
I ran into issues retrieving a full document count, and only identified the fix in [this issue](https://github.com/elastic/elasticsearch-dsl-py/issues/1183). To help the next person, I want to add a note in the docs about it