### PR TITLE
Add type hints to wrappers.py

### DIFF
--- a/elasticsearch_dsl/utils.py
+++ b/elasticsearch_dsl/utils.py
@@ -18,13 +18,25 @@
 
 import collections.abc
 from copy import copy
-from typing import Any, ClassVar, Dict, List, Optional, Type, Union
+from typing import Any, ClassVar, Dict, Generic, List, Optional, Type, TypeVar, Union
 
-from typing_extensions import Self
+from typing_extensions import Self, TypeAlias
 
 from .exceptions import UnknownDslObject, ValidationException
 
-JSONType = Union[int, bool, str, float, List["JSONType"], Dict[str, "JSONType"]]
+# Usefull types
+
+JSONType: TypeAlias = Union[
+    int, bool, str, float, List["JSONType"], Dict[str, "JSONType"]
+]
+
+
+# Type variables for internals
+
+_KeyT = TypeVar("_KeyT")
+_ValT = TypeVar("_ValT")
+
+# Constants
 
 SKIP_VALUES = ("", None)
 EXPAND__TO_DOT = True
@@ -110,18 +122,20 @@ class AttrList:
         return self._l_
 
 
-class AttrDict:
+class AttrDict(Generic[_KeyT, _ValT]):
     """
     Helper class to provide attribute like access (read and write) to
     dictionaries. Used to provide a convenient way to access both results and
     nested dsl dicts.
     """
 
-    def __init__(self, d):
+    _d_: Dict[_KeyT, _ValT]
+
+    def __init__(self, d: Dict[_KeyT, _ValT]):
         # assign the inner dict manually to prevent __setattr__ from firing
         super().__setattr__("_d_", d)
 
-    def __contains__(self, key):
+    def __contains__(self, key: object) -> bool:
         return key in self._d_
 
     def __nonzero__(self):

--- a/elasticsearch_dsl/wrappers.py
+++ b/elasticsearch_dsl/wrappers.py
@@ -38,7 +38,7 @@ from typing_extensions import TypeAlias
 from .utils import AttrDict
 
 ComparisonOperators: TypeAlias = Literal["lt", "lte", "gt", "gte"]
-RangeValT = TypeVar("RangeValT", bound=_SupportsComparison)
+RangeValT = TypeVar("RangeValT", bound="_SupportsComparison")
 
 __all__ = ["Range"]
 
@@ -47,7 +47,7 @@ class Range(AttrDict[ComparisonOperators, RangeValT]):
     OPS: ClassVar[
         Mapping[
             ComparisonOperators,
-            Callable[[_SupportsComparison, _SupportsComparison], bool],
+            Callable[["_SupportsComparison", "_SupportsComparison"], bool],
         ]
     ] = {
         "lt": operator.lt,
@@ -97,7 +97,7 @@ class Range(AttrDict[ComparisonOperators, RangeValT]):
 
         # Cast to tell mypy whe have checked it and its ok to use the comparison methods
         # on `item`
-        item = cast(_SupportsComparison, item)
+        item = cast("_SupportsComparison", item)
 
         for op in self.OPS:
             if op in self._d_ and not self.OPS[op](item, self._d_[op]):

--- a/elasticsearch_dsl/wrappers.py
+++ b/elasticsearch_dsl/wrappers.py
@@ -67,8 +67,10 @@ class Range(AttrDict[ComparisonOperators, RangeValT]):
                 "Range accepts a single dictionary or a set of keyword arguments."
             )
 
-        # Cast here since mypy is inferring d as an `object` type for some reason
-        data = cast(Dict[str, RangeValT], d) if d is not None else kwargs
+        if d is None:
+            data = cast(Dict[ComparisonOperators, RangeValT], kwargs)
+        else:
+            data = d
 
         for k in data:
             if k not in self.OPS:
@@ -80,9 +82,7 @@ class Range(AttrDict[ComparisonOperators, RangeValT]):
         if "lt" in data and "lte" in data:
             raise ValueError("You cannot specify both lt and lte for Range.")
 
