### PR TITLE
Fix Read the Docs build

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -1,0 +1,16 @@
+version: 2
+
+build:
+  os: ubuntu-22.04
+  tools:
+    python: "3"
+
+python:
+  install:
+    - method: pip
+      path: .
+      extra_requirements:
+        - develop
+
+sphinx:
+  fail_on_warning: true

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -28,7 +28,8 @@
 # serve to show the default.
 
 import datetime
-import os
+
+import sphinx_rtd_theme
 
 import elasticsearch_dsl
 
@@ -115,8 +116,6 @@ pygments_style = "sphinx"
 
 # The theme to use for HTML and HTML Help pages.  See the documentation for
 # a list of builtin themes.
-
-import sphinx_rtd_theme
 
 html_theme = "sphinx_rtd_theme"
 html_theme_path = [sphinx_rtd_theme.get_html_theme_path()]

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -116,13 +116,10 @@ pygments_style = "sphinx"
 # The theme to use for HTML and HTML Help pages.  See the documentation for
 # a list of builtin themes.
 
-on_rtd = os.environ.get("READTHEDOCS", None) == "True"
+import sphinx_rtd_theme
 
-if not on_rtd:  # only import and set the theme if we're building docs locally
-    import sphinx_rtd_theme
-
-    html_theme = "sphinx_rtd_theme"
-    html_theme_path = [sphinx_rtd_theme.get_html_theme_path()]
+html_theme = "sphinx_rtd_theme"
+html_theme_path = [sphinx_rtd_theme.get_html_theme_path()]
 
 # Theme options are theme-specific and customize the look and feel of a theme
 # further.  For a list of options available for each theme, see the

--- a/noxfile.py
+++ b/noxfile.py
@@ -73,6 +73,6 @@ def lint(session):
 
 @nox.session()
 def docs(session):
-    session.install(".[develop]", "sphinx-rtd-theme")
+    session.install(".[develop]")
 
-    session.run("sphinx-build", "docs/", "docs/_build", "-b", "html")
+    session.run("sphinx-build", "docs/", "docs/_build", "-b", "html", "-W")

--- a/setup.py
+++ b/setup.py
@@ -38,8 +38,9 @@ develop_requires = [
     "pytest-mock",
     "pytz",
     "coverage",
-    "sphinx",
-    "sphinx_rtd_theme",
+    # Override Read the Docs default (sphinx<2 and sphinx-rtd-theme<0.5)
+    "sphinx>2",
+    "sphinx-rtd-theme>0.5",
 ]
 
 setup(


### PR DESCRIPTION
The .readthedocs.yaml file is now required: https://blog.readthedocs.com/migrate-configuration-v2/

I faced two main issues here:
 * Our config file was not asking for sphinx-rtd-theme on Read the Docs, which was useful long ago but prevented the theme to be used today. This is why https://elasticsearch-dsl.readthedocs.io/en/latest/ shows the default theme instead (alabaster).
 * By default, Read the Docs installs old versions of sphinx and sphinx-rtd-theme, so I had to put lower bounds to avoid that.