### PR TITLE
Warn when slicing twice

### DIFF
--- a/elasticsearch_dsl/search_base.py
+++ b/elasticsearch_dsl/search_base.py
@@ -17,6 +17,7 @@
 
 import collections.abc
 import copy
+import warnings
 
 from .aggs import A, AggBase
 from .exceptions import IllegalOperation
@@ -347,6 +348,15 @@ class SearchBase(Request):
 
         """
         s = self._clone()
+
+        if "from" in s._extra or "size" in s._extra:
+            warnings.warn(
+                "Slicing multiple times currently has no effect but will be supported "
+                "in a future release. See https://github.com/elastic/elasticsearch-dsl-py/pull/1771 "
+                "for more details",
+                DeprecationWarning,
+                stacklevel=2,
+            )
 
         if isinstance(n, slice):
             # If negative slicing, abort.

--- a/tests/_async/test_search.py
+++ b/tests/_async/test_search.py
@@ -17,7 +17,7 @@
 
 from copy import deepcopy
 
-from pytest import raises
+from pytest import raises, warns
 
 from elasticsearch_dsl import AsyncSearch, Document, Q, query
 from elasticsearch_dsl.exceptions import IllegalOperation
@@ -361,6 +361,12 @@ def test_slice():
     assert {"from": 3, "size": 10} == s[3:].to_dict()
     assert {"from": 0, "size": 0} == s[0:0].to_dict()
     assert {"from": 20, "size": 0} == s[20:0].to_dict()
+
+
+def test_slice_twice():
+    with warns(DeprecationWarning, match="Slicing multiple times .*"):
+        s = AsyncSearch()
+        s[10:20][2:]
 
 
 def test_index():

--- a/tests/_sync/test_search.py
+++ b/tests/_sync/test_search.py
@@ -17,7 +17,7 @@
 
 from copy import deepcopy
 
-from pytest import raises
+from pytest import raises, warns
 
 from elasticsearch_dsl import Document, Q, Search, query
 from elasticsearch_dsl.exceptions import IllegalOperation
@@ -361,6 +361,12 @@ def test_slice():
     assert {"from": 3, "size": 10} == s[3:].to_dict()
     assert {"from": 0, "size": 0} == s[0:0].to_dict()
     assert {"from": 20, "size": 0} == s[20:0].to_dict()
+
+
+def test_slice_twice():
+    with warns(DeprecationWarning, match="Slicing multiple times .*"):
+        s = Search()
+        s[10:20][2:]
 
 
 def test_index():


### PR DESCRIPTION
This is an alternative to merging https://github.com/elastic/elasticsearch-dsl-py/pull/1771 directly.

Given the following file:

```python
from elasticsearch_dsl import Search

s = Search()
s[10:20][2:]
```

Running it gives:

```python
testwarn.py:4: DeprecationWarning: Slicing multiple times currently has no effect but will be supported in a future release. See https://github.com/elastic/elasticsearch-dsl-py/pull/1771 for more details
  s[10:20][2:]
```

Note that this is only displayed because the warning comes from the executed module. Users will only see it if they use pytest or use `-Wall`.