### PR TITLE
Stop mixing body and parameters in UpdateByQuery

### DIFF
--- a/elasticsearch_dsl/update_by_query.py
+++ b/elasticsearch_dsl/update_by_query.py
@@ -154,6 +154,6 @@ class UpdateByQuery(Request):
 
         self._response = self._response_class(
             self,
-            es.update_by_query(index=self._index, body=self.to_dict(), **self._params),
+            es.update_by_query(index=self._index, **self.to_dict(), **self._params),
         )
         return self._response

--- a/tests/test_update_by_query.py
+++ b/tests/test_update_by_query.py
@@ -141,9 +141,7 @@ def test_params_being_passed_to_search(mock_client):
     ubq = ubq.params(routing="42")
     ubq.execute()
 
-    mock_client.update_by_query.assert_called_once_with(
-        index=None, body={}, routing="42"
-    )
+    mock_client.update_by_query.assert_called_once_with(index=None, routing="42")
 
 
 def test_overwrite_script():


### PR DESCRIPTION
Since https://github.com/elastic/elasticsearch-py/pull/2383, passing body parameters as part of `body` *and* parameters  is deprecated. Well, it actually outright fails right now, so this commit fixes CI. (And when https://github.com/elastic/elasticsearch-py/issues/2425 will be fixed, it will correctly warn instead.)