### PR TITLE
Add Type hints to `function.py`

### DIFF
--- a/elasticsearch_dsl/function.py
+++ b/elasticsearch_dsl/function.py
@@ -17,12 +17,27 @@
 
 import collections.abc
 from copy import deepcopy
-from typing import Dict, Optional, ClassVar, Union, MutableMapping, Any
+from typing import Any, ClassVar, Dict, MutableMapping, Optional, Union, overload
 
 from .utils import DslBase, _JSONSafeTypes
 
 
-def SF(name_or_sf: Union[str, "ScoreFunction", MutableMapping[str, Any]], **params: Any) -> "ScoreFunction":
+@overload
+def SF(name_or_sf: MutableMapping[str, Any]) -> "ScoreFunction": ...
+
+
+@overload
+def SF(name_or_sf: "ScoreFunction") -> "ScoreFunction": ...
+
+
+@overload
+def SF(name_or_sf: str, **params: Any) -> "ScoreFunction": ...
+
+
+def SF(
+    name_or_sf: Union[str, "ScoreFunction", MutableMapping[str, Any]],
+    **params: Any,
+) -> "ScoreFunction":
     # {"script_score": {"script": "_score"}, "filter": {}}
     if isinstance(name_or_sf, collections.abc.MutableMapping):
         if params:

--- a/elasticsearch_dsl/function.py
+++ b/elasticsearch_dsl/function.py
@@ -19,7 +19,7 @@ import collections.abc
 from copy import deepcopy
 from typing import Any, ClassVar, Dict, MutableMapping, Optional, Union, overload
 
-from .utils import DslBase, _JSONSafeTypes
+from .utils import DslBase, JSONType
 
 
 @overload
@@ -89,7 +89,7 @@ class ScoreFunction(DslBase):
     }
     name: ClassVar[Optional[str]] = None
 
-    def to_dict(self) -> Dict[str, _JSONSafeTypes]:
+    def to_dict(self) -> Dict[str, JSONType]:
         d = super().to_dict()
         # filter and query dicts should be at the same level as us
         for k in self._param_defs:
@@ -107,7 +107,7 @@ class ScriptScore(ScoreFunction):
 class BoostFactor(ScoreFunction):
     name = "boost_factor"
 
-    def to_dict(self) -> Dict[str, _JSONSafeTypes]:
+    def to_dict(self) -> Dict[str, JSONType]:
         d = super().to_dict()
         if self.name is not None:
             val = d[self.name]

--- a/elasticsearch_dsl/function.py
+++ b/elasticsearch_dsl/function.py
@@ -16,7 +16,7 @@
 #  under the License.
 
 import collections.abc
-from typing import Dict
+from typing import Dict, Optional, ClassVar
 
 from .utils import DslBase
 
@@ -70,7 +70,7 @@ class ScoreFunction(DslBase):
         "filter": {"type": "query"},
         "weight": {},
     }
-    name = None
+    name: ClassVar[Optional[str]] = None
 
     def to_dict(self):
         d = super().to_dict()

--- a/elasticsearch_dsl/utils.py
+++ b/elasticsearch_dsl/utils.py
@@ -18,11 +18,13 @@
 
 import collections.abc
 from copy import copy
-from typing import Any, Dict, Optional, Type, ClassVar, Union
+from typing import Any, Dict, Optional, Type, ClassVar, Union, List
 
 from typing_extensions import Self
 
 from .exceptions import UnknownDslObject, ValidationException
+
+_JSONSafeTypes = Union[int, bool, str, float, List["_JSONSafeTypes"], Dict[str, "_JSONSafeTypes"]]
 
 SKIP_VALUES = ("", None)
 EXPAND__TO_DOT = True
@@ -356,8 +358,7 @@ class DslBase(metaclass=DslMeta):
             return AttrDict(value)
         return value
 
-    # TODO: This type annotation can probably be made tighter
-    def to_dict(self) -> Dict[str, Dict[str, Any]]:
+    def to_dict(self) -> Dict[str, _JSONSafeTypes]:
         """
         Serialize the DSL object to plain dict
         """

--- a/elasticsearch_dsl/utils.py
+++ b/elasticsearch_dsl/utils.py
@@ -18,13 +18,15 @@
 
 import collections.abc
 from copy import copy
-from typing import Any, Dict, Optional, Type, ClassVar, Union, List
+from typing import Any, ClassVar, Dict, List, Optional, Type, Union
 
 from typing_extensions import Self
 
 from .exceptions import UnknownDslObject, ValidationException
 