-        # Here we use cast() since we now the keys are in the allowed values, but mypy does
-        # not infer it.
-        super().__init__(cast(Dict[ComparisonOperators, RangeValT], data))
+        super().__init__(data)
 
     def __repr__(self) -> str:
         return "Range(%s)" % ", ".join("%s=%r" % op for op in self._d_.items())
@@ -95,12 +95,8 @@ class Range(AttrDict[ComparisonOperators, RangeValT]):
         if not item_supports_comp:
             return False
 
-        # Cast to tell mypy whe have checked it and its ok to use the comparison methods
-        # on `item`
-        item = cast("_SupportsComparison", item)
-
         for op in self.OPS:
-            if op in self._d_ and not self.OPS[op](item, self._d_[op]):
+            if op in self._d_ and not self.OPS[op](cast("_SupportsComparison", item), self._d_[op]):
                 return False
         return True
 

--- a/elasticsearch_dsl/wrappers.py
+++ b/elasticsearch_dsl/wrappers.py
@@ -17,56 +17,37 @@
 
 import operator
 from typing import (
-    Any,
+    TYPE_CHECKING,
     Callable,
     ClassVar,
     Dict,
     Literal,
     Mapping,
     Optional,
-    Protocol,
     Tuple,
     TypeVar,
     Union,
     cast,
 )
 
+if TYPE_CHECKING:
+    from _operator import _SupportsComparison
+
 from typing_extensions import TypeAlias
 
 from .utils import AttrDict
 
-
-class SupportsDunderLT(Protocol):
-    def __lt__(self, other: Any, /) -> Any: ...
-
-
-class SupportsDunderGT(Protocol):
-    def __gt__(self, other: Any, /) -> Any: ...
-
-
-class SupportsDunderLE(Protocol):
-    def __le__(self, other: Any, /) -> Any: ...
-
-
-class SupportsDunderGE(Protocol):
-    def __ge__(self, other: Any, /) -> Any: ...
-
-
-SupportsComparison: TypeAlias = Union[
-    SupportsDunderLE, SupportsDunderGE, SupportsDunderGT, SupportsDunderLT
-]
-
 ComparisonOperators: TypeAlias = Literal["lt", "lte", "gt", "gte"]
-RangeValT = TypeVar("RangeValT", bound=SupportsComparison)
+RangeValT = TypeVar("RangeValT", bound=_SupportsComparison)
 
-__all__ = ["Range", "SupportsComparison"]
+__all__ = ["Range"]
 
 
 class Range(AttrDict[ComparisonOperators, RangeValT]):
     OPS: ClassVar[
         Mapping[
             ComparisonOperators,
-            Callable[[SupportsComparison, SupportsComparison], bool],
+            Callable[[_SupportsComparison, _SupportsComparison], bool],
         ]
     ] = {
         "lt": operator.lt,
@@ -116,7 +97,7 @@ class Range(AttrDict[ComparisonOperators, RangeValT]):
 
         # Cast to tell mypy whe have checked it and its ok to use the comparison methods
         # on `item`
-        item = cast(SupportsComparison, item)
+        item = cast(_SupportsComparison, item)
 
         for op in self.OPS:
             if op in self._d_ and not self.OPS[op](item, self._d_[op]):

--- a/elasticsearch_dsl/wrappers.py
+++ b/elasticsearch_dsl/wrappers.py
@@ -96,7 +96,9 @@ class Range(AttrDict[ComparisonOperators, RangeValT]):
             return False
 
         for op in self.OPS:
-            if op in self._d_ and not self.OPS[op](cast("_SupportsComparison", item), self._d_[op]):
+            if op in self._d_ and not self.OPS[op](
+                cast("_SupportsComparison", item), self._d_[op]
+            ):
                 return False
         return True
 

--- a/noxfile.py
+++ b/noxfile.py
@@ -32,7 +32,9 @@ SOURCE_FILES = (
 TYPED_FILES = (
     "elasticsearch_dsl/function.py",
     "elasticsearch_dsl/query.py",
+    "elasticsearch_dsl/wrappers.py",
     "tests/test_query.py",
+    "tests/test_wrappers.py",
 )
 
 

--- a/tests/test_wrappers.py
+++ b/tests/test_wrappers.py
@@ -16,10 +16,12 @@
 #  under the License.
 
 from datetime import datetime, timedelta
+from typing import Any, Mapping, Optional, Sequence
 
 import pytest
 
 from elasticsearch_dsl import Range
+from elasticsearch_dsl.wrappers import SupportsComparison
 
 
 @pytest.mark.parametrize(
@@ -34,7 +36,9 @@ from elasticsearch_dsl import Range
         ({"gt": datetime.now() - timedelta(seconds=10)}, datetime.now()),
     ],
 )
-def test_range_contains(kwargs, item):
+def test_range_contains(
+    kwargs: Mapping[str, SupportsComparison], item: SupportsComparison
+) -> None:
     assert item in Range(**kwargs)
 
 
@@ -48,7 +52,9 @@ def test_range_contains(kwargs, item):
         ({"lte": datetime.now() - timedelta(seconds=10)}, datetime.now()),
     ],
 )
