### PR TITLE
Release 8.9.0a1

### DIFF
--- a/Changelog.rst
+++ b/Changelog.rst
@@ -7,10 +7,10 @@ Changelog
 --------------------
 
 * Added Elasticsearch 8.x support (`#1664`_)
-* Dropped support for Python 2.7 and 3.5 (`#1606`_), contributed by `@hugovk`_
-* Added support for Python 3.10 and 3.11 (`#1608`_), contributed by `@hugovk`_
-* Added the ``MultiTerms`` aggregation (`#1543`_), contributed by `@Telomeraz`_
-* Added the ``CombinedFields`` query (`#1557`_), contributed by `@Telomeraz`_
+* Dropped support for Python 2.7 and 3.5 (`#1606`_, contributed by `@hugovk`_)
+* Added support for Python 3.10 and 3.11 (`#1608`_, contributed by `@hugovk`_)
+* Added the ``MultiTerms`` aggregation (`#1543`_, contributed by `@Telomeraz`_)
+* Added the ``CombinedFields`` query (`#1557`_, contributed by `@Telomeraz`_)
 
 .. _@Telomeraz: https://github.com/Telomeraz
 .. _@hugovk: https://github.com/hugovk

--- a/Changelog.rst
+++ b/Changelog.rst
@@ -3,6 +3,24 @@
 Changelog
 =========
 
+8.9.0a1 (2023-08-29)
+--------------------
+
+* Added Elasticsearch 8.x support (`#1664`_)
+* Dropped support for Python 2.7 and 3.5 (`#1606`_), contributed by `@hugovk`_
+* Added support for Python 3.10 and 3.11 (`#1608`_), contributed by `@hugovk`_
+* Added the ``MultiTerms`` aggregation (`#1543`_), contributed by `@Telomeraz`_
+* Added the ``CombinedFields`` query (`#1557`_), contributed by `@Telomeraz`_
+
+.. _@Telomeraz: https://github.com/Telomeraz
+.. _@hugovk: https://github.com/hugovk
+.. _#1664: https://github.com/elastic/elasticsearch-dsl-py/pull/1664
+.. _#1606: https://github.com/elastic/elasticsearch-dsl-py/pull/1606
+.. _#1608: https://github.com/elastic/elasticsearch-dsl-py/pull/1608
+.. _#1543: https://github.com/elastic/elasticsearch-dsl-py/pull/1543
+.. _#1557: https://github.com/elastic/elasticsearch-dsl-py/pull/1557
+
+
 7.4.1 (2023-03-01)
 ------------------
 

--- a/elasticsearch_dsl/__init__.py
+++ b/elasticsearch_dsl/__init__.py
@@ -84,7 +84,7 @@ from .update_by_query import UpdateByQuery
 from .utils import AttrDict, AttrList, DslBase
 from .wrappers import Range
 
-VERSION = (8, 0, 0)
+VERSION = (8, 9, 0, "a1")
 __version__ = VERSION
 __versionstr__ = ".".join(map(str, VERSION))
 __all__ = [

--- a/setup.py
+++ b/setup.py
@@ -19,7 +19,7 @@ from os.path import dirname, join
 
 from setuptools import find_packages, setup
 
-VERSION = (8, 0, 0)
+VERSION = (8, 9, 0, "a1")
 __version__ = VERSION
 __versionstr__ = ".".join(map(str, VERSION))
 


### PR DESCRIPTION
This is a pre-release to get initial feedback for the recently added Elasticsearch 8.x support.

Using a pull request allows reviewing the changes going in the release (here is the [rendered changelog](https://github.com/pquentin/elasticsearch-dsl-py/blob/release-8.9.0a1/Changelog.rst)). Note that it is targeting the newly added 8.x branch. If approved, I plan to squash merge without the pull request number, and release from the resulting commit. I will then port the changelog to the `main` branch.