### PR TITLE
Drop support for Python 3.6

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -61,7 +61,6 @@ jobs:
       fail-fast: false
       matrix:
         python-version: [
-          "3.6",
           "3.7",
           "3.8",
           "3.9",

--- a/elasticsearch_dsl/index.py
+++ b/elasticsearch_dsl/index.py
@@ -50,7 +50,6 @@ class IndexTemplate:
         return d
 
     def save(self, using=None):
-
         es = get_connection(using or self._index._using)
         return es.indices.put_template(name=self._template_name, body=self.to_dict())
 

--- a/elasticsearch_dsl/update_by_query.py
+++ b/elasticsearch_dsl/update_by_query.py
@@ -23,7 +23,6 @@ from .utils import recursive_to_dict
 
 
 class UpdateByQuery(Request):
-
     query = ProxyDescriptor("query")
 
     def __init__(self, **kwargs):

--- a/noxfile.py
+++ b/noxfile.py
@@ -30,7 +30,6 @@ SOURCE_FILES = (
 
 @nox.session(
     python=[
-        "3.6",
         "3.7",
         "3.8",
         "3.9",
@@ -55,8 +54,8 @@ def test(session):
 
 @nox.session()
 def format(session):
-    session.install("black==21.12b0", "click==8.0.4", "isort")
-    session.run("black", "--target-version=py36", *SOURCE_FILES)
+    session.install("black~=23.0", "isort")
+    session.run("black", "--target-version=py37", *SOURCE_FILES)
     session.run("isort", *SOURCE_FILES)
     session.run("python", "utils/license-headers.py", "fix", *SOURCE_FILES)
 
@@ -65,8 +64,8 @@ def format(session):
 
 @nox.session
 def lint(session):
-    session.install("flake8", "black==21.12b0", "click==8.0.4", "isort")
-    session.run("black", "--check", "--target-version=py36", *SOURCE_FILES)
+    session.install("flake8", "black~=23.0", "isort")
+    session.run("black", "--check", "--target-version=py37", *SOURCE_FILES)
     session.run("isort", "--check", *SOURCE_FILES)
     session.run("flake8", "--ignore=E501,E741,W503", *SOURCE_FILES)
     session.run("python", "utils/license-headers.py", "check", *SOURCE_FILES)

--- a/setup.py
+++ b/setup.py
@@ -53,7 +53,7 @@ setup(
     author="Elastic Client Library Maintainers",
     author_email="client-libs@elastic.co",
     packages=find_packages(where=".", exclude=("tests*",)),
-    python_requires=">=3.6",
+    python_requires=">=3.7",
     classifiers=[
         "Development Status :: 4 - Beta",
         "License :: OSI Approved :: Apache Software License",
@@ -62,7 +62,6 @@ setup(
         "Programming Language :: Python",
         "Programming Language :: Python :: 3",
         "Programming Language :: Python :: 3 :: Only",
-        "Programming Language :: Python :: 3.6",
         "Programming Language :: Python :: 3.7",
         "Programming Language :: Python :: 3.8",
         "Programming Language :: Python :: 3.9",


### PR DESCRIPTION
It has reached EOL in December 2021 and breaks CI because GitHub Actions no longer provides this version. This was also the opportunity to bump Black: we were using an old version that still supported formatting Python 2.7 code.