### PR TITLE
Add AttrList.to_list()

### DIFF
--- a/elasticsearch_dsl/utils.py
+++ b/elasticsearch_dsl/utils.py
@@ -102,7 +102,8 @@ class AttrList:
         self._l_, self._obj_wrapper = state
 
     def to_list(self):
-        return [x for x in self.__iter__()]
+        return self._l_
+
 
 class AttrDict:
     """

--- a/elasticsearch_dsl/utils.py
+++ b/elasticsearch_dsl/utils.py
@@ -101,6 +101,8 @@ class AttrList:
     def __setstate__(self, state):
         self._l_, self._obj_wrapper = state
 
+    def to_list(self):
+        return [x for x in self.__iter__()]
 
 class AttrDict:
     """

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -100,3 +100,8 @@ def test_recursive_to_dict():
     assert utils.recursive_to_dict({"k": [1, (1.0, {"v": Q("match", key="val")})]}) == {
         "k": [1, (1.0, {"v": {"match": {"key": "val"}}})]
     }
+
+def test_attrlist_to_list():
+    l = utils.AttrList([{}, {}]).to_list()
+    assert isinstance(l, list)
+    assert l == [{}, {}]

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -101,6 +101,7 @@ def test_recursive_to_dict():
         "k": [1, (1.0, {"v": {"match": {"key": "val"}}})]
     }
 
+
 def test_attrlist_to_list():
     l = utils.AttrList([{}, {}]).to_list()
     assert isinstance(l, list)


### PR DESCRIPTION
`AttrDict` has `to_dict()` but `AttrList` does not have `to_list()`.

`AttrList` does not work for PyDantic as a data type. It's good if anyone can convert `AttrList` to `list` easily.

Thanks,