### PR TITLE
Documentation fixes

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -9,22 +9,28 @@ The :ref:`Asynchronous API <async_api>` classes are documented separately.
 .. py:module:: elasticsearch_dsl
 
 .. autoclass:: Search
+   :inherited-members:
    :members:
 
 .. autoclass:: MultiSearch
+   :inherited-members:
    :members:
 
 .. autoclass:: Document
+   :inherited-members:
    :members:
 
 .. autoclass:: Index
+   :inherited-members:
    :members:
 
 .. autoclass:: FacetedSearch
+   :inherited-members:
    :members:
 
 .. autoclass:: UpdateByQuery
-  :members:
+   :inherited-members:
+   :members:
 
 Mappings
 --------

--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -45,7 +45,7 @@ to the ``Elasticsearch`` class from ``elasticsearch-py``.
 
 To see all
 possible configuration options refer to the `documentation
-<http://elasticsearch-py.readthedocs.io/en/master/api.html#elasticsearch>`_.
+<https://elasticsearch-py.readthedocs.io/en/latest/api/elasticsearch.html>`_.
 
 Multiple clusters
 -----------------

--- a/elasticsearch_dsl/_async/document.py
+++ b/elasticsearch_dsl/_async/document.py
@@ -255,7 +255,7 @@ class AsyncDocument(DocumentBase, metaclass=AsyncIndexMeta):
         :arg return_doc_meta: set to ``True`` to return all metadata from the
             index API call instead of only the operation result
 
-        :return operation result noop/updated
+        :return: operation result noop/updated
         """
         body = {
             "doc_as_upsert": doc_as_upsert,
@@ -346,7 +346,7 @@ class AsyncDocument(DocumentBase, metaclass=AsyncIndexMeta):
         Any additional keyword arguments will be passed to
         ``Elasticsearch.index`` unchanged.
 
-        :return operation result created/updated
+        :return: operation result created/updated
         """
         if validate:
             self.full_clean()

--- a/elasticsearch_dsl/_sync/document.py
+++ b/elasticsearch_dsl/_sync/document.py
@@ -253,7 +253,7 @@ class Document(DocumentBase, metaclass=IndexMeta):
         :arg return_doc_meta: set to ``True`` to return all metadata from the
             index API call instead of only the operation result
 
-        :return operation result noop/updated
+        :return: operation result noop/updated
         """
         body = {
             "doc_as_upsert": doc_as_upsert,
@@ -344,7 +344,7 @@ class Document(DocumentBase, metaclass=IndexMeta):
         Any additional keyword arguments will be passed to
         ``Elasticsearch.index`` unchanged.
 
-        :return operation result created/updated
+        :return: operation result created/updated
         """
         if validate:
             self.full_clean()

--- a/elasticsearch_dsl/search_base.py
+++ b/elasticsearch_dsl/search_base.py
@@ -143,7 +143,7 @@ class Request:
         """
         Specify query params to be used when executing the search. All the
         keyword arguments will override the current values. See
-        https://elasticsearch-py.readthedocs.io/en/master/api.html#elasticsearch.Elasticsearch.search
+        https://elasticsearch-py.readthedocs.io/en/latest/api/elasticsearch.html#elasticsearch.Elasticsearch.search
         for all available parameters.
 
         Example::


### PR DESCRIPTION
I noticed a few minor issues:
- A couple of broken links to low-level client's documentation pages
- Missing inherited members in API reference pages (regression introduced with 8.13, it was fine in <=8.12)
- A few Sphinx docstring fixes