### PR TITLE
Run integration tests in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -92,3 +92,5 @@ jobs:
       - name: Run Tests
         run: |
           nox -rs test-${{ matrix.python-version }}
+        env:
+          WAIT_FOR_ES: "1"

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -45,7 +45,7 @@ else:
     ELASTICSEARCH_URL = "https://elastic:changeme@localhost:9200"
 
 
-def get_test_client(nowait=False, **kwargs):
+def get_test_client(wait=True, **kwargs):
     # construct kwargs from the environment
     kw = {"timeout": 30}
 
@@ -60,7 +60,7 @@ def get_test_client(nowait=False, **kwargs):
     client = Elasticsearch(ELASTICSEARCH_URL, **kw)
 
     # wait for yellow status
-    for _ in range(1 if nowait else 100):
+    for _ in range(100 if wait else 1):
         try:
             client.cluster.health(wait_for_status="yellow")
             return client
@@ -110,7 +110,7 @@ def _get_version(version_string):
 @fixture(scope="session")
 def client():
     try:
-        connection = get_test_client(nowait="WAIT_FOR_ES" not in os.environ)
+        connection = get_test_client(wait="WAIT_FOR_ES" in os.environ)
         add_connection("default", connection)
         return connection
     except SkipTest:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -42,7 +42,7 @@ from .test_integration.test_document import Comment, History, PullRequest, User
 if "ELASTICSEARCH_URL" in os.environ:
     ELASTICSEARCH_URL = os.environ["ELASTICSEARCH_URL"]
 else:
-    ELASTICSEARCH_URL = "https://elastic:changeme@localhost:9200"
+    ELASTICSEARCH_URL = "http://localhost:9200"
 
 
 def get_test_client(wait=True, **kwargs):

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -60,15 +60,16 @@ def get_test_client(wait=True, **kwargs):
     client = Elasticsearch(ELASTICSEARCH_URL, **kw)
 
     # wait for yellow status
-    for _ in range(100 if wait else 1):
+    for tries_left in range(100 if wait else 1, 0, -1):
         try:
             client.cluster.health(wait_for_status="yellow")
             return client
         except ConnectionError:
+            if wait and tries_left == 1:
+                raise
             time.sleep(0.1)
-    else:
-        # timeout
-        raise SkipTest("Elasticsearch failed to start.")
+
+    raise SkipTest("Elasticsearch failed to start.")
 
 
 class ElasticsearchTestCase(TestCase):


### PR DESCRIPTION
Integration tests were skipped in CI because `WAIT_FOR_ES` was forgotten in the move from Travis to GitHub Actions. While I was here, I introduced a few changes, one per commit:

 * Inline `elasticsearch.helpers.tests` since it was removed from elasticsearch-py 8.x and certificates are not needed here. (But this will be ultimately removed in favor of more pytest-native code, like elasticsearch-py did.)
 * Rename `nowait` to `wait` because I find parameters with a negative name very confusing (we had `nowait=False` and `nowait="WAIT_FOR_ES" not in os.environ`!).
 * Fail the test and report the exception when `WAIT_FOR_ES` is set but the connection fails.
 * Enable integration tests in CI.