### PR TITLE
Fix backport.yml syntax

### DIFF
--- a/.github/workflows/backport.yml
+++ b/.github/workflows/backport.yml
@@ -11,6 +11,6 @@ jobs:
     name: Backport
     steps:
       - name: Backport
-        uses: tibdex/backport
+        uses: tibdex/backport@v2
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Add the GitHub Action's version to follow `owner/repo@ref` to fix:

```
Error: .github#L1
the `uses' attribute must be a path, a Docker image, or owner/repo@ref
```

https://github.com/elastic/elasticsearch-dsl-py/actions/runs/2414920012