### PR TITLE
Stop ignoring body warnings in test suite

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -9,8 +9,5 @@ profile = black
 [tool:pytest]
 filterwarnings =
     error
-    # The body parameter is no longer deprecated, see
-    # https://github.com/elastic/elasticsearch-py/issues/2181#issuecomment-1490932964
-    ignore:The 'body' parameter is deprecated .*:DeprecationWarning
     ignore:Legacy index templates are deprecated in favor of composable templates.:elasticsearch.exceptions.ElasticsearchWarning
     ignore:datetime.datetime.utcfromtimestamp\(\) is deprecated and scheduled for removal in a future version..*:DeprecationWarning


### PR DESCRIPTION
The test suite now works without triggering those warnings.