### PR TITLE
explicit use of fixture decorator

### DIFF
--- a/tests/test_integration/test_examples/_async/test_parent_child.py
+++ b/tests/test_integration/test_examples/_async/test_parent_child.py
@@ -18,7 +18,7 @@
 from datetime import datetime
 
 import pytest
-from pytest_asyncio import fixture
+import pytest_asyncio
 
 from elasticsearch_dsl import Q
 
@@ -41,7 +41,7 @@ nick = User(
 )
 
 
-@fixture
+@pytest_asyncio.fixture
 async def question(async_write_client):
     await setup()
     assert await async_write_client.indices.exists_template(name="base")

--- a/tests/test_integration/test_examples/_sync/test_parent_child.py
+++ b/tests/test_integration/test_examples/_sync/test_parent_child.py
@@ -18,7 +18,6 @@
 from datetime import datetime
 
 import pytest
-from pytest import fixture
 
 from elasticsearch_dsl import Q
 
@@ -41,7 +40,7 @@ nick = User(
 )
 
 
-@fixture
+@pytest.fixture
 def question(write_client):
     setup()
     assert write_client.indices.exists_template(name="base")


### PR DESCRIPTION
This was one of the last suggestions in #1782, to use explicit `@pytest.fixture` and `@pytest_asyncio.fixture` decorators. I inadvertently left this change out of that PR, so here it is.