### PR TITLE
Update docs before 8.9.0 release

### DIFF
--- a/README
+++ b/README
@@ -37,6 +37,9 @@ Compatibility
 The library is compatible with all Elasticsearch versions since ``2.x`` but you
 **have to use a matching major version**:
 
+For **Elasticsearch 8.0** and later, use the major version 8 (``8.x.y``) of the
+library.
+
 For **Elasticsearch 7.0** and later, use the major version 7 (``7.x.y``) of the
 library.
 
@@ -49,9 +52,11 @@ library.
 For **Elasticsearch 2.0** and later, use the major version 2 (``2.x.y``) of the
 library.
 
-
 The recommended way to set your requirements in your `setup.py` or
 `requirements.txt` is::
+
+    # Elasticsearch 8.x
+    elasticsearch-dsl>=8.0.0,<9.0.0
 
     # Elasticsearch 7.x
     elasticsearch-dsl>=7.0.0,<8.0.0
@@ -66,7 +71,7 @@ The recommended way to set your requirements in your `setup.py` or
     elasticsearch-dsl>=2.0.0,<3.0.0
 
 
-The development is happening on ``master``, older branches only get bugfix releases
+The development is happening on ``main``, older branches only get bugfix releases
 
 Search Example
 --------------
@@ -76,7 +81,7 @@ Let's have a typical search request written directly as a ``dict``:
 .. code:: python
 
     from elasticsearch import Elasticsearch
-    client = Elasticsearch()
+    client = Elasticsearch("https://localhost:9200")
 
     response = client.search(
         index="my-index",
@@ -118,7 +123,7 @@ Let's rewrite the example using the Python DSL:
     from elasticsearch import Elasticsearch
     from elasticsearch_dsl import Search
 
-    client = Elasticsearch()
+    client = Elasticsearch("https://localhost:9200")
 
     s = Search(using=client, index="my-index") \
         .filter("term", category="search") \
@@ -138,15 +143,11 @@ Let's rewrite the example using the Python DSL:
 
 As you see, the library took care of:
 
-  * creating appropriate ``Query`` objects by name (eq. "match")
-
-  * composing queries into a compound ``bool`` query
-
-  * putting the ``term`` query in a filter context of the ``bool`` query
-
-  * providing a convenient access to response data
-
-  * no curly or square brackets everywhere
+- creating appropriate ``Query`` objects by name (eq. "match")
+- composing queries into a compound ``bool`` query
+- putting the ``term`` query in a filter context of the ``bool`` query
+- providing a convenient access to response data
+- no curly or square brackets everywhere
 
 
 Persistence Example
@@ -160,7 +161,7 @@ Let's have a simple Python class representing an article in a blogging system:
     from elasticsearch_dsl import Document, Date, Integer, Keyword, Text, connections
 
     # Define a default Elasticsearch client
-    connections.create_connection(hosts=['localhost'])
+    connections.create_connection(hosts="https://localhost:9200")
 
     class Article(Document):
         title = Text(analyzer='snowball', fields={'raw': Keyword()})
@@ -200,20 +201,14 @@ Let's have a simple Python class representing an article in a blogging system:
 
 In this example you can see:
 
-  * providing a default connection
-
-  * defining fields with mapping configuration
-
-  * setting index name
-
-  * defining custom methods
-
-  * overriding the built-in ``.save()`` method to hook into the persistence
-    life cycle
-
-  * retrieving and saving the object into Elasticsearch
-
-  * accessing the underlying client for other APIs
+- providing a default connection
+- defining fields with mapping configuration
+- setting index name
+- defining custom methods
+- overriding the built-in ``.save()`` method to hook into the persistence
+  life cycle
+- retrieving and saving the object into Elasticsearch
+- accessing the underlying client for other APIs
 
 You can see more in the persistence chapter of the documentation.
 


### PR DESCRIPTION
* Update README to mention Elasticsearch 8 (and use a full host for compatibility with elasticsearch-py 8.x)
* Switch to a way of writing bullet lists that GitHub formats correctly
* Synchronize README.rst with docs/index.rst.