### PR TITLE
Use Python types to declare document fields

### DIFF
--- a/docs/persistence.rst
+++ b/docs/persistence.rst
@@ -186,10 +186,10 @@ can be added to a field to convert it to an array, similar to using the
 ``multi=True`` argument on the field object.
 
 When using type hints as above, subclasses of ``Document`` and ``InnerDoc``
-inherit some of the behaviors associated with Python dataclasses. If
-necessary, the ``mapped_field()`` wrapper can be used on the right side of a
-typed field declaration, enabling dataclass options such as ``default`` or
-``default_factory`` to be included:
+inherit some of the behaviors associated with Python dataclasses. To add
+per-field dataclass options such as ``default`` or ``default_factory`` , the
+``mapped_field()`` wrapper can be used on the right side of a typed field
+declaration:
 
 .. code:: python
 

--- a/docs/persistence.rst
+++ b/docs/persistence.rst
@@ -145,15 +145,24 @@ following table:
      - ``Date(required=True)``
    * - ``date``
      - ``Date(format="yyyy-MM-dd", required=True)``
-   * - ``InnerDocSubclass``
-     - ``Object(InnerDocSubclass)``
-   * - ``List(InnerDocSubclass)``
-     - ``Nested(InnerDocSubclass)``
 
-As noted in the last two rows of the table, a field can also be given a type
-hint of an ``InnerDoc`` subclass, in which case it becomes an ``Object`` field
-of that class. When the ``InnerDoc`` subclass is wrapped with ``List``, a
-``Nested`` field is created instead.
+To type a field as optional, the standard ``Optional`` modifier from the Python
+``typing`` package can be used. The ``List`` modifier can be added to a field
+to convert it to an array, similar to using the ``multi=True`` argument on the
+field object.
+
+.. code:: python
+
+    from typing import Optional, List
+
+    class MyDoc(Document):
+        pub_date: Optional[datetime]  # same as pub_date = Date()
+        authors: List[str]            # same as authors = Text(multi=True, required=True)
+        comments: Optional[List[str]] # same as comments = Text(multi=True)
+
+A field can also be given a type hint of an ``InnerDoc`` subclass, in which
+case it becomes an ``Object`` field of that class. When the ``InnerDoc``
+subclass is wrapped with ``List``, a ``Nested`` field is created instead.
 
 .. code:: python
 
@@ -166,33 +175,29 @@ of that class. When the ``InnerDoc`` subclass is wrapped with ``List``, a
         ...
     
     class Post(Document):
-        address: Address         # same as address = Object(Address)
-        comments: List[Comment]  # same as comments = Nested(Comment)
+        address: Address         # same as address = Object(Address, required=True)
+        comments: List[Comment]  # same as comments = Nested(Comment, required=True)
 
 Unfortunately it is impossible to have Python type hints that uniquely
 identify every possible Elasticsearch field type. To choose a field type that
 is different than the ones in the table above, the field instance can be added
 explicitly as a right-side assignment in the field declaration. The next
-example creates a field that is typed as ``str``, but is mapped to ``Keyword``
-instead of ``Text``:
+example creates a field that is typed as ``Optional[str]``, but is mapped to
+``Keyword`` instead of ``Text``:
 
 .. code:: python
 
     class MyDocument(Document):
-        category: str = Keyword(required=True)
+        category: Optional[str] = Keyword()
 
 This form can also be used when additional options need to be given to
-initialize the field, such as when using custom analyzer settings:
+initialize the field, such as when using custom analyzer settings or changing
+the ``required`` default:
 
 .. code:: python
 
     class Comment(InnerDoc):
         content: str = Text(analyzer='snowball', required=True)
-
-The standard ``Optional`` modifier from the Python ``typing`` package can be
-used to change a typed field from required to optional. The ``List`` modifier
-can be added to a field to convert it to an array, similar to using the
-``multi=True`` argument on the field object.
 
 When using type hints as above, subclasses of ``Document`` and ``InnerDoc``
 inherit some of the behaviors associated with Python dataclasses, as defined by

