### PR TITLE
Add ``rank`` option to ``elasticsearch_dsl.search.Search``

### DIFF
--- a/tests/test_search.py
+++ b/tests/test_search.py
@@ -288,6 +288,18 @@ def test_knn():
     } == s.to_dict()
 
 
+def test_rank():
+    s = search.Search()
+    s.rank(rrf=False)
+    assert {} == s.to_dict()
+
+    s = s.rank(rrf=True)
+    assert {"rank": {"rrf": {}}} == s.to_dict()
+
+    s = s.rank(rrf={"window_size": 50, "rank_constant": 20})
+    assert {"rank": {"rrf": {"window_size": 50, "rank_constant": 20}}} == s.to_dict()
+
+
 def test_sort():
     s = search.Search()
     s = s.sort("fielda", "-fieldb")


### PR DESCRIPTION
This PR adds the `rank` option, to enable the use of the RRF algorithm to combine multiple sets of search results. Not sure if we want this published, given that `rank` is in technical preview at this point, but since I have implemented it for my own use I'm sharing the changes here.