### PR TITLE
Configure a unique user agent for usage tracking purposes

### DIFF
--- a/elasticsearch_dsl/connections.py
+++ b/elasticsearch_dsl/connections.py
@@ -58,7 +58,7 @@ class Connections:
         """
         Add a connection object, it will be passed through as-is.
         """
-        self._conns[alias] = conn
+        self._conns[alias] = self._with_user_agent(conn)
 
     def remove_connection(self, alias):
         """
@@ -82,7 +82,7 @@ class Connections:
         """
         kwargs.setdefault("serializer", serializer)
         conn = self._conns[alias] = self.elasticsearch_class(**kwargs)
-        return conn
+        return self._with_user_agent(conn)
 
     def get_connection(self, alias="default"):
         """
@@ -96,7 +96,7 @@ class Connections:
         # do not check isinstance(Elasticsearch) so that people can wrap their
         # clients
         if not isinstance(alias, str):
-            return alias
+            return self._with_user_agent(alias)
 
         # connection already established
         try:
@@ -110,6 +110,16 @@ class Connections:
         except KeyError:
             # no connection and no kwargs to set one up
             raise KeyError(f"There is no connection with alias {alias!r}.")
+
+    def _with_user_agent(self, conn):
+        from . import __versionstr__  # this is here to avoid circular imports
+
+        # try to inject our user agent
+        if hasattr(conn, "options"):
+            conn = conn.options(
+                headers={"user-agent": f"elasticsearch-dsl-py/{__versionstr__}"}
+            )
+        return conn
 
 
 connections = Connections()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -189,6 +189,7 @@ async def async_write_client(write_client, async_client):
 @fixture
 def mock_client(dummy_response):
     client = Mock()
+    client.options.return_value = client
     client.search.return_value = dummy_response
     add_connection("mock", client)
 
@@ -200,6 +201,7 @@ def mock_client(dummy_response):
 @fixture
 def async_mock_client(dummy_response):
     client = Mock()
+    client.options.return_value = client
     client.search = AsyncMock(return_value=dummy_response)
     client.indices = AsyncMock()
     client.update_by_query = AsyncMock()

--- a/tests/test_connections.py
+++ b/tests/test_connections.py
@@ -25,6 +25,9 @@ class DummyElasticsearch:
     def __init__(self, *args, hosts, **kwargs):
         self.hosts = hosts
 
+    def options(self, **kwargs):
+        return self
+
 
 def test_default_connection_is_returned_by_default():
     c = connections.Connections()

--- a/tests/test_integration/test_count.py
+++ b/tests/test_integration/test_count.py
@@ -15,6 +15,7 @@
 #  specific language governing permissions and limitations
 #  under the License.
 
+from elasticsearch_dsl.connections import get_connection
 from elasticsearch_dsl.search import Q, Search
 
 
@@ -24,16 +25,17 @@ def test_count_all(data_client):
 
 
 def test_count_prefetch(data_client, mocker):
-    mocker.spy(data_client, "count")
+    client = get_connection()
+    mocker.spy(client, "count")
 
-    search = Search(using=data_client).index("git")
+    search = Search().index("git")
     search.execute()
     assert search.count() == 53
-    assert data_client.count.call_count == 0
+    assert client.count.call_count == 0
 
     search._response.hits.total.relation = "gte"
     assert search.count() == 53
-    assert data_client.count.call_count == 1
+    assert client.count.call_count == 1
 
 
 def test_count_filter(data_client):


### PR DESCRIPTION
Issues/questions
- Attempting to inject a user agent in a user provided client feels not very robust. I'm looking for an `options` method before calling it in case they give us a wrapper and not an actual client, but it can still break.
- Mock clients need a bit of extra handling, because setting the user agent requires the client to be copied:
        ```
        client = client.options(headers={"user-agent": "..."})
        ```
This causes the original mock to not get any of the calls, unless the mock is configured with an `options()` method. Should we modify clients in place, instead of making a copy?