--- a/elasticsearch_dsl/__init__.py
+++ b/elasticsearch_dsl/__init__.py
@@ -19,7 +19,7 @@ from . import connections
 from .aggs import A
 from .analysis import analyzer, char_filter, normalizer, token_filter, tokenizer
 from .document import AsyncDocument, Document
-from .document_base import InnerDoc, MetaField
+from .document_base import InnerDoc, M, MetaField, mapped_field
 from .exceptions import (
     ElasticsearchDslException,
     IllegalOperation,
@@ -148,6 +148,7 @@ __all__ = [
     "Keyword",
     "Long",
     "LongRange",
+    "M",
     "Mapping",
     "MetaField",
     "MultiSearch",
@@ -178,6 +179,7 @@ __all__ = [
     "char_filter",
     "connections",
     "construct_field",
+    "mapped_field",
     "normalizer",
     "token_filter",
     "tokenizer",

--- a/elasticsearch_dsl/_async/document.py
+++ b/elasticsearch_dsl/_async/document.py
@@ -18,10 +18,11 @@
 import collections.abc
 
 from elasticsearch.exceptions import NotFoundError, RequestError
+from typing_extensions import dataclass_transform
 
 from .._async.index import AsyncIndex
 from ..async_connections import get_connection
-from ..document_base import DocumentBase, DocumentMeta
+from ..document_base import DocumentBase, DocumentMeta, mapped_field
 from ..exceptions import IllegalOperation
 from ..utils import DOC_META_FIELDS, META_FIELDS, merge
 from .search import AsyncSearch
@@ -62,6 +63,7 @@ class AsyncIndexMeta(DocumentMeta):
         return i
 
 
+@dataclass_transform(field_specifiers=(mapped_field,))
 class AsyncDocument(DocumentBase, metaclass=AsyncIndexMeta):
     """
     Model-like class for persisting documents in elasticsearch.

--- a/elasticsearch_dsl/_sync/document.py
+++ b/elasticsearch_dsl/_sync/document.py
@@ -18,10 +18,11 @@
 import collections.abc
 
 from elasticsearch.exceptions import NotFoundError, RequestError
+from typing_extensions import dataclass_transform
 
 from .._sync.index import Index
 from ..connections import get_connection
-from ..document_base import DocumentBase, DocumentMeta
+from ..document_base import DocumentBase, DocumentMeta, mapped_field
 from ..exceptions import IllegalOperation
 from ..utils import DOC_META_FIELDS, META_FIELDS, merge
 from .search import Search
@@ -60,6 +61,7 @@ class IndexMeta(DocumentMeta):
         return i
 
 
+@dataclass_transform(field_specifiers=(mapped_field,))
 class Document(DocumentBase, metaclass=IndexMeta):
     """
     Model-like class for persisting documents in elasticsearch.

--- a/elasticsearch_dsl/document_base.py
+++ b/elasticsearch_dsl/document_base.py
@@ -197,7 +197,6 @@ class DocumentOptions:
                     # object or nested field
                     field = Nested if multi else Object
                     field_args = [type_]
-                    required = False
                 elif type_ in self.type_annotation_map:
                     # use best field type for the type hint provided
                     field, field_kwargs = self.type_annotation_map[type_]

--- a/elasticsearch_dsl/document_base.py
+++ b/elasticsearch_dsl/document_base.py
@@ -62,14 +62,16 @@ class InstrumentedField:
         self._field = field
 
     def __getattr__(self, attr):
-        f = None
         try:
-            f = self._field[attr]
-        except KeyError:
-            pass
-        if isinstance(f, Field):
-            return InstrumentedField(f"{self._name}.{attr}", f)
-        return getattr(self._field, attr)
+            # first let's see if this is an attribute of this object
+            return super().__getattribute__(attr)
+        except AttributeError:
+            try:
+                # next we see if we have a sub-field with this name
+                return InstrumentedField(f"{self._name}.{attr}", self._field[attr])
+            except KeyError:
+                # lastly we let the wrapped field resolve this attribute
+                return getattr(self._field, attr)
 
     def __pos__(self):
         """Return the field name representation for ascending sort order"""

--- a/elasticsearch_dsl/document_base.py
+++ b/elasticsearch_dsl/document_base.py
@@ -45,7 +45,7 @@ class MetaField:
 class InstrumentedField:
     """Proxy object for a mapped document field.
 
-    An object of this instance is returned when a field is access as a class
+    An object of this instance is returned when a field is accessed as a class
     attribute of a ``Document`` or ``InnerDoc`` subclass. These objects can
     be used in any situation in which a reference to a field is required, such
     as when specifying sort options in a search::

--- a/elasticsearch_dsl/field.py
+++ b/elasticsearch_dsl/field.py
@@ -123,25 +123,6 @@ class Field(DslBase):
         return value
 
 
-class InstrumentedField:
-    def __init__(self, name, field):
-        self._name = name
-        self._field = field
-
-    def __getattr__(self, attr):
-        f = None
-        try:
-            f = self._field[attr]
-        except KeyError:
-            pass
-        if isinstance(f, Field):
-            return InstrumentedField(f"{self._name}.{attr}", f)
-        return getattr(self._field, attr)
-
-    def __repr__(self):
-        return self._name
-
-
 class CustomField(Field):
     name = "custom"
     _coerce = True

--- a/elasticsearch_dsl/field.py
+++ b/elasticsearch_dsl/field.py
@@ -77,6 +77,8 @@ class Field(DslBase):
         """
         self._multi = multi
         self._required = required
+        self._name = None
+        self._parent = None
         super().__init__(*args, **kwargs)
 
     def __getitem__(self, subfield):
@@ -121,6 +123,25 @@ class Field(DslBase):
         name, value = d.popitem()
         value["type"] = name
         return value
+
+
+class InstrumentedField:
+    def __init__(self, name, field):
+        self._name = name
+        self._field = field
+
+    def __getattr__(self, attr):
+        f = None
+        try:
+            f = self._field[attr]
+        except KeyError:
+            pass
+        if isinstance(f, Field):
+            return InstrumentedField(f"{self._name}.{attr}", f)
+        return getattr(self._field, attr)
+
+    def __repr__(self):
+        return self._name
 
 
 class CustomField(Field):

--- a/elasticsearch_dsl/field.py
+++ b/elasticsearch_dsl/field.py
@@ -77,8 +77,6 @@ class Field(DslBase):
         """
         self._multi = multi
         self._required = required
-        self._name = None
-        self._parent = None
         super().__init__(*args, **kwargs)
 
     def __getitem__(self, subfield):

--- a/elasticsearch_dsl/utils.py
+++ b/elasticsearch_dsl/utils.py
@@ -499,6 +499,12 @@ class ObjectBase(AttrDict):
                 return value
             raise
 
+    def __setattr__(self, name, value):
+        if name in self.__class__._doc_type.mapping:
+            self._d_[name] = value
+        else:
+            super().__setattr__(name, value)
+
     def to_dict(self, skip_empty=True):
         out = {}
         for k, v in self._d_.items():

--- a/elasticsearch_dsl/utils.py
+++ b/elasticsearch_dsl/utils.py
@@ -427,6 +427,15 @@ class ObjectBase(AttrDict):
 
         super(AttrDict, self).__setattr__("meta", HitMeta(meta))
 
+        # process field defaults
+        if hasattr(self, "_defaults"):
+            for name in self._defaults:
+                if name not in kwargs:
+                    value = self._defaults[name]
+                    if callable(value):
+                        value = value()
+                    kwargs[name] = value
+
         super().__init__(kwargs)
 
     @classmethod

--- a/examples/async/vectors.py
+++ b/examples/async/vectors.py
@@ -47,6 +47,8 @@ import argparse
 import asyncio
 import json
 import os
+from datetime import datetime
+from typing import List, Optional
 from urllib.request import urlopen
 
 import nltk
@@ -55,12 +57,10 @@ from tqdm import tqdm
 
 from elasticsearch_dsl import (
     AsyncDocument,
-    Date,
     DenseVector,
     InnerDoc,
     Keyword,
-    Nested,
-    Text,
+    M,
     async_connections,
 )
 
@@ -72,22 +72,22 @@ nltk.download("punkt", quiet=True)
 
 
 class Passage(InnerDoc):
-    content = Text()
-    embedding = DenseVector()
+    content: M[str]
+    embedding: M[DenseVector]
 
 
 class WorkplaceDoc(AsyncDocument):
     class Index:
         name = "workplace_documents"
 
-    name = Text()
-    summary = Text()
-    content = Text()
-    created = Date()
-    updated = Date()
-    url = Keyword()
-    category = Keyword()
-    passages = Nested(Passage)
+    name: M[str]
+    summary: M[str]
+    content: M[str]
+    created: M[datetime]
+    updated: M[Optional[datetime]]
+    url: M[Keyword]
+    category: M[Keyword]
+    passages: M[Optional[List[Passage]]]
 
     _model = None
 

--- a/examples/async/vectors.py
+++ b/examples/async/vectors.py
@@ -133,7 +133,7 @@ async def create():
 
 async def search(query):
     return WorkplaceDoc.search().knn(
-        field="passages.embedding",
+        field=WorkplaceDoc.passages.embedding,
         k=5,
         num_candidates=50,
         query_vector=list(WorkplaceDoc.get_embedding(query)),

--- a/examples/async/vectors.py
+++ b/examples/async/vectors.py
@@ -86,9 +86,9 @@ class WorkplaceDoc(AsyncDocument):
     content: M[str]
     created: M[datetime]
     updated: M[Optional[datetime]]
-    url: M[str] = mapped_field(Keyword())
-    category: M[str] = mapped_field(Keyword())
-    passages: M[List[Passage]] = mapped_field(default=[])
+    url: M[str] = mapped_field(Keyword(required=True))
+    category: M[str] = mapped_field(Keyword(required=True))
+    passages: M[Optional[List[Passage]]] = mapped_field(default=[])
 
     _model = None
 

--- a/examples/async/vectors.py
+++ b/examples/async/vectors.py
@@ -96,7 +96,7 @@ class WorkplaceDoc(AsyncDocument):
     def get_embedding(cls, input: str) -> List[float]:
         if cls._model is None:
             cls._model = SentenceTransformer(MODEL_NAME)
-        return cast(List[float], cls._model.encode(input))
+        return cast(List[float], list(cls._model.encode(input)))
 
     def clean(self):
         # split the content into sentences

--- a/examples/vectors.py
+++ b/examples/vectors.py
@@ -132,7 +132,7 @@ def create():
 
 def search(query):
     return WorkplaceDoc.search().knn(
-        field="passages.embedding",
+        field=WorkplaceDoc.passages.embedding,
         k=5,
         num_candidates=50,
         query_vector=list(WorkplaceDoc.get_embedding(query)),

--- a/examples/vectors.py
+++ b/examples/vectors.py
@@ -85,9 +85,9 @@ class WorkplaceDoc(Document):
     content: M[str]
     created: M[datetime]
     updated: M[Optional[datetime]]
-    url: M[str] = mapped_field(Keyword())
-    category: M[str] = mapped_field(Keyword())
-    passages: M[List[Passage]] = mapped_field(default=[])
+    url: M[str] = mapped_field(Keyword(required=True))
+    category: M[str] = mapped_field(Keyword(required=True))
+    passages: M[Optional[List[Passage]]] = mapped_field(default=[])
 
     _model = None
 

--- a/examples/vectors.py
+++ b/examples/vectors.py
@@ -46,22 +46,15 @@ command to see individual passage results as well.
 import argparse
 import json
 import os
+from datetime import datetime
+from typing import List, Optional
 from urllib.request import urlopen
 
 import nltk
 from sentence_transformers import SentenceTransformer
 from tqdm import tqdm
 
-from elasticsearch_dsl import (
-    Date,
-    DenseVector,
-    Document,
-    InnerDoc,
-    Keyword,
-    Nested,
-    Text,
-    connections,
-)
+from elasticsearch_dsl import DenseVector, Document, InnerDoc, Keyword, M, connections
 
 DATASET_URL = "https://raw.githubusercontent.com/elastic/elasticsearch-labs/main/datasets/workplace-documents.json"
 MODEL_NAME = "all-MiniLM-L6-v2"
@@ -71,22 +64,22 @@ nltk.download("punkt", quiet=True)
 
 
 class Passage(InnerDoc):
-    content = Text()
-    embedding = DenseVector()
+    content: M[str]
+    embedding: M[DenseVector]
 
 
 class WorkplaceDoc(Document):
     class Index:
         name = "workplace_documents"
 
-    name = Text()
-    summary = Text()
-    content = Text()
-    created = Date()
-    updated = Date()
-    url = Keyword()
-    category = Keyword()
-    passages = Nested(Passage)
+    name: M[str]
+    summary: M[str]
+    content: M[str]
+    created: M[datetime]
+    updated: M[Optional[datetime]]
+    url: M[Keyword]
+    category: M[Keyword]
+    passages: M[Optional[List[Passage]]]
 
     _model = None
 

--- a/examples/vectors.py
+++ b/examples/vectors.py
@@ -95,7 +95,7 @@ class WorkplaceDoc(Document):
     def get_embedding(cls, input: str) -> List[float]:
         if cls._model is None:
             cls._model = SentenceTransformer(MODEL_NAME)
-        return cast(List[float], cls._model.encode(input))
+        return cast(List[float], list(cls._model.encode(input)))
 
     def clean(self):
         # split the content into sentences

--- a/examples/vectors.py
+++ b/examples/vectors.py
@@ -47,14 +47,22 @@ import argparse
 import json
 import os
 from datetime import datetime
-from typing import List, Optional
+from typing import List, Optional, cast
 from urllib.request import urlopen
 
 import nltk
 from sentence_transformers import SentenceTransformer
 from tqdm import tqdm
 
-from elasticsearch_dsl import DenseVector, Document, InnerDoc, Keyword, M, connections
+from elasticsearch_dsl import (
+    DenseVector,
+    Document,
+    InnerDoc,
+    Keyword,
+    M,
+    connections,
+    mapped_field,
+)
 
 DATASET_URL = "https://raw.githubusercontent.com/elastic/elasticsearch-labs/main/datasets/workplace-documents.json"
 MODEL_NAME = "all-MiniLM-L6-v2"
@@ -65,7 +73,7 @@ nltk.download("punkt", quiet=True)
 
 class Passage(InnerDoc):
     content: M[str]
-    embedding: M[DenseVector]
+    embedding: M[List[float]] = mapped_field(DenseVector())
 
 
 class WorkplaceDoc(Document):
@@ -77,32 +85,30 @@ class WorkplaceDoc(Document):
     content: M[str]
     created: M[datetime]
     updated: M[Optional[datetime]]
-    url: M[Keyword]
-    category: M[Keyword]
-    passages: M[Optional[List[Passage]]]
+    url: M[str] = mapped_field(Keyword())
+    category: M[str] = mapped_field(Keyword())
+    passages: M[List[Passage]] = mapped_field(default=[])
 
     _model = None
 
     @classmethod
-    def get_embedding_model(cls):
+    def get_embedding(cls, input: str) -> List[float]:
         if cls._model is None:
             cls._model = SentenceTransformer(MODEL_NAME)
-        return cls._model
+        return cast(List[float], cls._model.encode(input))
 
     def clean(self):
         # split the content into sentences
         passages = nltk.sent_tokenize(self.content)
 
         # generate an embedding for each passage and save it as a nested document
-        model = self.get_embedding_model()
         for passage in passages:
             self.passages.append(
-                Passage(content=passage, embedding=list(model.encode(passage)))
+                Passage(content=passage, embedding=self.get_embedding(passage))
             )
 
 
 def create():
-
     # create the index
     WorkplaceDoc._index.delete(ignore_unavailable=True)
     WorkplaceDoc.init()
@@ -125,12 +131,11 @@ def create():
 
 
 def search(query):
-    model = WorkplaceDoc.get_embedding_model()
     return WorkplaceDoc.search().knn(
         field="passages.embedding",
         k=5,
         num_candidates=50,
-        query_vector=list(model.encode(query)),
+        query_vector=list(WorkplaceDoc.get_embedding(query)),
         inner_hits={"size": 2},
     )
 

--- a/mypy.ini
+++ b/mypy.ini
@@ -1,3 +1,6 @@
+[mypy]
+explicit_package_bases = True
+
 [mypy-elasticsearch_dsl.query]
 # Allow reexport of SF for tests
 implicit_reexport = True

--- a/noxfile.py
+++ b/noxfile.py
@@ -89,7 +89,7 @@ def type_check(session):
     session.install("mypy", ".[develop]")
     errors = []
     popen = subprocess.Popen(
-        "mypy --strict elasticsearch_dsl tests",
+        "mypy --strict elasticsearch_dsl tests examples",
         env=session.env,
         shell=True,
         stdout=subprocess.PIPE,

--- a/tests/_async/test_document.py
+++ b/tests/_async/test_document.py
@@ -656,8 +656,8 @@ def test_doc_with_type_hints():
         st: str
         dt: Optional[datetime]
         li: List[int]
-        ob: TypedInnerDoc
-        ns: List[TypedInnerDoc]
+        ob: Optional[TypedInnerDoc]
+        ns: Optional[List[TypedInnerDoc]]
         ip: Optional[str] = field.Ip()
         k1: str = field.Keyword(required=True)
         k2: M[str] = field.Keyword()

--- a/tests/_sync/test_document.py
+++ b/tests/_sync/test_document.py
@@ -130,29 +130,6 @@ class Host(Document):
         name = "test-host"
 
 
-class TypedInnerDoc(InnerDoc):
-    st: M[str]
-    dt: M[Optional[datetime]]
-    li: M[List[int]]
-
-
-class TypedDoc(Document):
-    st: str
-    dt: Optional[datetime]
-    li: List[int]
-    ob: TypedInnerDoc
-    ns: List[TypedInnerDoc]
-    ip: Optional[str] = field.Ip()
-    k1: str = field.Keyword(required=True)
-    k2: M[str] = field.Keyword()
-    k3: str = mapped_field(field.Keyword(), default="foo")
-    k4: M[Optional[str]] = mapped_field(field.Keyword())
-    s1: Secret = SecretField()
-    s2: M[Secret] = SecretField()
-    s3: Secret = mapped_field(SecretField())
-    s4: M[Optional[Secret]] = mapped_field(SecretField(), default_factory=lambda: "foo")
-
-
 def test_range_serializes_properly():
     class D(Document):
         lr = field.LongRange()
@@ -669,6 +646,29 @@ def test_nested_and_object_inner_doc():
 
 
 def test_doc_with_type_hints():
+    class TypedInnerDoc(InnerDoc):
+        st: M[str]
+        dt: M[Optional[datetime]]
+        li: M[List[int]]
+
+    class TypedDoc(Document):
+        st: str
+        dt: Optional[datetime]
+        li: List[int]
+        ob: TypedInnerDoc
+        ns: List[TypedInnerDoc]
+        ip: Optional[str] = field.Ip()
+        k1: str = field.Keyword(required=True)
+        k2: M[str] = field.Keyword()
+        k3: str = mapped_field(field.Keyword(), default="foo")
+        k4: M[Optional[str]] = mapped_field(field.Keyword())
+        s1: Secret = SecretField()
+        s2: M[Secret] = SecretField()
+        s3: Secret = mapped_field(SecretField())
+        s4: M[Optional[Secret]] = mapped_field(
+            SecretField(), default_factory=lambda: "foo"
+        )
+
     props = TypedDoc._doc_type.mapping.to_dict()["properties"]
     assert props == {
         "st": {"type": "text"},
@@ -752,3 +752,6 @@ def test_doc_with_type_hints():
         "k3": "foo",
         "s4": "foo",
     }
+
+    s = TypedDoc.search().sort(TypedDoc.st, -TypedDoc.dt, +TypedDoc.ob.st)
+    assert s.to_dict() == {"sort": ["st", {"dt": {"order": "desc"}}, "ob.st"]}

--- a/tests/_sync/test_document.py
+++ b/tests/_sync/test_document.py
@@ -656,8 +656,8 @@ def test_doc_with_type_hints():
         st: str
         dt: Optional[datetime]
         li: List[int]
-        ob: TypedInnerDoc
-        ns: List[TypedInnerDoc]
+        ob: Optional[TypedInnerDoc]
+        ns: Optional[List[TypedInnerDoc]]
         ip: Optional[str] = field.Ip()
         k1: str = field.Keyword(required=True)
         k2: M[str] = field.Keyword()

--- a/tests/_sync/test_document.py
+++ b/tests/_sync/test_document.py
@@ -38,6 +38,7 @@ from elasticsearch_dsl import (
     mapped_field,
     utils,
 )
+from elasticsearch_dsl.document_base import InstrumentedField
 from elasticsearch_dsl.exceptions import IllegalOperation, ValidationException
 
 
@@ -755,3 +756,64 @@ def test_doc_with_type_hints():
 
     s = TypedDoc.search().sort(TypedDoc.st, -TypedDoc.dt, +TypedDoc.ob.st)
     assert s.to_dict() == {"sort": ["st", {"dt": {"order": "desc"}}, "ob.st"]}
+
+
+def test_instrumented_field():
+    class Child(InnerDoc):
+        st: M[str]
+
+    class Doc(Document):
+        st: str
+        ob: Child
+        ns: List[Child]
+
+    doc = Doc(
+        st="foo",
+        ob=Child(st="bar"),
+        ns=[
+            Child(st="baz"),
+            Child(st="qux"),
+        ],
+    )
+
+    assert type(doc.st) is str
+    assert doc.st == "foo"
+
+    assert type(doc.ob) is Child
+    assert doc.ob.st == "bar"
+
+    assert type(doc.ns) is utils.AttrList
+    assert doc.ns[0].st == "baz"
+    assert doc.ns[1].st == "qux"
+    assert type(doc.ns[0]) is Child
+    assert type(doc.ns[1]) is Child
+
+    assert type(Doc.st) is InstrumentedField
+    assert str(Doc.st) == "st"
+    assert +Doc.st == "st"
+    assert -Doc.st == "-st"
+    assert Doc.st.to_dict() == {"type": "text"}
+    with raises(AttributeError):
+        Doc.st.something
+
+    assert type(Doc.ob) is InstrumentedField
+    assert str(Doc.ob) == "ob"
+    assert str(Doc.ob.st) == "ob.st"
+    assert +Doc.ob.st == "ob.st"
+    assert -Doc.ob.st == "-ob.st"
+    assert Doc.ob.st.to_dict() == {"type": "text"}
+    with raises(AttributeError):
+        Doc.ob.something
+    with raises(AttributeError):
+        Doc.ob.st.something
+
+    assert type(Doc.ns) is InstrumentedField
+    assert str(Doc.ns) == "ns"
+    assert str(Doc.ns.st) == "ns.st"
+    assert +Doc.ns.st == "ns.st"
+    assert -Doc.ns.st == "-ns.st"
+    assert Doc.ns.st.to_dict() == {"type": "text"}
+    with raises(AttributeError):
+        Doc.ns.something
+    with raises(AttributeError):
+        Doc.ns.st.something

--- a/tests/_sync/test_document.py
+++ b/tests/_sync/test_document.py
@@ -20,6 +20,7 @@ import ipaddress
 import pickle
 from datetime import datetime
 from hashlib import md5
+from typing import List, Optional
 
 import pytest
 from pytest import raises
@@ -28,11 +29,13 @@ from elasticsearch_dsl import (
     Document,
     Index,
     InnerDoc,
+    M,
     Mapping,
     MetaField,
     Range,
     analyzer,
     field,
+    mapped_field,
     utils,
 )
 from elasticsearch_dsl.exceptions import IllegalOperation, ValidationException
@@ -125,6 +128,29 @@ class Host(Document):
 
     class Index:
         name = "test-host"
+
+
+class TypedInnerDoc(InnerDoc):
+    st: M[str]
+    dt: M[Optional[datetime]]
+    li: M[List[int]]
+
+
+class TypedDoc(Document):
+    st: str
+    dt: Optional[datetime]
+    li: List[int]
+    ob: TypedInnerDoc
+    ns: List[TypedInnerDoc]
+    ip: Optional[str] = field.Ip()
+    k1: str = field.Keyword(required=True)
+    k2: M[str] = field.Keyword()
+    k3: str = mapped_field(field.Keyword(), default="foo")
+    k4: M[Optional[str]] = mapped_field(field.Keyword())
+    s1: Secret = SecretField()
+    s2: M[Secret] = SecretField()
+    s3: Secret = mapped_field(SecretField())
+    s4: M[Optional[Secret]] = mapped_field(SecretField(), default_factory=lambda: "foo")
 
 
 def test_range_serializes_properly():
@@ -639,4 +665,90 @@ def test_nested_and_object_inner_doc():
             "type": "nested",
         },
         "title": {"type": "keyword"},
+    }
+
+
+def test_doc_with_type_hints():
+    props = TypedDoc._doc_type.mapping.to_dict()["properties"]
+    assert props == {
+        "st": {"type": "text"},
+        "dt": {"type": "date"},
+        "li": {"type": "integer"},
+        "ob": {
+            "type": "object",
+            "properties": {
+                "st": {"type": "text"},
+                "dt": {"type": "date"},
+                "li": {"type": "integer"},
+            },
+        },
+        "ns": {
+            "type": "nested",
+            "properties": {
+                "st": {"type": "text"},
+                "dt": {"type": "date"},
+                "li": {"type": "integer"},
+            },
+        },
+        "ip": {"type": "ip"},
+        "k1": {"type": "keyword"},
+        "k2": {"type": "keyword"},
+        "k3": {"type": "keyword"},
+        "k4": {"type": "keyword"},
+        "s1": {"type": "text"},
+        "s2": {"type": "text"},
+        "s3": {"type": "text"},
+        "s4": {"type": "text"},
+    }
+
+    doc = TypedDoc()
+    assert doc.k3 == "foo"
+    assert doc.s4 == "foo"
+    with raises(ValidationException) as exc_info:
+        doc.full_clean()
+    assert set(exc_info.value.args[0].keys()) == {"st", "li", "k1"}
+
+    doc.st = "s"
+    doc.li = [1, 2, 3]
+    doc.k1 = "k"
+    doc.full_clean()
+
+    doc.ob = TypedInnerDoc()
+    with raises(ValidationException) as exc_info:
+        doc.full_clean()
+    assert set(exc_info.value.args[0].keys()) == {"ob"}
+    assert set(exc_info.value.args[0]["ob"][0].args[0].keys()) == {"st", "li"}
+
+    doc.ob.st = "s"
+    doc.ob.li = [1]
+    doc.full_clean()
+
+    doc.ns.append(TypedInnerDoc(st="s"))
+    with raises(ValidationException) as exc_info:
+        doc.full_clean()
+
+    doc.ns[0].li = [1, 2]
+    doc.full_clean()
+
+    doc.ip = "1.2.3.4"
+    n = datetime.now()
+    doc.dt = n
+    assert doc.to_dict() == {
+        "st": "s",
+        "li": [1, 2, 3],
+        "dt": n,
+        "ob": {
+            "st": "s",
+            "li": [1],
+        },
+        "ns": [
+            {
+                "st": "s",
+                "li": [1, 2],
+            }
+        ],
+        "ip": "1.2.3.4",
+        "k1": "k",
+        "k3": "foo",
+        "s4": "foo",
     }


### PR DESCRIPTION
With this change, `Document` and `InnerDoc` instances can optionally use Python type hints instead or in addition to DSL field objects, and inherit dataclass-style behaviors which allow type checkers to correctly infer types.