### PR TITLE
Switch to pytest-asyncio's strict mode for async tests

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -11,4 +11,5 @@ filterwarnings =
     error
     ignore:Legacy index templates are deprecated in favor of composable templates.:elasticsearch.exceptions.ElasticsearchWarning
     ignore:datetime.datetime.utcfromtimestamp\(\) is deprecated and scheduled for removal in a future version..*:DeprecationWarning
-asyncio_mode = auto
+markers =
+    syncio: mark a test as performing I/O without asyncio.

--- a/setup.cfg
+++ b/setup.cfg
@@ -12,4 +12,4 @@ filterwarnings =
     ignore:Legacy index templates are deprecated in favor of composable templates.:elasticsearch.exceptions.ElasticsearchWarning
     ignore:datetime.datetime.utcfromtimestamp\(\) is deprecated and scheduled for removal in a future version..*:DeprecationWarning
 markers =
-    syncio: mark a test as performing I/O without asyncio.
+    sync: mark a test as performing I/O without asyncio.

--- a/tests/_async/test_document.py
+++ b/tests/_async/test_document.py
@@ -21,6 +21,7 @@ import pickle
 from datetime import datetime
 from hashlib import md5
 
+import pytest
 from pytest import raises
 
 from elasticsearch_dsl import (
@@ -570,18 +571,21 @@ def test_meta_fields_can_be_set_directly_in_init():
     assert md.meta.id is p
 
 
+@pytest.mark.asyncio
 async def test_save_no_index(async_mock_client):
     md = MyDoc()
     with raises(ValidationException):
         await md.save(using="mock")
 
 
+@pytest.mark.asyncio
 async def test_delete_no_index(async_mock_client):
     md = MyDoc()
     with raises(ValidationException):
         await md.delete(using="mock")
 
 
+@pytest.mark.asyncio
 async def test_update_no_fields():
     md = MyDoc()
     with raises(IllegalOperation):

--- a/tests/_async/test_index.py
+++ b/tests/_async/test_index.py
@@ -18,6 +18,7 @@
 import string
 from random import choice
 
+import pytest
 from pytest import raises
 
 from elasticsearch_dsl import (
@@ -188,6 +189,7 @@ def test_index_template_can_have_order():
     assert {"index_patterns": ["i-*"], "order": 2} == it.to_dict()
 
 
+@pytest.mark.asyncio
 async def test_index_template_save_result(async_mock_client):
     it = AsyncIndexTemplate("test-template", "test-*")
 

--- a/tests/_async/test_search.py
+++ b/tests/_async/test_search.py
@@ -17,6 +17,7 @@
 
 from copy import deepcopy
 
+import pytest
 from pytest import raises, warns
 
 from elasticsearch_dsl import A, AsyncEmptySearch, AsyncSearch, Document, Q, query
@@ -29,6 +30,7 @@ def test_expand__to_dot_is_respected():
     assert {"query": {"match": {"a__b": 42}}} == s.to_dict()
 
 
+@pytest.mark.asyncio
 async def test_execute_uses_cache():
     s = AsyncSearch()
     r = object()
@@ -37,6 +39,7 @@ async def test_execute_uses_cache():
     assert r is await s.execute()
 
 
+@pytest.mark.asyncio
 async def test_cache_can_be_ignored(async_mock_client):
     s = AsyncSearch(using="mock")
     r = object()
@@ -46,6 +49,7 @@ async def test_cache_can_be_ignored(async_mock_client):
     async_mock_client.search.assert_awaited_once_with(index=None, body={})
 
 
+@pytest.mark.asyncio
 async def test_iter_iterates_over_hits():
     s = AsyncSearch()
     s._response = [1, 2, 3]
@@ -514,6 +518,7 @@ def test_from_dict_doesnt_need_query():
     assert {"size": 5} == s.to_dict()
 
 
+@pytest.mark.asyncio
 async def test_params_being_passed_to_search(async_mock_client):
     s = AsyncSearch(using="mock")
     s = s.params(routing="42")
@@ -605,6 +610,7 @@ def test_exclude():
     } == s.to_dict()
 
 
+@pytest.mark.asyncio
 async def test_delete_by_query(async_mock_client):
     s = AsyncSearch(using="mock").query("match", lang="java")
     await s.delete()
@@ -689,6 +695,7 @@ def test_rescore_query_to_dict():
     }
 
 
+@pytest.mark.asyncio
 async def test_empty_search():
     s = AsyncEmptySearch(index="index-name")
     s = s.query("match", lang="java")

--- a/tests/_async/test_update_by_query.py
+++ b/tests/_async/test_update_by_query.py
@@ -17,6 +17,8 @@
 
 from copy import deepcopy
 
+import pytest
+
 from elasticsearch_dsl import AsyncUpdateByQuery, Q
 from elasticsearch_dsl.response import UpdateByQueryResponse
 
@@ -136,6 +138,7 @@ def test_from_dict_doesnt_need_query():
     assert {"script": {"source": "test"}} == ubq.to_dict()
 
 
+@pytest.mark.asyncio
 async def test_params_being_passed_to_search(async_mock_client):
     ubq = AsyncUpdateByQuery(using="mock")
     ubq = ubq.params(routing="42")

--- a/tests/_sync/test_document.py
+++ b/tests/_sync/test_document.py
@@ -571,21 +571,21 @@ def test_meta_fields_can_be_set_directly_in_init():
     assert md.meta.id is p
 
 
-@pytest.mark.syncio
+@pytest.mark.sync
 def test_save_no_index(mock_client):
     md = MyDoc()
     with raises(ValidationException):
         md.save(using="mock")
 
 
-@pytest.mark.syncio
+@pytest.mark.sync
 def test_delete_no_index(mock_client):
     md = MyDoc()
     with raises(ValidationException):
         md.delete(using="mock")
 
 
-@pytest.mark.syncio
+@pytest.mark.sync
 def test_update_no_fields():
     md = MyDoc()
     with raises(IllegalOperation):

--- a/tests/_sync/test_document.py
+++ b/tests/_sync/test_document.py
@@ -21,6 +21,7 @@ import pickle
 from datetime import datetime
 from hashlib import md5
 
+import pytest
 from pytest import raises
 
 from elasticsearch_dsl import (
@@ -570,18 +571,21 @@ def test_meta_fields_can_be_set_directly_in_init():
     assert md.meta.id is p
 
 
+@pytest.mark.syncio
 def test_save_no_index(mock_client):
     md = MyDoc()
     with raises(ValidationException):
         md.save(using="mock")
 
 
+@pytest.mark.syncio
 def test_delete_no_index(mock_client):
     md = MyDoc()
     with raises(ValidationException):
         md.delete(using="mock")
 
 
+@pytest.mark.syncio
 def test_update_no_fields():
     md = MyDoc()
     with raises(IllegalOperation):

--- a/tests/_sync/test_index.py
+++ b/tests/_sync/test_index.py
@@ -182,7 +182,7 @@ def test_index_template_can_have_order():
     assert {"index_patterns": ["i-*"], "order": 2} == it.to_dict()
 
 
-@pytest.mark.syncio
+@pytest.mark.sync
 def test_index_template_save_result(mock_client):
     it = IndexTemplate("test-template", "test-*")
 

--- a/tests/_sync/test_index.py
+++ b/tests/_sync/test_index.py
@@ -18,6 +18,7 @@
 import string
 from random import choice
 
+import pytest
 from pytest import raises
 
 from elasticsearch_dsl import Date, Document, Index, IndexTemplate, Text, analyzer
@@ -181,6 +182,7 @@ def test_index_template_can_have_order():
     assert {"index_patterns": ["i-*"], "order": 2} == it.to_dict()
 
 
+@pytest.mark.syncio
 def test_index_template_save_result(mock_client):
     it = IndexTemplate("test-template", "test-*")
 

--- a/tests/_sync/test_search.py
+++ b/tests/_sync/test_search.py
@@ -17,6 +17,7 @@
 
 from copy import deepcopy
 
+import pytest
 from pytest import raises, warns
 
 from elasticsearch_dsl import A, Document, EmptySearch, Q, Search, query
@@ -29,6 +30,7 @@ def test_expand__to_dot_is_respected():
     assert {"query": {"match": {"a__b": 42}}} == s.to_dict()
 
 
+@pytest.mark.syncio
 def test_execute_uses_cache():
     s = Search()
     r = object()
@@ -37,6 +39,7 @@ def test_execute_uses_cache():
     assert r is s.execute()
 
 
+@pytest.mark.syncio
 def test_cache_can_be_ignored(mock_client):
     s = Search(using="mock")
     r = object()
@@ -46,6 +49,7 @@ def test_cache_can_be_ignored(mock_client):
     mock_client.search.assert_called_once_with(index=None, body={})
 
 
+@pytest.mark.syncio
 def test_iter_iterates_over_hits():
     s = Search()
     s._response = [1, 2, 3]
@@ -514,6 +518,7 @@ def test_from_dict_doesnt_need_query():
     assert {"size": 5} == s.to_dict()
 
 
+@pytest.mark.syncio
 def test_params_being_passed_to_search(mock_client):
     s = Search(using="mock")
     s = s.params(routing="42")
@@ -603,6 +608,7 @@ def test_exclude():
     } == s.to_dict()
 
 
+@pytest.mark.syncio
 def test_delete_by_query(mock_client):
     s = Search(using="mock").query("match", lang="java")
     s.delete()
@@ -687,6 +693,7 @@ def test_rescore_query_to_dict():
     }
 
 
+@pytest.mark.syncio
 def test_empty_search():
     s = EmptySearch(index="index-name")
     s = s.query("match", lang="java")

--- a/tests/_sync/test_search.py
+++ b/tests/_sync/test_search.py
@@ -30,7 +30,7 @@ def test_expand__to_dot_is_respected():
     assert {"query": {"match": {"a__b": 42}}} == s.to_dict()
 
 
-@pytest.mark.syncio
+@pytest.mark.sync
 def test_execute_uses_cache():
     s = Search()
     r = object()
@@ -39,7 +39,7 @@ def test_execute_uses_cache():
     assert r is s.execute()
 
 
-@pytest.mark.syncio
+@pytest.mark.sync
 def test_cache_can_be_ignored(mock_client):
     s = Search(using="mock")
     r = object()
@@ -49,7 +49,7 @@ def test_cache_can_be_ignored(mock_client):
     mock_client.search.assert_called_once_with(index=None, body={})
 
 
-@pytest.mark.syncio
+@pytest.mark.sync
 def test_iter_iterates_over_hits():
     s = Search()
     s._response = [1, 2, 3]
@@ -518,7 +518,7 @@ def test_from_dict_doesnt_need_query():
     assert {"size": 5} == s.to_dict()
 
 
-@pytest.mark.syncio
+@pytest.mark.sync
 def test_params_being_passed_to_search(mock_client):
     s = Search(using="mock")
     s = s.params(routing="42")
@@ -608,7 +608,7 @@ def test_exclude():
     } == s.to_dict()
 
 
-@pytest.mark.syncio
+@pytest.mark.sync
 def test_delete_by_query(mock_client):
     s = Search(using="mock").query("match", lang="java")
     s.delete()
@@ -693,7 +693,7 @@ def test_rescore_query_to_dict():
     }
 
 
