### PR TITLE
Resolve _expand__to_dot default at runtime

### DIFF
--- a/elasticsearch_dsl/utils.py
+++ b/elasticsearch_dsl/utils.py
@@ -252,7 +252,9 @@ class DslBase(metaclass=DslMeta):
                 f"DSL class `{name}` does not exist in {cls._type_name}."
             )
 
-    def __init__(self, _expand__to_dot=EXPAND__TO_DOT, **params):
+    def __init__(self, _expand__to_dot=None, **params):
+        if _expand__to_dot is None:
+            _expand__to_dot = EXPAND__TO_DOT
         self._params = {}
         for pname, pvalue in params.items():
             if "__" in pname and _expand__to_dot:

--- a/tests/test_query.py
+++ b/tests/test_query.py
@@ -17,7 +17,7 @@
 
 from pytest import raises
 
-from elasticsearch_dsl import function, query
+from elasticsearch_dsl import function, query, utils
 
 
 def test_empty_Q_is_match_all():
@@ -581,3 +581,12 @@ def test_script_score():
     assert isinstance(q.query, query.MatchAll)
     assert q.script == {"source": "...", "params": {}}
     assert q.to_dict() == d
+
+
+def test_expand_double_underscore_to_dot_setting():
+    q = query.Term(comment__count=2)
+    assert q.to_dict() == {'term': {'comment.count': 2}}
+    utils.EXPAND__TO_DOT = False
+    q = query.Term(comment__count=2)
+    assert q.to_dict() == {'term': {'comment__count': 2}}
+    utils.EXPAND__TO_DOT = True

--- a/tests/test_query.py
+++ b/tests/test_query.py
@@ -585,8 +585,8 @@ def test_script_score():
 
 def test_expand_double_underscore_to_dot_setting():
     q = query.Term(comment__count=2)
-    assert q.to_dict() == {'term': {'comment.count': 2}}
+    assert q.to_dict() == {"term": {"comment.count": 2}}
     utils.EXPAND__TO_DOT = False
     q = query.Term(comment__count=2)
-    assert q.to_dict() == {'term': {'comment__count': 2}}
+    assert q.to_dict() == {"term": {"comment__count": 2}}
     utils.EXPAND__TO_DOT = True


### PR DESCRIPTION
In the current situation, the default value of _expand__to_dot is bound to True when the module is imported. 
Changing the EXPAND__TO_DOT has no impact on the default behavior.

This change would allow the user to set EXPAND__TO_DOT to False as a global default.

Closes #1633 