### PR TITLE
Updated metadata to use group email address

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -50,10 +50,8 @@ setup(
     long_description=long_description,
     long_description_content_type="text/x-rst",
     version=__versionstr__,
-    author="Honza Král",
-    author_email="honza.kral@gmail.com",
-    maintainer="Seth Michael Larson",
-    maintainer_email="seth.larson@elastic.co",
+    author="Elastic Client Library Maintainers",
+    author_email="client-libs@elastic.co",
     packages=find_packages(where=".", exclude=("tests*",)),
     python_requires=">=3.6",
     classifiers=[


### PR DESCRIPTION
This PR removes individual names and email addresses and replaces those with the new (external) [group email address](mailto:client-libs@elastic.co).

The author and maintainer fields have also been collapsed down into just author. According to [setuptools](https://setuptools.pypa.io/en/latest/references/keywords.html), the maintainer is used as an override for author, so the former is removed to use only the primary field.