### PR TITLE
Store index alias settings under alias name, not index

### DIFF
--- a/elasticsearch_dsl/index.py
+++ b/elasticsearch_dsl/index.py
@@ -504,9 +504,12 @@ class Index:
         Any additional keyword arguments will be passed to
         ``Elasticsearch.indices.get_settings`` unchanged.
         """
-        return self._get_connection(using).indices.get_settings(
+        settings = self._get_connection(using).indices.get_settings(
             index=self._name, **kwargs
         )
+        if self._name not in settings:
+            settings[self._name] = list(settings.values())[0]
+        return settings
 
     def put_settings(self, using=None, **kwargs):
         """


### PR DESCRIPTION
Requesting index alias settings returns INDEX name, not INDEX ALIAS name, but we still store them under index name.

This causes a problem - it is unsafe to access via`[self._name]`:
```
    FancyIndex.init()
  File "/Users/adm/.local/share/virtualenvs/monolith-TtpprQ5c/lib/python3.7/site-packages/elasticsearch_dsl/document.py", line 156, in init
    i.save(using=using)
  File "/Users/adm/.local/share/virtualenvs/monolith-TtpprQ5c/lib/python3.7/site-packages/elasticsearch_dsl/index.py", line 304, in save
    current_settings = self.get_settings(using=using)[self._name]["settings"][
KeyError: 'fancy_index_alias'
```

Index class:
```
class FancyIndex(Document):
    class Index:
        name = 'fancy_index_alias'
```

This PR aims to return the same index settings. but under the alias name.
For example, right now calling `self.get_settings()` for alias returns:
```
{'fancy_index': {'settings': {'index': {'routing': {'allocation': {'include': {'_tier_preference': 'data_content'}}}, 'number_of_shards': '1', 'provided_name': 'fancy_index', 'creation_date': '1660750277393', 'number_of_replicas': '1', 'uuid': 'lLCF2d8kQp61zJh3-hrR5g', 'version': {'created': '7100099'}}}}}
```
while with fix it woud return:
```
{'fancy_index': {'settings': {'index': {'routing': {'allocation': {'include': {'_tier_preference': 'data_content'}}}, 'number_of_shards': '1', 'provided_name': 'fancy_index', 'creation_date': '1660750277393', 'number_of_replicas': '1', 'uuid': 'lLCF2d8kQp61zJh3-hrR5g', 'version': {'created': '7100099'}}}}, 
'fancy_index_alias': {'settings': {'index': {'routing': {'allocation': {'include': {'_tier_preference': 'data_content'}}}, 'number_of_shards': '1', 'provided_name': 'fancy_index', 'creation_date': '1660750277393', 'number_of_replicas': '1', 'uuid': 'lLCF2d8kQp61zJh3-hrR5g', 'version': {'created': '7100099'}}}}}
```