### PR TITLE
docs: Fix a few typos

### DIFF
--- a/elasticsearch_dsl/query.py
+++ b/elasticsearch_dsl/query.py
@@ -309,7 +309,7 @@ class TopChildren(Query):
     _param_defs = {"query": {"type": "query"}}
 
 
-# compount span queries
+# compound span queries
 class SpanFirst(Query):
     name = "span_first"
     _param_defs = {"match": {"type": "query"}}

--- a/examples/async/completion.py
+++ b/examples/async/completion.py
@@ -54,7 +54,7 @@ class Person(AsyncDocument):
     name = Text(fields={"keyword": Keyword()})
     popularity = Long()
 
-    # copletion field with a custom analyzer
+    # completion field with a custom analyzer
     suggest = Completion(analyzer=ascii_fold)
 
     def clean(self):

--- a/examples/async/parent_child.py
+++ b/examples/async/parent_child.py
@@ -190,7 +190,7 @@ class Answer(Post):
 
     async def get_question(self):
         # cache question in self.meta
-        # any attributes set on self would be interpretted as fields
+        # any attributes set on self would be interpreted as fields
         if "question" not in self.meta:
             self.meta.question = await Question.get(
                 id=self.question_answer.parent, index=self.meta.index

--- a/examples/completion.py
+++ b/examples/completion.py
@@ -53,7 +53,7 @@ class Person(Document):
     name = Text(fields={"keyword": Keyword()})
     popularity = Long()
 
-    # copletion field with a custom analyzer
+    # completion field with a custom analyzer
     suggest = Completion(analyzer=ascii_fold)
 
     def clean(self):

--- a/examples/parent_child.py
+++ b/examples/parent_child.py
@@ -189,7 +189,7 @@ class Answer(Post):
 
     def get_question(self):
         # cache question in self.meta
-        # any attributes set on self would be interpretted as fields
+        # any attributes set on self would be interpreted as fields
         if "question" not in self.meta:
             self.meta.question = Question.get(
                 id=self.question_answer.parent, index=self.meta.index


### PR DESCRIPTION
There are small typos in:
- elasticsearch_dsl/query.py
- examples/completion.py
- examples/parent_child.py

Fixes:
- Should read `interpreted` rather than `interpretted`.
- Should read `completion` rather than `copletion`.
- Should read `compound` rather than `compount`.



Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md