### PR TITLE
Added point in time support and the Search.iterate() method

### DIFF
--- a/elasticsearch_dsl/_async/search.py
+++ b/elasticsearch_dsl/_async/search.py
@@ -126,18 +126,6 @@ class AsyncSearch(SearchBase):
         configured to operate within the created pit.
 
         :arg keep_alive: the time to live for the point in time, renewed with each search request
-
-        The following example shows how to paginate through all the documents of an index::
-
-            page_size = 10
-            with Search(index="my-index")[:page_size].point_in_time() as s:
-                while True:
-                    r = s.execute()  # get a page of results
-                    // ... do something with r.hits
-
-                    if len(r.hits) < page_size:
-                        break  # we reached the end
-                    s = r.search_after()
         """
         es = get_connection(self._using)
 

--- a/elasticsearch_dsl/_async/search.py
+++ b/elasticsearch_dsl/_async/search.py
@@ -95,7 +95,7 @@ class AsyncSearch(SearchBase):
         https://elasticsearch-py.readthedocs.io/en/master/helpers.html#elasticsearch.helpers.scan
 
         The ``iterate()`` method should be preferred, as it provides similar
-        functionality using a point in time.
+        functionality using an Elasticsearch point in time.
         """
         es = get_connection(self._using)
 

--- a/elasticsearch_dsl/_sync/search.py
+++ b/elasticsearch_dsl/_sync/search.py
@@ -91,7 +91,7 @@ class Search(SearchBase):
         https://elasticsearch-py.readthedocs.io/en/master/helpers.html#elasticsearch.helpers.scan
 
         The ``iterate()`` method should be preferred, as it provides similar
-        functionality using a point in time.
+        functionality using an Elasticsearch point in time.
         """
         es = get_connection(self._using)
 
@@ -118,18 +118,6 @@ class Search(SearchBase):
         configured to operate within the created pit.
 
         :arg keep_alive: the time to live for the point in time, renewed with each search request
-
-        The following example shows how to paginate through all the documents of an index::
-
-            page_size = 10
-            with Search(index="my-index")[:page_size].point_in_time() as s:
-                while True:
-                    r = s.execute()  # get a page of results
-                    // ... do something with r.hits
-
-                    if len(r.hits) < page_size:
-                        break  # we reached the end
-                    s = r.search_after()
         """
         es = get_connection(self._using)
 

--- a/elasticsearch_dsl/_sync/search.py
+++ b/elasticsearch_dsl/_sync/search.py
@@ -15,6 +15,8 @@
 #  specific language governing permissions and limitations
 #  under the License.
 
+import contextlib
+
 from elasticsearch.exceptions import ApiError
 from elasticsearch.helpers import scan
 
@@ -88,6 +90,8 @@ class Search(SearchBase):
         pass to the underlying ``scan`` helper from ``elasticsearch-py`` -
         https://elasticsearch-py.readthedocs.io/en/master/helpers.html#elasticsearch.helpers.scan
 
+        The ``iterate()`` method should be preferred, as it provides similar
+        functionality using a point in time.
         """
         es = get_connection(self._using)
 
@@ -104,6 +108,55 @@ class Search(SearchBase):
         return AttrDict(
             es.delete_by_query(index=self._index, body=self.to_dict(), **self._params)
         )
+
+    @contextlib.contextmanager
+    def point_in_time(self, keep_alive="1m"):
+        """
+        Open a point in time (pit) that can be used across several searches.
+
+        This method implements a context manager that returns a search object
+        configured to operate within the created pit.
+
+        :arg keep_alive: the time to live for the point in time, renewed with each search request
+
+        The following example shows how to paginate through all the documents of an index::
+
+            page_size = 10
+            with Search(index="my-index")[:page_size].point_in_time() as s:
+                while True:
+                    r = s.execute()  # get a page of results
+                    // ... do something with r.hits
+
+                    if len(r.hits) < page_size:
+                        break  # we reached the end
+                    s = r.search_after()
+        """
+        es = get_connection(self._using)
+
+        pit = es.open_point_in_time(index=self._index or "*", keep_alive=keep_alive)
+        search = self.index().extra(pit={"id": pit["id"], "keep_alive": keep_alive})
+        if not search._sort:
+            search = search.sort("_shard_doc")
+        yield search
+        es.close_point_in_time(id=pit["id"])
+
+    def iterate(self, keep_alive="1m"):
+        """
+        Return a generator that iterates over all the documents matching the query.
+
+        This method uses a point in time to provide consistent results even when
+        the index is changing. It should be preferred over ``scan()``.
+
+        :arg keep_alive: the time to live for the point in time, renewed with each new search request
+        """
+        with self.point_in_time(keep_alive=keep_alive) as s:
+            while True:
+                r = s.execute()
+                for hit in r:
+                    yield hit
+                if len(r.hits) == 0:
+                    break
+                s = r.search_after()
 
 
 class MultiSearch(MultiSearchBase):

--- a/utils/run-unasync.py
+++ b/utils/run-unasync.py
@@ -72,6 +72,7 @@ def main(check=False):
         "async_sleep": "sleep",
         "assert_awaited_once_with": "assert_called_once_with",
         "pytest_asyncio": "pytest",
+        "asynccontextmanager": "contextmanager",
     }
     rules = [
         unasync.Rule(


### PR DESCRIPTION
This change adds two new methods to the `Search` class. The `point_in_time()` method and `iterate()`, to combine `point_in_time()` with `search_after()` to provide a better option to `scan()`.