### PR TITLE
Fix deprecation warnings

### DIFF
--- a/elasticsearch_dsl/document.py
+++ b/elasticsearch_dsl/document.py
@@ -244,7 +244,7 @@ class Document(ObjectBase, metaclass=IndexMeta):
                 for doc in docs
             ]
         }
-        results = es.mget(body, index=cls._default_index(index), **kwargs)
+        results = es.mget(index=cls._default_index(index), body=body, **kwargs)
 
         objs, error_docs, missing_docs = [], [], []
         for doc in results["docs"]:

--- a/setup.cfg
+++ b/setup.cfg
@@ -5,3 +5,13 @@ all_files = 1
 
 [isort]
 profile = black
+
+[tool:pytest]
+filterwarnings =
+    error
+    # The body parameter is no longer deprecated, see
+    # https://github.com/elastic/elasticsearch-py/issues/2181#issuecomment-1490932964
+    ignore:The 'body' parameter is deprecated .*:DeprecationWarning
+    # calendar_interval was only added in Elasticsearch 7.2 and we still support Elasticsearch 7.0
+    # using `default` instead of `ignore` to show it in the output as a reminder to remove it for Elasticsearch 8
+    default:\[interval\] on \[date_histogram\] is deprecated, use \[fixed_interval\] or \[calendar_interval\] in the future.:elasticsearch.exceptions.ElasticsearchWarning

--- a/setup.py
+++ b/setup.py
@@ -33,11 +33,11 @@ install_requires = [
 ]
 
 develop_requires = [
-    "pytest>=3.0.0",
+    "pytest",
     "pytest-cov",
-    "pytest-mock<3.0.0",
+    "pytest-mock",
     "pytz",
-    "coverage<5.0.0",
+    "coverage",
     "sphinx",
     "sphinx_rtd_theme",
 ]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -131,8 +131,8 @@ def es_version(client):
 @fixture
 def write_client(client):
     yield client
-    client.indices.delete("test-*", ignore=404)
-    client.indices.delete_template("test-template", ignore=404)
+    client.indices.delete(index="test-*", ignore=404)
+    client.indices.delete_template(name="test-template", ignore=404)
 
 
 @fixture
@@ -154,8 +154,8 @@ def data_client(client):
     bulk(client, DATA, raise_on_error=True, refresh=True)
     bulk(client, FLAT_DATA, raise_on_error=True, refresh=True)
     yield client
-    client.indices.delete("git")
-    client.indices.delete("flat-git")
+    client.indices.delete(index="git")
+    client.indices.delete(index="flat-git")
 
 
 @fixture

--- a/tests/test_integration/test_examples/test_alias_migration.py
+++ b/tests/test_integration/test_examples/test_alias_migration.py
@@ -33,13 +33,14 @@ def test_alias_migration(write_client):
     index_name, _ = indices.popitem()
 
     # which means we can now save a document
-    bp = BlogPost(
-        _id=0,
-        title="Hello World!",
-        tags=["testing", "dummy"],
-        content=open(__file__).read(),
-    )
-    bp.save(refresh=True)
+    with open(__file__) as f:
+        bp = BlogPost(
+            _id=0,
+            title="Hello World!",
+            tags=["testing", "dummy"],
+            content=f.read(),
+        )
+        bp.save(refresh=True)
 
     assert BlogPost.search().count() == 1
 


### PR DESCRIPTION
In preparation for `elasticsearch-py` 8.x support, I've looked at deprecation warnings emitted when running the test suite and fixed them, [following the official recommendation](https://github.com/elastic/elasticsearch-py/issues/1698).

The way [filterwarnings](https://docs.python.org/3/library/warnings.html#warning-filter) work is that by default we raise an exception instead of a warning (this is what `error` does), but then we also add special cases, currently two of them.

I also removed the pins on `pytest-mock` and `coverage`: they were only needed to support Python 2.7 and produced deprecation warnings themselves. The benefit is that the test suite will break if a new deprecation warning is introduced. If this causes too much noise, we can always adjust our strategy later.