-def test_range_not_contains(kwargs, item):
+def test_range_not_contains(
+    kwargs: Mapping[str, SupportsComparison], item: SupportsComparison
+) -> None:
     assert item not in Range(**kwargs)
 
 
@@ -62,7 +68,9 @@ def test_range_not_contains(kwargs, item):
         ((), {"gt": 1, "gte": 1}),
     ],
 )
-def test_range_raises_value_error_on_wrong_params(args, kwargs):
+def test_range_raises_value_error_on_wrong_params(
+    args: Sequence[Any], kwargs: Mapping[str, SupportsComparison]
+) -> None:
     with pytest.raises(ValueError):
         Range(*args, **kwargs)
 
@@ -76,7 +84,11 @@ def test_range_raises_value_error_on_wrong_params(args, kwargs):
         (Range(lt=42), None, False),
     ],
 )
-def test_range_lower(range, lower, inclusive):
+def test_range_lower(
+    range: Range[SupportsComparison],
+    lower: Optional[SupportsComparison],
+    inclusive: bool,
+) -> None:
     assert (lower, inclusive) == range.lower
 
 
@@ -89,5 +101,9 @@ def test_range_lower(range, lower, inclusive):
         (Range(gt=42), None, False),
     ],
 )
-def test_range_upper(range, upper, inclusive):
+def test_range_upper(
+    range: Range[SupportsComparison],
+    upper: Optional[SupportsComparison],
+    inclusive: bool,
+) -> None:
     assert (upper, inclusive) == range.upper

--- a/tests/test_wrappers.py
+++ b/tests/test_wrappers.py
@@ -16,12 +16,14 @@
 #  under the License.
 
 from datetime import datetime, timedelta
-from typing import Any, Mapping, Optional, Sequence
+from typing import TYPE_CHECKING, Any, Mapping, Optional, Sequence
+
+if TYPE_CHECKING:
+    from _operator import _SupportsComparison
 
 import pytest
 
 from elasticsearch_dsl import Range
-from elasticsearch_dsl.wrappers import SupportsComparison
 
 
 @pytest.mark.parametrize(
@@ -37,7 +39,7 @@ from elasticsearch_dsl.wrappers import SupportsComparison
     ],
 )
 def test_range_contains(
-    kwargs: Mapping[str, SupportsComparison], item: SupportsComparison
+    kwargs: Mapping[str, _SupportsComparison], item: _SupportsComparison
 ) -> None:
     assert item in Range(**kwargs)
 
@@ -53,7 +55,7 @@ def test_range_contains(
     ],
 )
 def test_range_not_contains(
-    kwargs: Mapping[str, SupportsComparison], item: SupportsComparison
+    kwargs: Mapping[str, _SupportsComparison], item: _SupportsComparison
 ) -> None:
     assert item not in Range(**kwargs)
 
