### PR TITLE
Added inner_hits option to kNN search

### DIFF
--- a/elasticsearch_dsl/search_base.py
+++ b/elasticsearch_dsl/search_base.py
@@ -514,6 +514,7 @@ class SearchBase(Request):
         boost=None,
         filter=None,
         similarity=None,
+        inner_hits=None,
     ):
         """
         Add a k-nearest neighbor (kNN) search.
@@ -526,6 +527,7 @@ class SearchBase(Request):
         :arg boost: A floating-point boost factor for kNN scores
         :arg filter: query to filter the documents that can match
         :arg similarity: the minimum similarity required for a document to be considered a match, as a float value
+        :arg inner_hits: retrieve hits from nested field
 
         Example::
 
@@ -560,6 +562,8 @@ class SearchBase(Request):
                 s._knn[-1]["filter"] = filter
         if similarity is not None:
             s._knn[-1]["similarity"] = similarity
+        if inner_hits is not None:
+            s._knn[-1]["inner_hits"] = inner_hits
         return s
 
     def rank(self, rrf=None):

--- a/tests/_async/test_search.py
+++ b/tests/_async/test_search.py
@@ -266,6 +266,7 @@ def test_knn():
         query_vector_builder={
             "text_embedding": {"model_id": "foo", "model_text": "search text"}
         },
+        inner_hits={"size": 1},
     )
     assert {
         "knn": [
@@ -283,6 +284,7 @@ def test_knn():
                     "text_embedding": {"model_id": "foo", "model_text": "search text"}
                 },
                 "boost": 0.8,
+                "inner_hits": {"size": 1},
             },
         ]
     } == s.to_dict()

--- a/tests/_sync/test_search.py
+++ b/tests/_sync/test_search.py
@@ -266,6 +266,7 @@ def test_knn():
         query_vector_builder={
             "text_embedding": {"model_id": "foo", "model_text": "search text"}
         },
+        inner_hits={"size": 1},
     )
     assert {
         "knn": [
@@ -283,6 +284,7 @@ def test_knn():
                     "text_embedding": {"model_id": "foo", "model_text": "search text"}
                 },
                 "boost": 0.8,
+                "inner_hits": {"size": 1},
             },
         ]
     } == s.to_dict()


### PR DESCRIPTION
I've missed the `inner_hits` option for kNN, needed to retrieve nested documents.