-@pytest.mark.syncio
+@pytest.mark.sync
 def test_empty_search():
     s = EmptySearch(index="index-name")
     s = s.query("match", lang="java")

--- a/tests/_sync/test_update_by_query.py
+++ b/tests/_sync/test_update_by_query.py
@@ -17,6 +17,8 @@
 
 from copy import deepcopy
 
+import pytest
+
 from elasticsearch_dsl import Q, UpdateByQuery
 from elasticsearch_dsl.response import UpdateByQueryResponse
 
@@ -136,6 +138,7 @@ def test_from_dict_doesnt_need_query():
     assert {"script": {"source": "test"}} == ubq.to_dict()
 
 
+@pytest.mark.syncio
 def test_params_being_passed_to_search(mock_client):
     ubq = UpdateByQuery(using="mock")
     ubq = ubq.params(routing="42")

--- a/tests/_sync/test_update_by_query.py
+++ b/tests/_sync/test_update_by_query.py
@@ -138,7 +138,7 @@ def test_from_dict_doesnt_need_query():
     assert {"script": {"source": "test"}} == ubq.to_dict()
 
 
-@pytest.mark.syncio
+@pytest.mark.sync
 def test_params_being_passed_to_search(mock_client):
     ubq = UpdateByQuery(using="mock")
     ubq = ubq.params(routing="42")

--- a/tests/test_integration/_async/test_analysis.py
+++ b/tests/test_integration/_async/test_analysis.py
@@ -15,9 +15,12 @@
 #  specific language governing permissions and limitations
 #  under the License.
 
+import pytest
+
 from elasticsearch_dsl import analyzer, token_filter, tokenizer
 
 
+@pytest.mark.asyncio
 async def test_simulate_with_just__builtin_tokenizer(async_client):
     a = analyzer("my-analyzer", tokenizer="keyword")
     tokens = (await a.async_simulate("Hello World!", using=async_client)).tokens
@@ -26,6 +29,7 @@ async def test_simulate_with_just__builtin_tokenizer(async_client):
     assert tokens[0].token == "Hello World!"
 
 