-_JSONSafeTypes = Union[int, bool, str, float, List["_JSONSafeTypes"], Dict[str, "_JSONSafeTypes"]]
+_JSONSafeTypes = Union[
+    int, bool, str, float, List["_JSONSafeTypes"], Dict[str, "_JSONSafeTypes"]
+]
 
 SKIP_VALUES = ("", None)
 EXPAND__TO_DOT = True
@@ -212,7 +214,7 @@ class DslMeta(type):
     For typical use see `QueryMeta` and `Query` in `elasticsearch_dsl.query`.
     """
 
-    _types: ClassVar[Dict[str, type["DslBase"]]] = {}
+    _types: ClassVar[Dict[str, Type["DslBase"]]] = {}
 
     def __init__(cls, name, bases, attrs):
         super().__init__(name, bases, attrs)

--- a/elasticsearch_dsl/utils.py
+++ b/elasticsearch_dsl/utils.py
@@ -253,6 +253,7 @@ class DslBase(metaclass=DslMeta):
           all values in the `must` attribute into Query objects)
     """
 
+    _type_name: ClassVar[str]
     _param_defs: ClassVar[Dict[str, Dict[str, Union[str, bool]]]] = {}
 
     @classmethod

--- a/elasticsearch_dsl/utils.py
+++ b/elasticsearch_dsl/utils.py
@@ -24,9 +24,7 @@ from typing_extensions import Self
 
 from .exceptions import UnknownDslObject, ValidationException
 
-JSONType = Union[
-    int, bool, str, float, List["JSONType"], Dict[str, "JSONType"]
-]
+JSONType = Union[int, bool, str, float, List["JSONType"], Dict[str, "JSONType"]]
 
 SKIP_VALUES = ("", None)
 EXPAND__TO_DOT = True

--- a/elasticsearch_dsl/utils.py
+++ b/elasticsearch_dsl/utils.py
@@ -18,7 +18,7 @@
 
 import collections.abc
 from copy import copy
-from typing import Any, Dict, Optional, Type
+from typing import Any, Dict, Optional, Type, ClassVar, Union
 
 from typing_extensions import Self
 
@@ -210,7 +210,7 @@ class DslMeta(type):
     For typical use see `QueryMeta` and `Query` in `elasticsearch_dsl.query`.
     """
 
-    _types = {}
+    _types: ClassVar[Dict[str, type["DslBase"]]] = {}
 
     def __init__(cls, name, bases, attrs):
         super().__init__(name, bases, attrs)
@@ -251,7 +251,7 @@ class DslBase(metaclass=DslMeta):
           all values in the `must` attribute into Query objects)
     """
 
-    _param_defs = {}
+    _param_defs: ClassVar[Dict[str, Dict[str, Union[str, bool]]]] = {}
 
     @classmethod
     def get_dsl_class(

--- a/elasticsearch_dsl/utils.py
+++ b/elasticsearch_dsl/utils.py
@@ -24,8 +24,8 @@ from typing_extensions import Self
 
 from .exceptions import UnknownDslObject, ValidationException
 
-_JSONSafeTypes = Union[
-    int, bool, str, float, List["_JSONSafeTypes"], Dict[str, "_JSONSafeTypes"]
+JSONType = Union[
+    int, bool, str, float, List["JSONType"], Dict[str, "JSONType"]
 ]
 
 SKIP_VALUES = ("", None)
@@ -361,7 +361,7 @@ class DslBase(metaclass=DslMeta):
             return AttrDict(value)
         return value
 
-    def to_dict(self) -> Dict[str, _JSONSafeTypes]:
+    def to_dict(self) -> Dict[str, JSONType]:
         """
         Serialize the DSL object to plain dict
         """

--- a/noxfile.py
+++ b/noxfile.py
@@ -30,6 +30,7 @@ SOURCE_FILES = (
 )
 
 TYPED_FILES = (
+    "elasticsearch_dsl/function.py",
     "elasticsearch_dsl/query.py",
     "tests/test_query.py",
 )


### PR DESCRIPTION
Continuation of #1821 (issue #1533 ).


Notable changes:

- Add `_JsonSafeTypes` in `utils.py` in an attempt to properly catch all cases in `.to_dict()` methods.
- Same `Mapping` -> `MutableMapping` and `.copy()` -> `deepcopy()` changes in `SF()` function as was done in `Q()`.
- Still having some `Any` types in kwargs and params, maybe create a new ticket to tighten these up after initial type hints are done? don't know if I can just go by the test cases and assume types not present in them are invalid, the way the functions are written it seems purposefully loose.