@@ -69,7 +71,7 @@ def test_range_not_contains(
     ],
 )
 def test_range_raises_value_error_on_wrong_params(
-    args: Sequence[Any], kwargs: Mapping[str, SupportsComparison]
+    args: Sequence[Any], kwargs: Mapping[str, _SupportsComparison]
 ) -> None:
     with pytest.raises(ValueError):
         Range(*args, **kwargs)
@@ -85,8 +87,8 @@ def test_range_raises_value_error_on_wrong_params(
     ],
 )
 def test_range_lower(
-    range: Range[SupportsComparison],
-    lower: Optional[SupportsComparison],
+    range: Range[_SupportsComparison],
+    lower: Optional[_SupportsComparison],
     inclusive: bool,
 ) -> None:
     assert (lower, inclusive) == range.lower
@@ -102,8 +104,8 @@ def test_range_lower(
     ],
 )
 def test_range_upper(
-    range: Range[SupportsComparison],
-    upper: Optional[SupportsComparison],
+    range: Range[_SupportsComparison],
+    upper: Optional[_SupportsComparison],
     inclusive: bool,
 ) -> None:
     assert (upper, inclusive) == range.upper

--- a/tests/test_wrappers.py
+++ b/tests/test_wrappers.py
@@ -39,7 +39,7 @@ from elasticsearch_dsl import Range
     ],
 )
 def test_range_contains(
-    kwargs: Mapping[str, _SupportsComparison], item: _SupportsComparison
+    kwargs: Mapping[str, "_SupportsComparison"], item: "_SupportsComparison"
 ) -> None:
     assert item in Range(**kwargs)
 
@@ -55,7 +55,7 @@ def test_range_contains(
     ],
 )
 def test_range_not_contains(
-    kwargs: Mapping[str, _SupportsComparison], item: _SupportsComparison
+    kwargs: Mapping[str, "_SupportsComparison"], item: "_SupportsComparison"
 ) -> None:
     assert item not in Range(**kwargs)
 
@@ -71,7 +71,7 @@ def test_range_not_contains(
     ],
 )
 def test_range_raises_value_error_on_wrong_params(
-    args: Sequence[Any], kwargs: Mapping[str, _SupportsComparison]
+    args: Sequence[Any], kwargs: Mapping[str, "_SupportsComparison"]
 ) -> None:
     with pytest.raises(ValueError):
         Range(*args, **kwargs)
@@ -87,8 +87,8 @@ def test_range_raises_value_error_on_wrong_params(
     ],
 )
 def test_range_lower(
-    range: Range[_SupportsComparison],
-    lower: Optional[_SupportsComparison],
+    range: Range["_SupportsComparison"],
+    lower: Optional["_SupportsComparison"],
     inclusive: bool,
 ) -> None:
     assert (lower, inclusive) == range.lower
@@ -104,8 +104,8 @@ def test_range_lower(
     ],
 )
 def test_range_upper(
-    range: Range[_SupportsComparison],
-    upper: Optional[_SupportsComparison],
+    range: Range["_SupportsComparison"],
+    upper: Optional["_SupportsComparison"],
     inclusive: bool,
 ) -> None:
     assert (upper, inclusive) == range.upper


### PR DESCRIPTION
Adds type hints to `wrappers.py` and starts to add typing to `utils.AttrDict`. Continuation of #1533 

This one is more complex then previous typing MRs, so I'm open to suggestions. The main points are:

- The definition of the `SupportsComparison` TypeAlias to ensure that the operators in Range can be compared. This could posibly be avoided by utilizing the  [typeshed](https://github.com/python/typeshed) library, but at this point it seems like overkill to add it as a development dependency for only these 4/5 types.

- The use of `cast` in some instances where I needed to convey information to mypy that can be easily verified by the code validations, but it's not inferred by the type-checking. I feel that is the cleaner solution and feel that the 3 cases where it's used are justifiable.

Leave it up to you to decide on these matters due to lacking the context on how the project maintainers feel about these kind of issues.