### PR TITLE
Fix backport GitHub Action for forks

### DIFF
--- a/.github/workflows/backport.yml
+++ b/.github/workflows/backport.yml
@@ -1,16 +1,26 @@
 name: Backport
 on:
-  pull_request:
+  pull_request_target:
     types:
       - closed
       - labeled
 
 jobs:
   backport:
-    runs-on: ubuntu-latest
     name: Backport
+    runs-on: ubuntu-latest
+    # Only react to merged PRs for security reasons.
+    # See https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#pull_request_target.
+    if: >
+      github.event.pull_request.merged
+      && (
+        github.event.action == 'closed'
+        || (
+          github.event.action == 'labeled'
+          && contains(github.event.label.name, 'backport')
+        )
+      )
     steps:
-      - name: Backport
-        uses: tibdex/backport@v2
+      - uses: tibdex/backport@9565281eda0731b1d20c4025c43339fb0a23812e # v2.0.4
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Due to the way GitHub Actions works, there is no way to backport pull request from forks using the `pull_request` workflow trigger as it won't have write permissions on the repository. The fix is to use [`pull_request_target`](https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#pull_request_target). It is [much more dangerous](https://securitylab.github.com/research/github-actions-preventing-pwn-requests/), but is safe if those conditions are met:

 * The code in the pull request can be trusted (it is, since we have merged it)
 * The GitHub Action can be trusted (it is, I have audited it and pinned to a specific hash)

Does my analysis make sense?