### PR TITLE
Remove support for Python 3.7

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -61,7 +61,6 @@ jobs:
       fail-fast: false
       matrix:
         python-version: [
-          "3.7",
           "3.8",
           "3.9",
           "3.10",

--- a/noxfile.py
+++ b/noxfile.py
@@ -30,7 +30,6 @@ SOURCE_FILES = (
 
 @nox.session(
     python=[
-        "3.7",
         "3.8",
         "3.9",
         "3.10",
@@ -56,7 +55,7 @@ def test(session):
 @nox.session(python="3.12")
 def format(session):
     session.install("black~=24.0", "isort")
-    session.run("black", "--target-version=py37", *SOURCE_FILES)
+    session.run("black", "--target-version=py38", *SOURCE_FILES)
     session.run("isort", *SOURCE_FILES)
     session.run("python", "utils/license-headers.py", "fix", *SOURCE_FILES)
 
@@ -66,7 +65,7 @@ def format(session):
 @nox.session(python="3.12")
 def lint(session):
     session.install("flake8", "black~=24.0", "isort")
-    session.run("black", "--check", "--target-version=py37", *SOURCE_FILES)
+    session.run("black", "--check", "--target-version=py38", *SOURCE_FILES)
     session.run("isort", "--check", *SOURCE_FILES)
     session.run("flake8", "--ignore=E501,E741,W503", *SOURCE_FILES)
     session.run("python", "utils/license-headers.py", "check", *SOURCE_FILES)

--- a/setup.py
+++ b/setup.py
@@ -54,7 +54,7 @@ setup(
     author="Elastic Client Library Maintainers",
     author_email="client-libs@elastic.co",
     packages=find_packages(where=".", exclude=("tests*",)),
-    python_requires=">=3.7",
+    python_requires=">=3.8",
     classifiers=[
         "Development Status :: 4 - Beta",
         "License :: OSI Approved :: Apache Software License",
@@ -63,7 +63,6 @@ setup(
         "Programming Language :: Python",
         "Programming Language :: Python :: 3",
         "Programming Language :: Python :: 3 :: Only",
-        "Programming Language :: Python :: 3.7",
         "Programming Language :: Python :: 3.8",
         "Programming Language :: Python :: 3.9",
         "Programming Language :: Python :: 3.10",

--- a/utils/build-dists.py
+++ b/utils/build-dists.py
@@ -47,7 +47,7 @@ def run(*argv, expect_exit_code=0):
     else:
         os.chdir(tmp_dir)
 
-    cmd = " ".join(shlex.quote(x) for x in argv)
+    cmd = shlex.join(argv)
     print("$ " + cmd)
     exit_code = os.system(cmd)
     if exit_code != expect_exit_code:


### PR DESCRIPTION
As discussed, we are removing Python 3.7 from the actively supported versions.