### PR TITLE
Add 'include_type_name' to 6.x write endpoints to ease ES7 migration

### DIFF
--- a/elasticsearch_dsl/index.py
+++ b/elasticsearch_dsl/index.py
@@ -30,7 +30,7 @@ class IndexTemplate(object):
 
     def save(self, using=None):
         es = connections.get_connection(using or self._index._using)
-        es.indices.put_template(name=self._template_name, body=self.to_dict())
+        es.indices.put_template(name=self._template_name, body=self.to_dict(), params={'include_type_name': 'true'})
 
 class Index(object):
     def __init__(self, name, doc_type=DEFAULT_DOC_TYPE, using='default'):
@@ -275,6 +275,9 @@ class Index(object):
         Any additional keyword arguments will be passed to
         ``Elasticsearch.indices.create`` unchanged.
         """
+        if 'params' not in kwargs:
+            kwargs['params'] = {}
+        kwargs['params']['include_type_name'] = 'true'
         self._get_connection(using).indices.create(index=self._name, body=self.to_dict(), **kwargs)
 
     def is_closed(self, using=None):
@@ -420,6 +423,9 @@ class Index(object):
         Any additional keyword arguments will be passed to
         ``Elasticsearch.indices.put_mapping`` unchanged.
         """
+        if 'params' not in kwargs:
+            kwargs['params'] = {}
+        kwargs['params']['include_type_name'] = 'true'
         return self._get_connection(using).indices.put_mapping(index=self._name, **kwargs)
 
     def get_mapping(self, using=None, **kwargs):


### PR DESCRIPTION
Closing https://github.com/elastic/elasticsearch-dsl-py/issues/1381 with the workflow proposed by @sethmlarson and [official Elasticsearch doc](https://www.elastic.co/guide/en/elasticsearch/reference/6.8/removal-of-types.html#_schedule_for_removal_of_mapping_types).

This PR includes `include_type_name` GET parameter to the following calls in order to make Elasticsearch-DSL 6.x able to talk to an Elasticsearch 7 cluster:
- create index
- put mapping
- put template

It allows the following Elasticsearch 6 to 7 migration process from an initial state where codebase and elastic cluster are 6.x:
- upgrade Elasticsearch clusters to 7.x while keeping Elasticsearch-DSL 6.x
- update your codebase according to Elasticsearch-DSL 7.x internal API changes
- upgrade Elasticsearch-DSL to 7.x
- no need to reindex indices while Elasticsearch cluster < 8.0

I've signed the CLA as part as an @opendatasoft employee. I can send you a copy of the document if needed.