### PR TITLE
Fix missing jQuery in docs

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -29,8 +29,6 @@
 
 import datetime
 
-import sphinx_rtd_theme
-
 import elasticsearch_dsl
 
 # If extensions (or modules to document with autodoc) are in another directory,
@@ -118,7 +116,6 @@ pygments_style = "sphinx"
 # a list of builtin themes.
 
 html_theme = "sphinx_rtd_theme"
-html_theme_path = [sphinx_rtd_theme.get_html_theme_path()]
 
 # Theme options are theme-specific and customize the look and feel of a theme
 # further.  For a list of options available for each theme, see the


### PR DESCRIPTION
This is currently breaking search and moving between versions.