+@pytest.mark.asyncio
 async def test_simulate_complex(async_client):
     a = analyzer(
         "my-analyzer",
@@ -39,6 +43,7 @@ async def test_simulate_complex(async_client):
     assert ["this", "works"] == [t.token for t in tokens]
 
 
+@pytest.mark.asyncio
 async def test_simulate_builtin(async_client):
     a = analyzer("my-analyzer", "english")
     tokens = (await a.async_simulate("fixes running")).tokens

--- a/tests/test_integration/_async/test_document.py
+++ b/tests/test_integration/_async/test_document.py
@@ -120,6 +120,7 @@ class SerializationDoc(AsyncDocument):
         name = "test-serialization"
 
 
+@pytest.mark.asyncio
 async def test_serialization(async_write_client):
     await SerializationDoc.init()
     await async_write_client.index(
@@ -150,6 +151,7 @@ async def test_serialization(async_write_client):
     }
 
 
+@pytest.mark.asyncio
 async def test_nested_inner_hits_are_wrapped_properly(async_pull_request):
     history_query = Q(
         "nested",
@@ -178,6 +180,7 @@ async def test_nested_inner_hits_are_wrapped_properly(async_pull_request):
     assert "score" in history.meta
 
 
+@pytest.mark.asyncio
 async def test_nested_inner_hits_are_deserialized_properly(async_pull_request):
     s = PullRequest.search().query(
         "nested",
@@ -193,6 +196,7 @@ async def test_nested_inner_hits_are_deserialized_properly(async_pull_request):
     assert isinstance(pr.comments[0].created_at, datetime)
 
 
+@pytest.mark.asyncio
 async def test_nested_top_hits_are_wrapped_properly(async_pull_request):
     s = PullRequest.search()
     s.aggs.bucket("comments", "nested", path="comments").metric(
@@ -205,6 +209,7 @@ async def test_nested_top_hits_are_wrapped_properly(async_pull_request):
     assert isinstance(r.aggregations.comments.hits.hits[0], Comment)
 
 
+@pytest.mark.asyncio
 async def test_update_object_field(async_write_client):
     await Wiki.init()
     w = Wiki(
@@ -225,6 +230,7 @@ async def test_update_object_field(async_write_client):
     assert w.ranked == {"test1": 0.1, "topic2": 0.2}
 
 
+@pytest.mark.asyncio
 async def test_update_script(async_write_client):
     await Wiki.init()
     w = Wiki(owner=User(name="Honza Kral"), _id="elasticsearch-py", views=42)
@@ -235,6 +241,7 @@ async def test_update_script(async_write_client):
     assert w.views == 47
 
 
+@pytest.mark.asyncio
 async def test_update_retry_on_conflict(async_write_client):
     await Wiki.init()
     w = Wiki(owner=User(name="Honza Kral"), _id="elasticsearch-py", views=42)
@@ -253,6 +260,7 @@ async def test_update_retry_on_conflict(async_write_client):
     assert w.views == 52
 
 
+@pytest.mark.asyncio
 @pytest.mark.parametrize("retry_on_conflict", [None, 0])
 async def test_update_conflicting_version(async_write_client, retry_on_conflict):
     await Wiki.init()
@@ -271,6 +279,7 @@ async def test_update_conflicting_version(async_write_client, retry_on_conflict)
         )
 
 
+@pytest.mark.asyncio
 async def test_save_and_update_return_doc_meta(async_write_client):
     await Wiki.init()
     w = Wiki(owner=User(name="Honza Kral"), _id="elasticsearch-py", views=42)
@@ -303,28 +312,33 @@ async def test_save_and_update_return_doc_meta(async_write_client):
     }
 
 
+@pytest.mark.asyncio
 async def test_init(async_write_client):
     await Repository.init(index="test-git")
 
     assert await async_write_client.indices.exists(index="test-git")
 
 
+@pytest.mark.asyncio
 async def test_get_raises_404_on_index_missing(async_data_client):
     with raises(NotFoundError):
         await Repository.get("elasticsearch-dsl-php", index="not-there")
 
 
+@pytest.mark.asyncio
 async def test_get_raises_404_on_non_existent_id(async_data_client):
     with raises(NotFoundError):
         await Repository.get("elasticsearch-dsl-php")
 
 
+@pytest.mark.asyncio
 async def test_get_returns_none_if_404_ignored(async_data_client):
     assert None is await Repository.get(
         "elasticsearch-dsl-php", using=async_data_client.options(ignore_status=404)
     )
 
 
+@pytest.mark.asyncio
 async def test_get_returns_none_if_404_ignored_and_index_doesnt_exist(
     async_data_client,
 ):
@@ -333,6 +347,7 @@ async def test_get_returns_none_if_404_ignored_and_index_doesnt_exist(
     )
 
 
+@pytest.mark.asyncio
 async def test_get(async_data_client):
     elasticsearch_repo = await Repository.get("elasticsearch-dsl-py")
 
@@ -341,14 +356,17 @@ async def test_get(async_data_client):
     assert datetime(2014, 3, 3) == elasticsearch_repo.created_at
 
 
+@pytest.mark.asyncio
 async def test_exists_return_true(async_data_client):
     assert await Repository.exists("elasticsearch-dsl-py")
 
 
+@pytest.mark.asyncio
 async def test_exists_false(async_data_client):
     assert not await Repository.exists("elasticsearch-dsl-php")
 
 
+@pytest.mark.asyncio
 async def test_get_with_tz_date(async_data_client):
     first_commit = await Commit.get(
         id="3ca6e1e73a071a705b4babd2f581c91a2a3e5037", routing="elasticsearch-dsl-py"
@@ -361,6 +379,7 @@ async def test_get_with_tz_date(async_data_client):
     )
 
 
+@pytest.mark.asyncio
 async def test_save_with_tz_date(async_data_client):
     tzinfo = timezone("Europe/Prague")
     first_commit = await Commit.get(
@@ -388,6 +407,7 @@ COMMIT_DOCS_WITH_MISSING = [
 ]
 
 
+@pytest.mark.asyncio
 async def test_mget(async_data_client):
     commits = await Commit.mget(COMMIT_DOCS_WITH_MISSING)
     assert commits[0] is None
@@ -396,22 +416,26 @@ async def test_mget(async_data_client):
     assert commits[3].meta.id == "eb3e543323f189fd7b698e66295427204fff5755"
 
 
+@pytest.mark.asyncio
 async def test_mget_raises_exception_when_missing_param_is_invalid(async_data_client):
     with raises(ValueError):
         await Commit.mget(COMMIT_DOCS_WITH_MISSING, missing="raj")
 
 
+@pytest.mark.asyncio
 async def test_mget_raises_404_when_missing_param_is_raise(async_data_client):
     with raises(NotFoundError):
         await Commit.mget(COMMIT_DOCS_WITH_MISSING, missing="raise")
 
 
+@pytest.mark.asyncio
 async def test_mget_ignores_missing_docs_when_missing_param_is_skip(async_data_client):
     commits = await Commit.mget(COMMIT_DOCS_WITH_MISSING, missing="skip")
     assert commits[0].meta.id == "3ca6e1e73a071a705b4babd2f581c91a2a3e5037"
     assert commits[1].meta.id == "eb3e543323f189fd7b698e66295427204fff5755"
 
 
+@pytest.mark.asyncio
 async def test_update_works_from_search_response(async_data_client):
     elasticsearch_repo = (await Repository.search().execute())[0]
 
@@ -423,6 +447,7 @@ async def test_update_works_from_search_response(async_data_client):
     assert "elasticsearch" == new_version.owner.name
 
 
+@pytest.mark.asyncio
 async def test_update(async_data_client):
     elasticsearch_repo = await Repository.get("elasticsearch-dsl-py")
     v = elasticsearch_repo.meta.version
@@ -447,6 +472,7 @@ async def test_update(async_data_client):
     assert "primary_term" in new_version.meta
 
 
+@pytest.mark.asyncio
 async def test_save_updates_existing_doc(async_data_client):
     elasticsearch_repo = await Repository.get("elasticsearch-dsl-py")
 
@@ -460,6 +486,7 @@ async def test_save_updates_existing_doc(async_data_client):
     assert new_repo["_seq_no"] == elasticsearch_repo.meta.seq_no
 
 
+@pytest.mark.asyncio
 async def test_save_automatically_uses_seq_no_and_primary_term(async_data_client):
     elasticsearch_repo = await Repository.get("elasticsearch-dsl-py")
     elasticsearch_repo.meta.seq_no += 1
@@ -468,6 +495,7 @@ async def test_save_automatically_uses_seq_no_and_primary_term(async_data_client
         await elasticsearch_repo.save()
 
 
+@pytest.mark.asyncio
 async def test_delete_automatically_uses_seq_no_and_primary_term(async_data_client):
     elasticsearch_repo = await Repository.get("elasticsearch-dsl-py")
     elasticsearch_repo.meta.seq_no += 1
@@ -482,6 +510,7 @@ def assert_doc_equals(expected, actual):
         assert actual[f] == expected[f]
 
 
+@pytest.mark.asyncio
 async def test_can_save_to_different_index(async_write_client):
     test_repo = Repository(description="testing", meta={"id": 42})
     assert await test_repo.save(index="test-document")
@@ -497,6 +526,7 @@ async def test_can_save_to_different_index(async_write_client):
     )
 
 
+@pytest.mark.asyncio
 async def test_save_without_skip_empty_will_include_empty_fields(async_write_client):
     test_repo = Repository(field_1=[], field_2=None, field_3={}, meta={"id": 42})
     assert await test_repo.save(index="test-document", skip_empty=False)
@@ -512,6 +542,7 @@ async def test_save_without_skip_empty_will_include_empty_fields(async_write_cli
     )
 
 
+@pytest.mark.asyncio
 async def test_delete(async_write_client):
     await async_write_client.create(
         index="test-document",
@@ -533,10 +564,12 @@ async def test_delete(async_write_client):
     )
 
 
+@pytest.mark.asyncio
 async def test_search(async_data_client):
     assert await Repository.search().count() == 1
 
 
+@pytest.mark.asyncio
 async def test_search_returns_proper_doc_classes(async_data_client):
     result = await Repository.search().execute()
 
@@ -546,6 +579,7 @@ async def test_search_returns_proper_doc_classes(async_data_client):
     assert elasticsearch_repo.owner.name == "elasticsearch"
 
 
+@pytest.mark.asyncio
 async def test_refresh_mapping(async_data_client):
     class Commit(AsyncDocument):
         class Index:
@@ -560,6 +594,7 @@ async def test_refresh_mapping(async_data_client):
     assert isinstance(Commit._index._mapping["committed_date"], Date)
 
 
+@pytest.mark.asyncio
 async def test_highlight_in_meta(async_data_client):
     commit = (
         await Commit.search()

--- a/tests/test_integration/_async/test_faceted_search.py
+++ b/tests/test_integration/_async/test_faceted_search.py
@@ -124,6 +124,7 @@ def pr_search_cls(es_version):
     return PRSearch
 
 
+@pytest.mark.asyncio
 async def test_facet_with_custom_metric(async_data_client):
     ms = MetricSearch()
     r = await ms.execute()
@@ -133,6 +134,7 @@ async def test_facet_with_custom_metric(async_data_client):
     assert dates[0] == 1399038439000
 
 
+@pytest.mark.asyncio
 async def test_nested_facet(async_pull_request, pr_search_cls):
     prs = pr_search_cls()
     r = await prs.execute()
@@ -141,6 +143,7 @@ async def test_nested_facet(async_pull_request, pr_search_cls):
     assert [(datetime(2018, 1, 1, 0, 0), 1, False)] == r.facets.comments
 
 
+@pytest.mark.asyncio
 async def test_nested_facet_with_filter(async_pull_request, pr_search_cls):
     prs = pr_search_cls(filters={"comments": datetime(2018, 1, 1, 0, 0)})
     r = await prs.execute()
@@ -153,6 +156,7 @@ async def test_nested_facet_with_filter(async_pull_request, pr_search_cls):
     assert not r.hits
 
 
+@pytest.mark.asyncio
 async def test_datehistogram_facet(async_data_client, repo_search_cls):
     rs = repo_search_cls()
     r = await rs.execute()
@@ -161,6 +165,7 @@ async def test_datehistogram_facet(async_data_client, repo_search_cls):
     assert [(datetime(2014, 3, 1, 0, 0), 1, False)] == r.facets.created
 
 
+@pytest.mark.asyncio
 async def test_boolean_facet(async_data_client, repo_search_cls):
     rs = repo_search_cls()
     r = await rs.execute()
@@ -171,6 +176,7 @@ async def test_boolean_facet(async_data_client, repo_search_cls):
     assert value is True
 
 
+@pytest.mark.asyncio
 async def test_empty_search_finds_everything(
     async_data_client, es_version, commit_search_cls
 ):
@@ -218,6 +224,7 @@ async def test_empty_search_finds_everything(
     ] == r.facets.deletions
 
 
+@pytest.mark.asyncio
 async def test_term_filters_are_shown_as_selected_and_data_is_filtered(
     async_data_client, commit_search_cls
 ):
@@ -264,6 +271,7 @@ async def test_term_filters_are_shown_as_selected_and_data_is_filtered(
     ] == r.facets.deletions
 
 
+@pytest.mark.asyncio
 async def test_range_filters_are_shown_as_selected_and_data_is_filtered(
     async_data_client, commit_search_cls
 ):
@@ -274,6 +282,7 @@ async def test_range_filters_are_shown_as_selected_and_data_is_filtered(
     assert 19 == r.hits.total.value
 
 
+@pytest.mark.asyncio
 async def test_pagination(async_data_client, commit_search_cls):
     cs = commit_search_cls()
     cs = cs[0:20]

--- a/tests/test_integration/_async/test_index.py
+++ b/tests/test_integration/_async/test_index.py
@@ -15,6 +15,8 @@
 #  specific language governing permissions and limitations
 #  under the License.
 
+import pytest
+
 from elasticsearch_dsl import (
     AsyncDocument,
     AsyncIndex,
@@ -30,6 +32,7 @@ class Post(AsyncDocument):
     published_from = Date()
 
 
+@pytest.mark.asyncio
 async def test_index_template_works(async_write_client):
     it = AsyncIndexTemplate("test-template", "test-*")
     it.document(Post)
@@ -51,6 +54,7 @@ async def test_index_template_works(async_write_client):
     } == await async_write_client.indices.get_mapping(index="test-blog")
 
 
+@pytest.mark.asyncio
 async def test_index_can_be_saved_even_with_settings(async_write_client):
     i = AsyncIndex("test-blog", using=async_write_client)
     i.settings(number_of_shards=3, number_of_replicas=0)
@@ -66,11 +70,13 @@ async def test_index_can_be_saved_even_with_settings(async_write_client):
     )
 
 
+@pytest.mark.asyncio
 async def test_index_exists(async_data_client):
     assert await AsyncIndex("git").exists()
     assert not await AsyncIndex("not-there").exists()
 
 
+@pytest.mark.asyncio
 async def test_index_can_be_created_with_settings_and_mappings(async_write_client):
     i = AsyncIndex("test-blog", using=async_write_client)
     i.document(Post)
@@ -96,6 +102,7 @@ async def test_index_can_be_created_with_settings_and_mappings(async_write_clien
     }
 
 
+@pytest.mark.asyncio
 async def test_delete(async_write_client):
     await async_write_client.indices.create(
         index="test-index",
@@ -107,6 +114,7 @@ async def test_delete(async_write_client):
     assert not await async_write_client.indices.exists(index="test-index")
 
 
+@pytest.mark.asyncio
 async def test_multiple_indices_with_same_doc_type_work(async_write_client):
     i1 = AsyncIndex("test-index-1", using=async_write_client)
     i2 = AsyncIndex("test-index-2", using=async_write_client)

--- a/tests/test_integration/_async/test_mapping.py
+++ b/tests/test_integration/_async/test_mapping.py
@@ -15,11 +15,13 @@
 #  specific language governing permissions and limitations
 #  under the License.
 
+import pytest
 from pytest import raises
 
 from elasticsearch_dsl import AsyncMapping, analysis, exceptions
 
 
+@pytest.mark.asyncio
 async def test_mapping_saved_into_es(async_write_client):
     m = AsyncMapping()
     m.field(
@@ -40,6 +42,7 @@ async def test_mapping_saved_into_es(async_write_client):
     } == await async_write_client.indices.get_mapping(index="test-mapping")
 
 
+@pytest.mark.asyncio
 async def test_mapping_saved_into_es_when_index_already_exists_closed(
     async_write_client,
 ):
@@ -67,6 +70,7 @@ async def test_mapping_saved_into_es_when_index_already_exists_closed(
     } == await async_write_client.indices.get_mapping(index="test-mapping")
 
 
+@pytest.mark.asyncio
 async def test_mapping_saved_into_es_when_index_already_exists_with_analysis(
     async_write_client,
 ):
@@ -98,6 +102,7 @@ async def test_mapping_saved_into_es_when_index_already_exists_with_analysis(
     } == await async_write_client.indices.get_mapping(index="test-mapping")
 
 
+@pytest.mark.asyncio
 async def test_mapping_gets_updated_from_es(async_write_client):
     await async_write_client.indices.create(
         index="test-mapping",

--- a/tests/test_integration/_async/test_search.py
+++ b/tests/test_integration/_async/test_search.py
@@ -16,6 +16,7 @@
 #  under the License.
 
 
+import pytest
 from elasticsearch import ApiError
 from pytest import raises
 
@@ -51,6 +52,7 @@ class Commit(AsyncDocument):
         name = "flat-git"
 
 
+@pytest.mark.asyncio
 async def test_filters_aggregation_buckets_are_accessible(async_data_client):
     has_tests_query = Q("term", files="test_elasticsearch_dsl")
     s = Commit.search()[0:0]
@@ -73,6 +75,7 @@ async def test_filters_aggregation_buckets_are_accessible(async_data_client):
     )
 
 
+@pytest.mark.asyncio
 async def test_top_hits_are_wrapped_in_response(async_data_client):
     s = Commit.search()[0:0]
     s.aggs.bucket("top_authors", "terms", field="author.name.raw").metric(
@@ -89,6 +92,7 @@ async def test_top_hits_are_wrapped_in_response(async_data_client):
     assert isinstance(hits[0], Commit)
 
 
+@pytest.mark.asyncio
 async def test_inner_hits_are_wrapped_in_response(async_data_client):
     s = AsyncSearch(index="git")[0:1].query(
         "has_parent", parent_type="repo", inner_hits={}, query=Q("match_all")
@@ -102,6 +106,7 @@ async def test_inner_hits_are_wrapped_in_response(async_data_client):
     )
 
 
+@pytest.mark.asyncio
 async def test_scan_respects_doc_types(async_data_client):
     repos = [repo async for repo in Repository.search().scan()]
 
@@ -110,6 +115,7 @@ async def test_scan_respects_doc_types(async_data_client):
     assert repos[0].organization == "elasticsearch"
 
 
+@pytest.mark.asyncio
 async def test_scan_iterates_through_all_docs(async_data_client):
     s = AsyncSearch(index="flat-git")
 
@@ -119,6 +125,7 @@ async def test_scan_iterates_through_all_docs(async_data_client):
     assert {d["_id"] for d in FLAT_DATA} == {c.meta.id for c in commits}
 
 
+@pytest.mark.asyncio
 async def test_response_is_cached(async_data_client):
     s = Repository.search()
     repos = [repo async for repo in s]
@@ -127,6 +134,7 @@ async def test_response_is_cached(async_data_client):
     assert s._response.hits == repos
 
 
+@pytest.mark.asyncio
 async def test_multi_search(async_data_client):
     s1 = Repository.search()
     s2 = AsyncSearch(index="flat-git")
@@ -144,6 +152,7 @@ async def test_multi_search(async_data_client):
     assert r2._search is s2
 
 
+@pytest.mark.asyncio
 async def test_multi_missing(async_data_client):
     s1 = Repository.search()
     s2 = AsyncSearch(index="flat-git")
@@ -167,6 +176,7 @@ async def test_multi_missing(async_data_client):
     assert r3 is None
 
 
+@pytest.mark.asyncio
 async def test_raw_subfield_can_be_used_in_aggs(async_data_client):
     s = AsyncSearch(index="git")[0:0]
     s.aggs.bucket("authors", "terms", field="author.name.raw", size=1)

--- a/tests/test_integration/_async/test_update_by_query.py
+++ b/tests/test_integration/_async/test_update_by_query.py
@@ -15,10 +15,13 @@
 #  specific language governing permissions and limitations
 #  under the License.
 
+import pytest
+
 from elasticsearch_dsl import AsyncUpdateByQuery
 from elasticsearch_dsl.search import Q
 
 
+@pytest.mark.asyncio
 async def test_update_by_query_no_script(async_write_client, setup_ubq_tests):
     index = setup_ubq_tests
 
@@ -38,6 +41,7 @@ async def test_update_by_query_no_script(async_write_client, setup_ubq_tests):
     assert response.success()
 
 
+@pytest.mark.asyncio
 async def test_update_by_query_with_script(async_write_client, setup_ubq_tests):
     index = setup_ubq_tests
 
@@ -55,6 +59,7 @@ async def test_update_by_query_with_script(async_write_client, setup_ubq_tests):
     assert response.version_conflicts == 0
 
 
+@pytest.mark.asyncio
 async def test_delete_by_query_with_script(async_write_client, setup_ubq_tests):
     index = setup_ubq_tests
 

--- a/tests/test_integration/_sync/test_analysis.py
+++ b/tests/test_integration/_sync/test_analysis.py
@@ -20,7 +20,7 @@ import pytest
 from elasticsearch_dsl import analyzer, token_filter, tokenizer
 
 
-@pytest.mark.syncio
+@pytest.mark.sync
 def test_simulate_with_just__builtin_tokenizer(client):
     a = analyzer("my-analyzer", tokenizer="keyword")
     tokens = (a.simulate("Hello World!", using=client)).tokens
@@ -29,7 +29,7 @@ def test_simulate_with_just__builtin_tokenizer(client):
     assert tokens[0].token == "Hello World!"
 
 
-@pytest.mark.syncio
+@pytest.mark.sync
 def test_simulate_complex(client):
     a = analyzer(
         "my-analyzer",
@@ -43,7 +43,7 @@ def test_simulate_complex(client):
     assert ["this", "works"] == [t.token for t in tokens]
 
 
-@pytest.mark.syncio
+@pytest.mark.sync
 def test_simulate_builtin(client):
     a = analyzer("my-analyzer", "english")
     tokens = (a.simulate("fixes running")).tokens

--- a/tests/test_integration/_sync/test_analysis.py
+++ b/tests/test_integration/_sync/test_analysis.py
@@ -15,9 +15,12 @@
 #  specific language governing permissions and limitations
 #  under the License.
 
+import pytest
+
 from elasticsearch_dsl import analyzer, token_filter, tokenizer
 
 
+@pytest.mark.syncio
 def test_simulate_with_just__builtin_tokenizer(client):
     a = analyzer("my-analyzer", tokenizer="keyword")
     tokens = (a.simulate("Hello World!", using=client)).tokens
@@ -26,6 +29,7 @@ def test_simulate_with_just__builtin_tokenizer(client):
     assert tokens[0].token == "Hello World!"
 
 
+@pytest.mark.syncio
 def test_simulate_complex(client):
     a = analyzer(
         "my-analyzer",
@@ -39,6 +43,7 @@ def test_simulate_complex(client):
     assert ["this", "works"] == [t.token for t in tokens]
 
 
+@pytest.mark.syncio
 def test_simulate_builtin(client):
     a = analyzer("my-analyzer", "english")
     tokens = (a.simulate("fixes running")).tokens

--- a/tests/test_integration/_sync/test_document.py
+++ b/tests/test_integration/_sync/test_document.py
@@ -120,6 +120,7 @@ class SerializationDoc(Document):
         name = "test-serialization"
 
 
+@pytest.mark.syncio
 def test_serialization(write_client):
     SerializationDoc.init()
     write_client.index(
@@ -150,6 +151,7 @@ def test_serialization(write_client):
     }
 
 
+@pytest.mark.syncio
 def test_nested_inner_hits_are_wrapped_properly(pull_request):
     history_query = Q(
         "nested",
@@ -178,6 +180,7 @@ def test_nested_inner_hits_are_wrapped_properly(pull_request):
     assert "score" in history.meta
 
 
+@pytest.mark.syncio
 def test_nested_inner_hits_are_deserialized_properly(pull_request):
     s = PullRequest.search().query(
         "nested",
@@ -193,6 +196,7 @@ def test_nested_inner_hits_are_deserialized_properly(pull_request):
     assert isinstance(pr.comments[0].created_at, datetime)
 
 
+@pytest.mark.syncio
 def test_nested_top_hits_are_wrapped_properly(pull_request):
     s = PullRequest.search()
     s.aggs.bucket("comments", "nested", path="comments").metric(
@@ -205,6 +209,7 @@ def test_nested_top_hits_are_wrapped_properly(pull_request):
     assert isinstance(r.aggregations.comments.hits.hits[0], Comment)
 
 
+@pytest.mark.syncio
 def test_update_object_field(write_client):
     Wiki.init()
     w = Wiki(
@@ -225,6 +230,7 @@ def test_update_object_field(write_client):
     assert w.ranked == {"test1": 0.1, "topic2": 0.2}
 
 
+@pytest.mark.syncio
 def test_update_script(write_client):
     Wiki.init()
     w = Wiki(owner=User(name="Honza Kral"), _id="elasticsearch-py", views=42)
@@ -235,6 +241,7 @@ def test_update_script(write_client):
     assert w.views == 47
 
 
+@pytest.mark.syncio
 def test_update_retry_on_conflict(write_client):
     Wiki.init()
     w = Wiki(owner=User(name="Honza Kral"), _id="elasticsearch-py", views=42)
@@ -249,6 +256,7 @@ def test_update_retry_on_conflict(write_client):
     assert w.views == 52
 
 
+@pytest.mark.syncio
 @pytest.mark.parametrize("retry_on_conflict", [None, 0])
 def test_update_conflicting_version(write_client, retry_on_conflict):
     Wiki.init()
@@ -267,6 +275,7 @@ def test_update_conflicting_version(write_client, retry_on_conflict):
         )
 
 
+@pytest.mark.syncio
 def test_save_and_update_return_doc_meta(write_client):
     Wiki.init()
     w = Wiki(owner=User(name="Honza Kral"), _id="elasticsearch-py", views=42)
@@ -299,28 +308,33 @@ def test_save_and_update_return_doc_meta(write_client):
     }
 
 
+@pytest.mark.syncio
 def test_init(write_client):
     Repository.init(index="test-git")
 
     assert write_client.indices.exists(index="test-git")
 
 
+@pytest.mark.syncio
 def test_get_raises_404_on_index_missing(data_client):
     with raises(NotFoundError):
         Repository.get("elasticsearch-dsl-php", index="not-there")
 
 
+@pytest.mark.syncio
 def test_get_raises_404_on_non_existent_id(data_client):
     with raises(NotFoundError):
         Repository.get("elasticsearch-dsl-php")
 
 
+@pytest.mark.syncio
 def test_get_returns_none_if_404_ignored(data_client):
     assert None is Repository.get(
         "elasticsearch-dsl-php", using=data_client.options(ignore_status=404)
     )
 
 
+@pytest.mark.syncio
 def test_get_returns_none_if_404_ignored_and_index_doesnt_exist(
     data_client,
 ):
@@ -329,6 +343,7 @@ def test_get_returns_none_if_404_ignored_and_index_doesnt_exist(
     )
 
 
+@pytest.mark.syncio
 def test_get(data_client):
     elasticsearch_repo = Repository.get("elasticsearch-dsl-py")
 
@@ -337,14 +352,17 @@ def test_get(data_client):
     assert datetime(2014, 3, 3) == elasticsearch_repo.created_at
 
 
+@pytest.mark.syncio
 def test_exists_return_true(data_client):
     assert Repository.exists("elasticsearch-dsl-py")
 
 
+@pytest.mark.syncio
 def test_exists_false(data_client):
     assert not Repository.exists("elasticsearch-dsl-php")
 
 
+@pytest.mark.syncio
 def test_get_with_tz_date(data_client):
     first_commit = Commit.get(
         id="3ca6e1e73a071a705b4babd2f581c91a2a3e5037", routing="elasticsearch-dsl-py"
@@ -357,6 +375,7 @@ def test_get_with_tz_date(data_client):
     )
 
 
+@pytest.mark.syncio
 def test_save_with_tz_date(data_client):
     tzinfo = timezone("Europe/Prague")
     first_commit = Commit.get(
@@ -384,6 +403,7 @@ COMMIT_DOCS_WITH_MISSING = [
 ]
 
 
+@pytest.mark.syncio
 def test_mget(data_client):
     commits = Commit.mget(COMMIT_DOCS_WITH_MISSING)
     assert commits[0] is None
@@ -392,22 +412,26 @@ def test_mget(data_client):
     assert commits[3].meta.id == "eb3e543323f189fd7b698e66295427204fff5755"
 
 
+@pytest.mark.syncio
 def test_mget_raises_exception_when_missing_param_is_invalid(data_client):
     with raises(ValueError):
         Commit.mget(COMMIT_DOCS_WITH_MISSING, missing="raj")
 
 
+@pytest.mark.syncio
 def test_mget_raises_404_when_missing_param_is_raise(data_client):
     with raises(NotFoundError):
         Commit.mget(COMMIT_DOCS_WITH_MISSING, missing="raise")
 
 
+@pytest.mark.syncio
 def test_mget_ignores_missing_docs_when_missing_param_is_skip(data_client):
     commits = Commit.mget(COMMIT_DOCS_WITH_MISSING, missing="skip")
     assert commits[0].meta.id == "3ca6e1e73a071a705b4babd2f581c91a2a3e5037"
     assert commits[1].meta.id == "eb3e543323f189fd7b698e66295427204fff5755"
 
 
+@pytest.mark.syncio
 def test_update_works_from_search_response(data_client):
     elasticsearch_repo = (Repository.search().execute())[0]
 
@@ -419,6 +443,7 @@ def test_update_works_from_search_response(data_client):
     assert "elasticsearch" == new_version.owner.name
 
 
+@pytest.mark.syncio
 def test_update(data_client):
     elasticsearch_repo = Repository.get("elasticsearch-dsl-py")
     v = elasticsearch_repo.meta.version
@@ -441,6 +466,7 @@ def test_update(data_client):
     assert "primary_term" in new_version.meta
 
 
+@pytest.mark.syncio
 def test_save_updates_existing_doc(data_client):
     elasticsearch_repo = Repository.get("elasticsearch-dsl-py")
 
@@ -454,6 +480,7 @@ def test_save_updates_existing_doc(data_client):
     assert new_repo["_seq_no"] == elasticsearch_repo.meta.seq_no
 
 
+@pytest.mark.syncio
 def test_save_automatically_uses_seq_no_and_primary_term(data_client):
     elasticsearch_repo = Repository.get("elasticsearch-dsl-py")
     elasticsearch_repo.meta.seq_no += 1
@@ -462,6 +489,7 @@ def test_save_automatically_uses_seq_no_and_primary_term(data_client):
         elasticsearch_repo.save()
 
 
+@pytest.mark.syncio
 def test_delete_automatically_uses_seq_no_and_primary_term(data_client):
     elasticsearch_repo = Repository.get("elasticsearch-dsl-py")
     elasticsearch_repo.meta.seq_no += 1
@@ -476,6 +504,7 @@ def assert_doc_equals(expected, actual):
         assert actual[f] == expected[f]
 
 
+@pytest.mark.syncio
 def test_can_save_to_different_index(write_client):
     test_repo = Repository(description="testing", meta={"id": 42})
     assert test_repo.save(index="test-document")
@@ -491,6 +520,7 @@ def test_can_save_to_different_index(write_client):
     )
 
 
+@pytest.mark.syncio
 def test_save_without_skip_empty_will_include_empty_fields(write_client):
     test_repo = Repository(field_1=[], field_2=None, field_3={}, meta={"id": 42})
     assert test_repo.save(index="test-document", skip_empty=False)
@@ -506,6 +536,7 @@ def test_save_without_skip_empty_will_include_empty_fields(write_client):
     )
 
 
+@pytest.mark.syncio
 def test_delete(write_client):
     write_client.create(
         index="test-document",
@@ -527,10 +558,12 @@ def test_delete(write_client):
     )
 
 
+@pytest.mark.syncio
 def test_search(data_client):
     assert Repository.search().count() == 1
 
 
+@pytest.mark.syncio
 def test_search_returns_proper_doc_classes(data_client):
     result = Repository.search().execute()
 
@@ -540,6 +573,7 @@ def test_search_returns_proper_doc_classes(data_client):
     assert elasticsearch_repo.owner.name == "elasticsearch"
 
 
+@pytest.mark.syncio
 def test_refresh_mapping(data_client):
     class Commit(Document):
         class Index:
@@ -554,6 +588,7 @@ def test_refresh_mapping(data_client):
     assert isinstance(Commit._index._mapping["committed_date"], Date)
 
 
+@pytest.mark.syncio
 def test_highlight_in_meta(data_client):
     commit = (
         Commit.search()

--- a/tests/test_integration/_sync/test_document.py
+++ b/tests/test_integration/_sync/test_document.py
@@ -120,7 +120,7 @@ class SerializationDoc(Document):
         name = "test-serialization"
 
 
-@pytest.mark.syncio
+@pytest.mark.sync
 def test_serialization(write_client):
     SerializationDoc.init()
     write_client.index(
@@ -151,7 +151,7 @@ def test_serialization(write_client):
     }
 
 
-@pytest.mark.syncio
+@pytest.mark.sync
 def test_nested_inner_hits_are_wrapped_properly(pull_request):
     history_query = Q(
         "nested",
@@ -180,7 +180,7 @@ def test_nested_inner_hits_are_wrapped_properly(pull_request):
     assert "score" in history.meta
 
 
-@pytest.mark.syncio
+@pytest.mark.sync
 def test_nested_inner_hits_are_deserialized_properly(pull_request):
     s = PullRequest.search().query(
         "nested",
@@ -196,7 +196,7 @@ def test_nested_inner_hits_are_deserialized_properly(pull_request):
     assert isinstance(pr.comments[0].created_at, datetime)
 
 
-@pytest.mark.syncio
+@pytest.mark.sync
 def test_nested_top_hits_are_wrapped_properly(pull_request):
     s = PullRequest.search()
     s.aggs.bucket("comments", "nested", path="comments").metric(
@@ -209,7 +209,7 @@ def test_nested_top_hits_are_wrapped_properly(pull_request):
     assert isinstance(r.aggregations.comments.hits.hits[0], Comment)
 
 
-@pytest.mark.syncio
+@pytest.mark.sync
 def test_update_object_field(write_client):
     Wiki.init()
     w = Wiki(
@@ -230,7 +230,7 @@ def test_update_object_field(write_client):
     assert w.ranked == {"test1": 0.1, "topic2": 0.2}
 
 
-@pytest.mark.syncio
+@pytest.mark.sync
 def test_update_script(write_client):
     Wiki.init()
     w = Wiki(owner=User(name="Honza Kral"), _id="elasticsearch-py", views=42)
@@ -241,7 +241,7 @@ def test_update_script(write_client):
     assert w.views == 47
 
 
-@pytest.mark.syncio
+@pytest.mark.sync
 def test_update_retry_on_conflict(write_client):
     Wiki.init()
     w = Wiki(owner=User(name="Honza Kral"), _id="elasticsearch-py", views=42)
@@ -256,7 +256,7 @@ def test_update_retry_on_conflict(write_client):
     assert w.views == 52
 
 
-@pytest.mark.syncio
+@pytest.mark.sync
 @pytest.mark.parametrize("retry_on_conflict", [None, 0])
 def test_update_conflicting_version(write_client, retry_on_conflict):
     Wiki.init()
@@ -275,7 +275,7 @@ def test_update_conflicting_version(write_client, retry_on_conflict):
         )
 
 
-@pytest.mark.syncio
+@pytest.mark.sync
 def test_save_and_update_return_doc_meta(write_client):
     Wiki.init()
     w = Wiki(owner=User(name="Honza Kral"), _id="elasticsearch-py", views=42)
@@ -308,33 +308,33 @@ def test_save_and_update_return_doc_meta(write_client):
     }
 
 
-@pytest.mark.syncio
+@pytest.mark.sync
 def test_init(write_client):
     Repository.init(index="test-git")
 
     assert write_client.indices.exists(index="test-git")
 
 
-@pytest.mark.syncio
+@pytest.mark.sync
 def test_get_raises_404_on_index_missing(data_client):
     with raises(NotFoundError):
         Repository.get("elasticsearch-dsl-php", index="not-there")
 
 
-@pytest.mark.syncio
+@pytest.mark.sync
 def test_get_raises_404_on_non_existent_id(data_client):
     with raises(NotFoundError):
         Repository.get("elasticsearch-dsl-php")
 
 
-@pytest.mark.syncio
+@pytest.mark.sync
 def test_get_returns_none_if_404_ignored(data_client):
     assert None is Repository.get(
         "elasticsearch-dsl-php", using=data_client.options(ignore_status=404)
     )
 
 
-@pytest.mark.syncio
+@pytest.mark.sync
 def test_get_returns_none_if_404_ignored_and_index_doesnt_exist(
     data_client,
 ):
@@ -343,7 +343,7 @@ def test_get_returns_none_if_404_ignored_and_index_doesnt_exist(
     )
 
 
-@pytest.mark.syncio
+@pytest.mark.sync
 def test_get(data_client):
     elasticsearch_repo = Repository.get("elasticsearch-dsl-py")
 
@@ -352,17 +352,17 @@ def test_get(data_client):
     assert datetime(2014, 3, 3) == elasticsearch_repo.created_at
 
 
-@pytest.mark.syncio
+@pytest.mark.sync
 def test_exists_return_true(data_client):
     assert Repository.exists("elasticsearch-dsl-py")
 
 
-@pytest.mark.syncio
+@pytest.mark.sync
 def test_exists_false(data_client):
     assert not Repository.exists("elasticsearch-dsl-php")
 
 
-@pytest.mark.syncio
+@pytest.mark.sync
 def test_get_with_tz_date(data_client):
     first_commit = Commit.get(
         id="3ca6e1e73a071a705b4babd2f581c91a2a3e5037", routing="elasticsearch-dsl-py"
@@ -375,7 +375,7 @@ def test_get_with_tz_date(data_client):
     )
 
 
-@pytest.mark.syncio
+@pytest.mark.sync
 def test_save_with_tz_date(data_client):
     tzinfo = timezone("Europe/Prague")
     first_commit = Commit.get(
@@ -403,7 +403,7 @@ COMMIT_DOCS_WITH_MISSING = [
 ]
 
 
-@pytest.mark.syncio
+@pytest.mark.sync
 def test_mget(data_client):
     commits = Commit.mget(COMMIT_DOCS_WITH_MISSING)
     assert commits[0] is None
@@ -412,26 +412,26 @@ def test_mget(data_client):
     assert commits[3].meta.id == "eb3e543323f189fd7b698e66295427204fff5755"
 
 
-@pytest.mark.syncio
+@pytest.mark.sync
 def test_mget_raises_exception_when_missing_param_is_invalid(data_client):
     with raises(ValueError):
         Commit.mget(COMMIT_DOCS_WITH_MISSING, missing="raj")
 
 
-@pytest.mark.syncio
+@pytest.mark.sync
 def test_mget_raises_404_when_missing_param_is_raise(data_client):
     with raises(NotFoundError):
         Commit.mget(COMMIT_DOCS_WITH_MISSING, missing="raise")
 
 
-@pytest.mark.syncio
+@pytest.mark.sync
 def test_mget_ignores_missing_docs_when_missing_param_is_skip(data_client):
     commits = Commit.mget(COMMIT_DOCS_WITH_MISSING, missing="skip")
     assert commits[0].meta.id == "3ca6e1e73a071a705b4babd2f581c91a2a3e5037"
     assert commits[1].meta.id == "eb3e543323f189fd7b698e66295427204fff5755"
 
 
-@pytest.mark.syncio
+@pytest.mark.sync
 def test_update_works_from_search_response(data_client):
     elasticsearch_repo = (Repository.search().execute())[0]
 
@@ -443,7 +443,7 @@ def test_update_works_from_search_response(data_client):
     assert "elasticsearch" == new_version.owner.name
 
 
-@pytest.mark.syncio
+@pytest.mark.sync
 def test_update(data_client):
     elasticsearch_repo = Repository.get("elasticsearch-dsl-py")
     v = elasticsearch_repo.meta.version
@@ -466,7 +466,7 @@ def test_update(data_client):
     assert "primary_term" in new_version.meta
 
 
-@pytest.mark.syncio
+@pytest.mark.sync
 def test_save_updates_existing_doc(data_client):
     elasticsearch_repo = Repository.get("elasticsearch-dsl-py")
 
@@ -480,7 +480,7 @@ def test_save_updates_existing_doc(data_client):
     assert new_repo["_seq_no"] == elasticsearch_repo.meta.seq_no
 
 
-@pytest.mark.syncio
+@pytest.mark.sync
 def test_save_automatically_uses_seq_no_and_primary_term(data_client):
     elasticsearch_repo = Repository.get("elasticsearch-dsl-py")
     elasticsearch_repo.meta.seq_no += 1
@@ -489,7 +489,7 @@ def test_save_automatically_uses_seq_no_and_primary_term(data_client):
         elasticsearch_repo.save()
 
 
-@pytest.mark.syncio
+@pytest.mark.sync
 def test_delete_automatically_uses_seq_no_and_primary_term(data_client):
     elasticsearch_repo = Repository.get("elasticsearch-dsl-py")
     elasticsearch_repo.meta.seq_no += 1
@@ -504,7 +504,7 @@ def assert_doc_equals(expected, actual):
         assert actual[f] == expected[f]
 
 
-@pytest.mark.syncio
+@pytest.mark.sync
 def test_can_save_to_different_index(write_client):
     test_repo = Repository(description="testing", meta={"id": 42})
     assert test_repo.save(index="test-document")
@@ -520,7 +520,7 @@ def test_can_save_to_different_index(write_client):
     )
 
 
-@pytest.mark.syncio
+@pytest.mark.sync
 def test_save_without_skip_empty_will_include_empty_fields(write_client):
     test_repo = Repository(field_1=[], field_2=None, field_3={}, meta={"id": 42})
     assert test_repo.save(index="test-document", skip_empty=False)
@@ -536,7 +536,7 @@ def test_save_without_skip_empty_will_include_empty_fields(write_client):
     )
 
 
-@pytest.mark.syncio
+@pytest.mark.sync
 def test_delete(write_client):
     write_client.create(
         index="test-document",
@@ -558,12 +558,12 @@ def test_delete(write_client):
     )
 
 
-@pytest.mark.syncio
+@pytest.mark.sync
 def test_search(data_client):
     assert Repository.search().count() == 1
 
 
-@pytest.mark.syncio
+@pytest.mark.sync
 def test_search_returns_proper_doc_classes(data_client):
     result = Repository.search().execute()
 
@@ -573,7 +573,7 @@ def test_search_returns_proper_doc_classes(data_client):
     assert elasticsearch_repo.owner.name == "elasticsearch"
 
 
-@pytest.mark.syncio
+@pytest.mark.sync
 def test_refresh_mapping(data_client):
     class Commit(Document):
         class Index:
@@ -588,7 +588,7 @@ def test_refresh_mapping(data_client):
     assert isinstance(Commit._index._mapping["committed_date"], Date)
 
 
-@pytest.mark.syncio
+@pytest.mark.sync
 def test_highlight_in_meta(data_client):
     commit = (
         Commit.search()

--- a/tests/test_integration/_sync/test_faceted_search.py
+++ b/tests/test_integration/_sync/test_faceted_search.py
@@ -124,7 +124,7 @@ def pr_search_cls(es_version):
     return PRSearch
 
 
-@pytest.mark.syncio
+@pytest.mark.sync
 def test_facet_with_custom_metric(data_client):
     ms = MetricSearch()
     r = ms.execute()
@@ -134,7 +134,7 @@ def test_facet_with_custom_metric(data_client):
     assert dates[0] == 1399038439000
 
 
-@pytest.mark.syncio
+@pytest.mark.sync
 def test_nested_facet(pull_request, pr_search_cls):
     prs = pr_search_cls()
     r = prs.execute()
@@ -143,7 +143,7 @@ def test_nested_facet(pull_request, pr_search_cls):
     assert [(datetime(2018, 1, 1, 0, 0), 1, False)] == r.facets.comments
 
 
-@pytest.mark.syncio
+@pytest.mark.sync
 def test_nested_facet_with_filter(pull_request, pr_search_cls):
     prs = pr_search_cls(filters={"comments": datetime(2018, 1, 1, 0, 0)})
     r = prs.execute()
@@ -156,7 +156,7 @@ def test_nested_facet_with_filter(pull_request, pr_search_cls):
     assert not r.hits
 
 
-@pytest.mark.syncio
+@pytest.mark.sync
 def test_datehistogram_facet(data_client, repo_search_cls):
     rs = repo_search_cls()
     r = rs.execute()
@@ -165,7 +165,7 @@ def test_datehistogram_facet(data_client, repo_search_cls):
     assert [(datetime(2014, 3, 1, 0, 0), 1, False)] == r.facets.created
 
 
-@pytest.mark.syncio
+@pytest.mark.sync
 def test_boolean_facet(data_client, repo_search_cls):
     rs = repo_search_cls()
     r = rs.execute()
@@ -176,7 +176,7 @@ def test_boolean_facet(data_client, repo_search_cls):
     assert value is True
 
 
-@pytest.mark.syncio
+@pytest.mark.sync
 def test_empty_search_finds_everything(data_client, es_version, commit_search_cls):
     cs = commit_search_cls()
     r = cs.execute()
@@ -222,7 +222,7 @@ def test_empty_search_finds_everything(data_client, es_version, commit_search_cl
     ] == r.facets.deletions
 
 
-@pytest.mark.syncio
+@pytest.mark.sync
 def test_term_filters_are_shown_as_selected_and_data_is_filtered(
     data_client, commit_search_cls
 ):
@@ -269,7 +269,7 @@ def test_term_filters_are_shown_as_selected_and_data_is_filtered(
     ] == r.facets.deletions
 
 
-@pytest.mark.syncio
+@pytest.mark.sync
 def test_range_filters_are_shown_as_selected_and_data_is_filtered(
     data_client, commit_search_cls
 ):
@@ -280,7 +280,7 @@ def test_range_filters_are_shown_as_selected_and_data_is_filtered(
     assert 19 == r.hits.total.value
 
 
-@pytest.mark.syncio
+@pytest.mark.sync
 def test_pagination(data_client, commit_search_cls):
     cs = commit_search_cls()
     cs = cs[0:20]

--- a/tests/test_integration/_sync/test_faceted_search.py
+++ b/tests/test_integration/_sync/test_faceted_search.py
@@ -124,6 +124,7 @@ def pr_search_cls(es_version):
     return PRSearch
 
 
+@pytest.mark.syncio
 def test_facet_with_custom_metric(data_client):
     ms = MetricSearch()
     r = ms.execute()
@@ -133,6 +134,7 @@ def test_facet_with_custom_metric(data_client):
     assert dates[0] == 1399038439000
 
 
+@pytest.mark.syncio
 def test_nested_facet(pull_request, pr_search_cls):
     prs = pr_search_cls()
     r = prs.execute()
@@ -141,6 +143,7 @@ def test_nested_facet(pull_request, pr_search_cls):
     assert [(datetime(2018, 1, 1, 0, 0), 1, False)] == r.facets.comments
 
 
+@pytest.mark.syncio
 def test_nested_facet_with_filter(pull_request, pr_search_cls):
     prs = pr_search_cls(filters={"comments": datetime(2018, 1, 1, 0, 0)})
     r = prs.execute()
@@ -153,6 +156,7 @@ def test_nested_facet_with_filter(pull_request, pr_search_cls):
     assert not r.hits
 
 
+@pytest.mark.syncio
 def test_datehistogram_facet(data_client, repo_search_cls):
     rs = repo_search_cls()
     r = rs.execute()
@@ -161,6 +165,7 @@ def test_datehistogram_facet(data_client, repo_search_cls):
     assert [(datetime(2014, 3, 1, 0, 0), 1, False)] == r.facets.created
 
 
+@pytest.mark.syncio
 def test_boolean_facet(data_client, repo_search_cls):
     rs = repo_search_cls()
     r = rs.execute()
@@ -171,6 +176,7 @@ def test_boolean_facet(data_client, repo_search_cls):
     assert value is True
 
 
+@pytest.mark.syncio
 def test_empty_search_finds_everything(data_client, es_version, commit_search_cls):
     cs = commit_search_cls()
     r = cs.execute()
@@ -216,6 +222,7 @@ def test_empty_search_finds_everything(data_client, es_version, commit_search_cl
     ] == r.facets.deletions
 
 
+@pytest.mark.syncio
 def test_term_filters_are_shown_as_selected_and_data_is_filtered(
     data_client, commit_search_cls
 ):
@@ -262,6 +269,7 @@ def test_term_filters_are_shown_as_selected_and_data_is_filtered(
     ] == r.facets.deletions
 
 
+@pytest.mark.syncio
 def test_range_filters_are_shown_as_selected_and_data_is_filtered(
     data_client, commit_search_cls
 ):
@@ -272,6 +280,7 @@ def test_range_filters_are_shown_as_selected_and_data_is_filtered(
     assert 19 == r.hits.total.value
 
 
+@pytest.mark.syncio
 def test_pagination(data_client, commit_search_cls):
     cs = commit_search_cls()
     cs = cs[0:20]

--- a/tests/test_integration/_sync/test_index.py
+++ b/tests/test_integration/_sync/test_index.py
@@ -15,6 +15,8 @@
 #  specific language governing permissions and limitations
 #  under the License.
 
+import pytest
+
 from elasticsearch_dsl import Date, Document, Index, IndexTemplate, Text, analysis
 
 
@@ -23,6 +25,7 @@ class Post(Document):
     published_from = Date()
 
 
+@pytest.mark.syncio
 def test_index_template_works(write_client):
     it = IndexTemplate("test-template", "test-*")
     it.document(Post)
@@ -44,6 +47,7 @@ def test_index_template_works(write_client):
     } == write_client.indices.get_mapping(index="test-blog")
 
 
+@pytest.mark.syncio
 def test_index_can_be_saved_even_with_settings(write_client):
     i = Index("test-blog", using=write_client)
     i.settings(number_of_shards=3, number_of_replicas=0)
@@ -57,11 +61,13 @@ def test_index_can_be_saved_even_with_settings(write_client):
     )
 
 
+@pytest.mark.syncio
 def test_index_exists(data_client):
     assert Index("git").exists()
     assert not Index("not-there").exists()
 
 
+@pytest.mark.syncio
 def test_index_can_be_created_with_settings_and_mappings(write_client):
     i = Index("test-blog", using=write_client)
     i.document(Post)
@@ -87,6 +93,7 @@ def test_index_can_be_created_with_settings_and_mappings(write_client):
     }
 
 
+@pytest.mark.syncio
 def test_delete(write_client):
     write_client.indices.create(
         index="test-index",
@@ -98,6 +105,7 @@ def test_delete(write_client):
     assert not write_client.indices.exists(index="test-index")
 
 
+@pytest.mark.syncio
 def test_multiple_indices_with_same_doc_type_work(write_client):
     i1 = Index("test-index-1", using=write_client)
     i2 = Index("test-index-2", using=write_client)

--- a/tests/test_integration/_sync/test_index.py
+++ b/tests/test_integration/_sync/test_index.py
@@ -25,7 +25,7 @@ class Post(Document):
     published_from = Date()
 
 
-@pytest.mark.syncio
+@pytest.mark.sync
 def test_index_template_works(write_client):
     it = IndexTemplate("test-template", "test-*")
     it.document(Post)
@@ -47,7 +47,7 @@ def test_index_template_works(write_client):
     } == write_client.indices.get_mapping(index="test-blog")
 
 
-@pytest.mark.syncio
+@pytest.mark.sync
 def test_index_can_be_saved_even_with_settings(write_client):
     i = Index("test-blog", using=write_client)
     i.settings(number_of_shards=3, number_of_replicas=0)
@@ -61,13 +61,13 @@ def test_index_can_be_saved_even_with_settings(write_client):
     )
 
 
-@pytest.mark.syncio
+@pytest.mark.sync
 def test_index_exists(data_client):
     assert Index("git").exists()
     assert not Index("not-there").exists()
 
 
-@pytest.mark.syncio
+@pytest.mark.sync
 def test_index_can_be_created_with_settings_and_mappings(write_client):
     i = Index("test-blog", using=write_client)
     i.document(Post)
@@ -93,7 +93,7 @@ def test_index_can_be_created_with_settings_and_mappings(write_client):
     }
 
 
-@pytest.mark.syncio
+@pytest.mark.sync
 def test_delete(write_client):
     write_client.indices.create(
         index="test-index",
@@ -105,7 +105,7 @@ def test_delete(write_client):
     assert not write_client.indices.exists(index="test-index")
 
 
-@pytest.mark.syncio
+@pytest.mark.sync
 def test_multiple_indices_with_same_doc_type_work(write_client):
     i1 = Index("test-index-1", using=write_client)
     i2 = Index("test-index-2", using=write_client)

--- a/tests/test_integration/_sync/test_mapping.py
+++ b/tests/test_integration/_sync/test_mapping.py
@@ -21,7 +21,7 @@ from pytest import raises
 from elasticsearch_dsl import Mapping, analysis, exceptions
 
 
-@pytest.mark.syncio
+@pytest.mark.sync
 def test_mapping_saved_into_es(write_client):
     m = Mapping()
     m.field(
@@ -42,7 +42,7 @@ def test_mapping_saved_into_es(write_client):
     } == write_client.indices.get_mapping(index="test-mapping")
 
 
-@pytest.mark.syncio
+@pytest.mark.sync
 def test_mapping_saved_into_es_when_index_already_exists_closed(
     write_client,
 ):
@@ -68,7 +68,7 @@ def test_mapping_saved_into_es_when_index_already_exists_closed(
     } == write_client.indices.get_mapping(index="test-mapping")
 
 
-@pytest.mark.syncio
+@pytest.mark.sync
 def test_mapping_saved_into_es_when_index_already_exists_with_analysis(
     write_client,
 ):
@@ -100,7 +100,7 @@ def test_mapping_saved_into_es_when_index_already_exists_with_analysis(
     } == write_client.indices.get_mapping(index="test-mapping")
 
 
-@pytest.mark.syncio
+@pytest.mark.sync
 def test_mapping_gets_updated_from_es(write_client):
     write_client.indices.create(
         index="test-mapping",

--- a/tests/test_integration/_sync/test_mapping.py
+++ b/tests/test_integration/_sync/test_mapping.py
@@ -15,11 +15,13 @@
 #  specific language governing permissions and limitations
 #  under the License.
 
+import pytest
 from pytest import raises
 
 from elasticsearch_dsl import Mapping, analysis, exceptions
 
 
+@pytest.mark.syncio
 def test_mapping_saved_into_es(write_client):
     m = Mapping()
     m.field(
@@ -40,6 +42,7 @@ def test_mapping_saved_into_es(write_client):
     } == write_client.indices.get_mapping(index="test-mapping")
 
 
+@pytest.mark.syncio
 def test_mapping_saved_into_es_when_index_already_exists_closed(
     write_client,
 ):
@@ -65,6 +68,7 @@ def test_mapping_saved_into_es_when_index_already_exists_closed(
     } == write_client.indices.get_mapping(index="test-mapping")
 
 
+@pytest.mark.syncio
 def test_mapping_saved_into_es_when_index_already_exists_with_analysis(
     write_client,
 ):
@@ -96,6 +100,7 @@ def test_mapping_saved_into_es_when_index_already_exists_with_analysis(
     } == write_client.indices.get_mapping(index="test-mapping")
 
 
+@pytest.mark.syncio
 def test_mapping_gets_updated_from_es(write_client):
     write_client.indices.create(
         index="test-mapping",

--- a/tests/test_integration/_sync/test_search.py
+++ b/tests/test_integration/_sync/test_search.py
@@ -44,7 +44,7 @@ class Commit(Document):
         name = "flat-git"
 
 
-@pytest.mark.syncio
+@pytest.mark.sync
 def test_filters_aggregation_buckets_are_accessible(data_client):
     has_tests_query = Q("term", files="test_elasticsearch_dsl")
     s = Commit.search()[0:0]
@@ -67,7 +67,7 @@ def test_filters_aggregation_buckets_are_accessible(data_client):
     )
 
 
-@pytest.mark.syncio
+@pytest.mark.sync
 def test_top_hits_are_wrapped_in_response(data_client):
     s = Commit.search()[0:0]
     s.aggs.bucket("top_authors", "terms", field="author.name.raw").metric(
@@ -84,7 +84,7 @@ def test_top_hits_are_wrapped_in_response(data_client):
     assert isinstance(hits[0], Commit)
 
 
-@pytest.mark.syncio
+@pytest.mark.sync
 def test_inner_hits_are_wrapped_in_response(data_client):
     s = Search(index="git")[0:1].query(
         "has_parent", parent_type="repo", inner_hits={}, query=Q("match_all")
@@ -98,7 +98,7 @@ def test_inner_hits_are_wrapped_in_response(data_client):
     )
 
 
-@pytest.mark.syncio
+@pytest.mark.sync
 def test_scan_respects_doc_types(data_client):
     repos = [repo for repo in Repository.search().scan()]
 
@@ -107,7 +107,7 @@ def test_scan_respects_doc_types(data_client):
     assert repos[0].organization == "elasticsearch"
 
 
-@pytest.mark.syncio
+@pytest.mark.sync
 def test_scan_iterates_through_all_docs(data_client):
     s = Search(index="flat-git")
 
@@ -117,7 +117,7 @@ def test_scan_iterates_through_all_docs(data_client):
     assert {d["_id"] for d in FLAT_DATA} == {c.meta.id for c in commits}
 
 
-@pytest.mark.syncio
+@pytest.mark.sync
 def test_response_is_cached(data_client):
     s = Repository.search()
     repos = [repo for repo in s]
@@ -126,7 +126,7 @@ def test_response_is_cached(data_client):
     assert s._response.hits == repos
 
 
-@pytest.mark.syncio
+@pytest.mark.sync
 def test_multi_search(data_client):
     s1 = Repository.search()
     s2 = Search(index="flat-git")
@@ -144,7 +144,7 @@ def test_multi_search(data_client):
     assert r2._search is s2
 
 
-@pytest.mark.syncio
+@pytest.mark.sync
 def test_multi_missing(data_client):
     s1 = Repository.search()
     s2 = Search(index="flat-git")
@@ -168,7 +168,7 @@ def test_multi_missing(data_client):
     assert r3 is None
 
 
-@pytest.mark.syncio
+@pytest.mark.sync
 def test_raw_subfield_can_be_used_in_aggs(data_client):
     s = Search(index="git")[0:0]
     s.aggs.bucket("authors", "terms", field="author.name.raw", size=1)

--- a/tests/test_integration/_sync/test_search.py
+++ b/tests/test_integration/_sync/test_search.py
@@ -16,6 +16,7 @@
 #  under the License.
 
 
+import pytest
 from elasticsearch import ApiError
 from pytest import raises
 
@@ -43,6 +44,7 @@ class Commit(Document):
         name = "flat-git"
 
 
+@pytest.mark.syncio
 def test_filters_aggregation_buckets_are_accessible(data_client):
     has_tests_query = Q("term", files="test_elasticsearch_dsl")
     s = Commit.search()[0:0]
@@ -65,6 +67,7 @@ def test_filters_aggregation_buckets_are_accessible(data_client):
     )
 
 
+@pytest.mark.syncio
 def test_top_hits_are_wrapped_in_response(data_client):
     s = Commit.search()[0:0]
     s.aggs.bucket("top_authors", "terms", field="author.name.raw").metric(
@@ -81,6 +84,7 @@ def test_top_hits_are_wrapped_in_response(data_client):
     assert isinstance(hits[0], Commit)
 
 
+@pytest.mark.syncio
 def test_inner_hits_are_wrapped_in_response(data_client):
     s = Search(index="git")[0:1].query(
         "has_parent", parent_type="repo", inner_hits={}, query=Q("match_all")
@@ -94,6 +98,7 @@ def test_inner_hits_are_wrapped_in_response(data_client):
     )
 
 
+@pytest.mark.syncio
 def test_scan_respects_doc_types(data_client):
     repos = [repo for repo in Repository.search().scan()]
 
@@ -102,6 +107,7 @@ def test_scan_respects_doc_types(data_client):
     assert repos[0].organization == "elasticsearch"
 
 
+@pytest.mark.syncio
 def test_scan_iterates_through_all_docs(data_client):
     s = Search(index="flat-git")
 
@@ -111,6 +117,7 @@ def test_scan_iterates_through_all_docs(data_client):
     assert {d["_id"] for d in FLAT_DATA} == {c.meta.id for c in commits}
 
 
+@pytest.mark.syncio
 def test_response_is_cached(data_client):
     s = Repository.search()
     repos = [repo for repo in s]
@@ -119,6 +126,7 @@ def test_response_is_cached(data_client):
     assert s._response.hits == repos
 
 
+@pytest.mark.syncio
 def test_multi_search(data_client):
     s1 = Repository.search()
     s2 = Search(index="flat-git")
@@ -136,6 +144,7 @@ def test_multi_search(data_client):
     assert r2._search is s2
 
 
+@pytest.mark.syncio
 def test_multi_missing(data_client):
     s1 = Repository.search()
     s2 = Search(index="flat-git")
@@ -159,6 +168,7 @@ def test_multi_missing(data_client):
     assert r3 is None
 
 
+@pytest.mark.syncio
 def test_raw_subfield_can_be_used_in_aggs(data_client):
     s = Search(index="git")[0:0]
     s.aggs.bucket("authors", "terms", field="author.name.raw", size=1)

--- a/tests/test_integration/_sync/test_update_by_query.py
+++ b/tests/test_integration/_sync/test_update_by_query.py
@@ -15,10 +15,13 @@
 #  specific language governing permissions and limitations
 #  under the License.
 
+import pytest
+
 from elasticsearch_dsl import UpdateByQuery
 from elasticsearch_dsl.search import Q
 
 
+@pytest.mark.syncio
 def test_update_by_query_no_script(write_client, setup_ubq_tests):
     index = setup_ubq_tests
 
@@ -38,6 +41,7 @@ def test_update_by_query_no_script(write_client, setup_ubq_tests):
     assert response.success()
 
 
+@pytest.mark.syncio
 def test_update_by_query_with_script(write_client, setup_ubq_tests):
     index = setup_ubq_tests
 
@@ -55,6 +59,7 @@ def test_update_by_query_with_script(write_client, setup_ubq_tests):
     assert response.version_conflicts == 0
 
 
+@pytest.mark.syncio
 def test_delete_by_query_with_script(write_client, setup_ubq_tests):
     index = setup_ubq_tests
 

--- a/tests/test_integration/_sync/test_update_by_query.py
+++ b/tests/test_integration/_sync/test_update_by_query.py
@@ -21,7 +21,7 @@ from elasticsearch_dsl import UpdateByQuery
 from elasticsearch_dsl.search import Q
 
 
-@pytest.mark.syncio
+@pytest.mark.sync
 def test_update_by_query_no_script(write_client, setup_ubq_tests):
     index = setup_ubq_tests
 
@@ -41,7 +41,7 @@ def test_update_by_query_no_script(write_client, setup_ubq_tests):
     assert response.success()
 
 
-@pytest.mark.syncio
+@pytest.mark.sync
 def test_update_by_query_with_script(write_client, setup_ubq_tests):
     index = setup_ubq_tests
 
@@ -59,7 +59,7 @@ def test_update_by_query_with_script(write_client, setup_ubq_tests):
     assert response.version_conflicts == 0
 
 
-@pytest.mark.syncio
+@pytest.mark.sync
 def test_delete_by_query_with_script(write_client, setup_ubq_tests):
     index = setup_ubq_tests
 

--- a/tests/test_integration/test_examples/_async/test_alias_migration.py
+++ b/tests/test_integration/test_examples/_async/test_alias_migration.py
@@ -15,10 +15,13 @@
 #  specific language governing permissions and limitations
 #  under the License.
 
+import pytest
+
 from ..async_examples import alias_migration
 from ..async_examples.alias_migration import ALIAS, PATTERN, BlogPost, migrate
 
 
+@pytest.mark.asyncio
 async def test_alias_migration(async_write_client):
     # create the index
     await alias_migration.setup()

--- a/tests/test_integration/test_examples/_async/test_completion.py
+++ b/tests/test_integration/test_examples/_async/test_completion.py
@@ -15,10 +15,12 @@
 #  specific language governing permissions and limitations
 #  under the License.
 
+import pytest
 
 from ..async_examples.completion import Person
 
 
+@pytest.mark.asyncio
 async def test_person_suggests_on_all_variants_of_name(async_write_client):
     await Person.init(using=async_write_client)
 

--- a/tests/test_integration/test_examples/_async/test_composite_aggs.py
+++ b/tests/test_integration/test_examples/_async/test_composite_aggs.py
@@ -15,11 +15,14 @@
 #  specific language governing permissions and limitations
 #  under the License.
 
+import pytest
+
 from elasticsearch_dsl import A, AsyncSearch
 
 from ..async_examples.composite_agg import scan_aggs
 
 
+@pytest.mark.asyncio
 async def test_scan_aggs_exhausts_all_files(async_data_client):
     s = AsyncSearch(index="flat-git")
     key_aggs = {"files": A("terms", field="files")}
@@ -28,6 +31,7 @@ async def test_scan_aggs_exhausts_all_files(async_data_client):
     assert len(file_list) == 26
 
 
+@pytest.mark.asyncio
 async def test_scan_aggs_with_multiple_aggs(async_data_client):
     s = AsyncSearch(index="flat-git")
     key_aggs = [

--- a/tests/test_integration/test_examples/_async/test_parent_child.py
+++ b/tests/test_integration/test_examples/_async/test_parent_child.py
@@ -17,7 +17,8 @@
 
 from datetime import datetime
 
-from pytest import fixture
+import pytest
+from pytest_asyncio import fixture
 
 from elasticsearch_dsl import Q
 
@@ -59,6 +60,7 @@ async def question(async_write_client):
     return q
 
 
+@pytest.mark.asyncio
 async def test_comment(async_write_client, question):
     await question.add_comment(nick, "Just use elasticsearch-py")
 
@@ -71,6 +73,7 @@ async def test_comment(async_write_client, question):
     assert c.author.username == "fxdgear"
 
 
+@pytest.mark.asyncio
 async def test_question_answer(async_write_client, question):
     a = await question.add_answer(honza, "Just use `elasticsearch-py`!")
 

--- a/tests/test_integration/test_examples/_async/test_percolate.py
+++ b/tests/test_integration/test_examples/_async/test_percolate.py
@@ -15,9 +15,12 @@
 #  specific language governing permissions and limitations
 #  under the License.
 
+import pytest
+
 from ..async_examples.percolate import BlogPost, setup
 
 
+@pytest.mark.asyncio
 async def test_post_gets_tagged_automatically(async_write_client):
     await setup()
 

--- a/tests/test_integration/test_examples/_async/test_vectors.py
+++ b/tests/test_integration/test_examples/_async/test_vectors.py
@@ -17,9 +17,12 @@
 
 from unittest import SkipTest
 
+import pytest
+
 from ..async_examples.vectors import create, search
 
 
+@pytest.mark.asyncio
 async def test_vector_search(async_write_client, es_version):
     # this test only runs on Elasticsearch >= 8.11 because the example uses
     # a dense vector without giving them an explicit size

--- a/tests/test_integration/test_examples/_sync/test_alias_migration.py
+++ b/tests/test_integration/test_examples/_sync/test_alias_migration.py
@@ -15,10 +15,13 @@
 #  specific language governing permissions and limitations
 #  under the License.
 
+import pytest
+
 from ..examples import alias_migration
 from ..examples.alias_migration import ALIAS, PATTERN, BlogPost, migrate
 
 
+@pytest.mark.syncio
 def test_alias_migration(write_client):
     # create the index
     alias_migration.setup()

--- a/tests/test_integration/test_examples/_sync/test_alias_migration.py
+++ b/tests/test_integration/test_examples/_sync/test_alias_migration.py
@@ -21,7 +21,7 @@ from ..examples import alias_migration
 from ..examples.alias_migration import ALIAS, PATTERN, BlogPost, migrate
 
 
-@pytest.mark.syncio
+@pytest.mark.sync
 def test_alias_migration(write_client):
     # create the index
     alias_migration.setup()

--- a/tests/test_integration/test_examples/_sync/test_completion.py
+++ b/tests/test_integration/test_examples/_sync/test_completion.py
@@ -15,10 +15,12 @@
 #  specific language governing permissions and limitations
 #  under the License.
 
+import pytest
 
 from ..examples.completion import Person
 
 
+@pytest.mark.syncio
 def test_person_suggests_on_all_variants_of_name(write_client):
     Person.init(using=write_client)
 

--- a/tests/test_integration/test_examples/_sync/test_completion.py
+++ b/tests/test_integration/test_examples/_sync/test_completion.py
@@ -20,7 +20,7 @@ import pytest
 from ..examples.completion import Person
 
 
-@pytest.mark.syncio
+@pytest.mark.sync
 def test_person_suggests_on_all_variants_of_name(write_client):
     Person.init(using=write_client)
 

--- a/tests/test_integration/test_examples/_sync/test_composite_aggs.py
+++ b/tests/test_integration/test_examples/_sync/test_composite_aggs.py
@@ -15,11 +15,14 @@
 #  specific language governing permissions and limitations
 #  under the License.
 
+import pytest
+
 from elasticsearch_dsl import A, Search
 
 from ..examples.composite_agg import scan_aggs
 
 
+@pytest.mark.syncio
 def test_scan_aggs_exhausts_all_files(data_client):
     s = Search(index="flat-git")
     key_aggs = {"files": A("terms", field="files")}
@@ -28,6 +31,7 @@ def test_scan_aggs_exhausts_all_files(data_client):
     assert len(file_list) == 26
 
 
+@pytest.mark.syncio
 def test_scan_aggs_with_multiple_aggs(data_client):
     s = Search(index="flat-git")
     key_aggs = [

--- a/tests/test_integration/test_examples/_sync/test_composite_aggs.py
+++ b/tests/test_integration/test_examples/_sync/test_composite_aggs.py
@@ -22,7 +22,7 @@ from elasticsearch_dsl import A, Search
 from ..examples.composite_agg import scan_aggs
 
 
-@pytest.mark.syncio
+@pytest.mark.sync
 def test_scan_aggs_exhausts_all_files(data_client):
     s = Search(index="flat-git")
     key_aggs = {"files": A("terms", field="files")}
@@ -31,7 +31,7 @@ def test_scan_aggs_exhausts_all_files(data_client):
     assert len(file_list) == 26
 
 
-@pytest.mark.syncio
+@pytest.mark.sync
 def test_scan_aggs_with_multiple_aggs(data_client):
     s = Search(index="flat-git")
     key_aggs = [

--- a/tests/test_integration/test_examples/_sync/test_parent_child.py
+++ b/tests/test_integration/test_examples/_sync/test_parent_child.py
@@ -17,6 +17,7 @@
 
 from datetime import datetime
 
+import pytest
 from pytest import fixture
 
 from elasticsearch_dsl import Q
@@ -59,6 +60,7 @@ def question(write_client):
     return q
 
 
+@pytest.mark.syncio
 def test_comment(write_client, question):
     question.add_comment(nick, "Just use elasticsearch-py")
 
@@ -71,6 +73,7 @@ def test_comment(write_client, question):
     assert c.author.username == "fxdgear"
 
 
+@pytest.mark.syncio
 def test_question_answer(write_client, question):
     a = question.add_answer(honza, "Just use `elasticsearch-py`!")
 

--- a/tests/test_integration/test_examples/_sync/test_parent_child.py
+++ b/tests/test_integration/test_examples/_sync/test_parent_child.py
@@ -60,7 +60,7 @@ def question(write_client):
     return q
 
 
-@pytest.mark.syncio
+@pytest.mark.sync
 def test_comment(write_client, question):
     question.add_comment(nick, "Just use elasticsearch-py")
 
@@ -73,7 +73,7 @@ def test_comment(write_client, question):
     assert c.author.username == "fxdgear"
 
 
-@pytest.mark.syncio
+@pytest.mark.sync
 def test_question_answer(write_client, question):
     a = question.add_answer(honza, "Just use `elasticsearch-py`!")
 

--- a/tests/test_integration/test_examples/_sync/test_percolate.py
+++ b/tests/test_integration/test_examples/_sync/test_percolate.py
@@ -20,7 +20,7 @@ import pytest
 from ..examples.percolate import BlogPost, setup
 
 
-@pytest.mark.syncio
+@pytest.mark.sync
 def test_post_gets_tagged_automatically(write_client):
     setup()
 

--- a/tests/test_integration/test_examples/_sync/test_percolate.py
+++ b/tests/test_integration/test_examples/_sync/test_percolate.py
@@ -15,9 +15,12 @@
 #  specific language governing permissions and limitations
 #  under the License.
 
+import pytest
+
 from ..examples.percolate import BlogPost, setup
 
 
+@pytest.mark.syncio
 def test_post_gets_tagged_automatically(write_client):
     setup()
 

--- a/tests/test_integration/test_examples/_sync/test_vectors.py
+++ b/tests/test_integration/test_examples/_sync/test_vectors.py
@@ -17,9 +17,12 @@
 
 from unittest import SkipTest
 
+import pytest
+
 from ..examples.vectors import create, search
 
 
+@pytest.mark.sync
 def test_vector_search(write_client, es_version):
     # this test only runs on Elasticsearch >= 8.11 because the example uses
     # a dense vector without giving them an explicit size

--- a/utils/run-unasync.py
+++ b/utils/run-unasync.py
@@ -70,6 +70,7 @@ def main(check=False):
         "async_pull_request": "pull_request",
         "async_examples": "examples",
         "assert_awaited_once_with": "assert_called_once_with",
+        "pytest_asyncio": "pytest",
     }
     rules = [
         unasync.Rule(
@@ -112,6 +113,14 @@ def main(check=False):
                     "sed",
                     "-i.bak",
                     "s/elasticsearch-dsl\\[async\\]/elasticsearch-dsl/",
+                    f"{output_dir}{file}",
+                ]
+            )
+            subprocess.check_call(
+                [
+                    "sed",
+                    "-i.bak",
+                    "s/pytest.mark.asyncio/pytest.mark.syncio/",
                     f"{output_dir}{file}",
                 ]
             )

--- a/utils/run-unasync.py
+++ b/utils/run-unasync.py
@@ -120,7 +120,7 @@ def main(check=False):
                 [
                     "sed",
                     "-i.bak",
-                    "s/pytest.mark.asyncio/pytest.mark.syncio/",
+                    "s/pytest.mark.asyncio/pytest.mark.sync/",
                     f"{output_dir}{file}",
                 ]
             )


### PR DESCRIPTION
The trick is to using the following for async tests:

    @pytest.mark.asyncio

which is convert to the following for the unasynced tests:

    @pytest.mark.sync

This eliminates issues with unused imports, which would need to be taken care of in some, but not all files. WDYT?