### PR TITLE
Fix importing collapse from dict

### DIFF
--- a/elasticsearch_dsl/search.py
+++ b/elasticsearch_dsl/search.py
@@ -120,7 +120,6 @@ class Request:
 
         self._doc_type = []
         self._doc_type_map = {}
-        self._collapse = {}
         if isinstance(doc_type, (tuple, list)):
             self._doc_type.extend(doc_type)
         elif isinstance(doc_type, collections.abc.Mapping):
@@ -294,7 +293,6 @@ class Request:
         s = self.__class__(
             using=self._using, index=self._index, doc_type=self._doc_type
         )
-        s._collapse = self._collapse.copy()
         s._doc_type_map = self._doc_type_map.copy()
         s._extra = self._extra.copy()
         s._params = self._params.copy()
@@ -408,6 +406,7 @@ class Search(Request):
         s = super()._clone()
 
         s._response_class = self._response_class
+        s._collapse = self._collapse.copy()
         s._sort = self._sort[:]
         s._source = copy.copy(self._source) if self._source is not None else None
         s._highlight = self._highlight.copy()
@@ -446,6 +445,8 @@ class Search(Request):
             self.aggs._params = {
                 "aggs": {name: A(value) for (name, value) in aggs.items()}
             }
+        if "collapse" in d:
+            self._collapse = d.pop("collapse")
         if "sort" in d:
             self._sort = d.pop("sort")
         if "_source" in d:

--- a/tests/test_search.py
+++ b/tests/test_search.py
@@ -544,10 +544,12 @@ def test_update_from_dict():
     s = search.Search()
     s.update_from_dict({"indices_boost": [{"important-documents": 2}]})
     s.update_from_dict({"_source": ["id", "name"]})
+    s.update_from_dict({"collapse": {"field": "user_id"}})
 
     assert {
         "indices_boost": [{"important-documents": 2}],
         "_source": ["id", "name"],
+        "collapse": {"field": "user_id"},
     } == s.to_dict()
 
 


### PR DESCRIPTION
Two minor bugs in the `collapse` implementation:

- The cloning of the `collapse` key was in `Request` instead of `Search`
- The `collapse` key was not importing from dict