### PR TITLE
type hints for remaining elasticsearch_dsl classes

### DIFF
--- a/elasticsearch_dsl/_async/document.py
+++ b/elasticsearch_dsl/_async/document.py
@@ -84,7 +84,7 @@ class AsyncDocument(DocumentBase, metaclass=AsyncIndexMeta):
 
     @classmethod
     def _get_using(cls, using: Optional[AsyncUsingType] = None) -> AsyncUsingType:
-        return using or cls._index._using
+        return cast(AsyncUsingType, using or cls._index._using)
 
     @classmethod
     def _get_connection(

--- a/elasticsearch_dsl/_async/faceted_search.py
+++ b/elasticsearch_dsl/_async/faceted_search.py
@@ -15,23 +15,34 @@
 #  specific language governing permissions and limitations
 #  under the License.
 
+from typing import TYPE_CHECKING
+
 from elasticsearch_dsl.faceted_search_base import FacetedResponse, FacetedSearchBase
 
+from ..utils import _R
 from .search import AsyncSearch
 
+if TYPE_CHECKING:
+    from ..response import Response
 
-class AsyncFacetedSearch(FacetedSearchBase):
-    def search(self):
+
+class AsyncFacetedSearch(FacetedSearchBase[_R]):
+    _s: AsyncSearch[_R]
+
+    async def count(self) -> int:
+        return await self._s.count()
+
+    def search(self) -> AsyncSearch[_R]:
         """
         Returns the base Search object to which the facets are added.
 
         You can customize the query by overriding this method and returning a
         modified search object.
         """
-        s = AsyncSearch(doc_type=self.doc_types, index=self.index, using=self.using)
+        s = AsyncSearch[_R](doc_type=self.doc_types, index=self.index, using=self.using)
         return s.response_class(FacetedResponse)
 
-    async def execute(self):
+    async def execute(self) -> "Response[_R]":
         """
         Execute the search and return the response.
         """

--- a/elasticsearch_dsl/_async/index.py
+++ b/elasticsearch_dsl/_async/index.py
@@ -168,14 +168,14 @@ class AsyncIndex(IndexBase):
 
     async def create(
         self, using: Optional[AsyncUsingType] = None, **kwargs: Any
-    ) -> None:
+    ) -> "ObjectApiResponse[Any]":
         """
         Creates the index in elasticsearch.
 
         Any additional keyword arguments will be passed to
         ``Elasticsearch.indices.create`` unchanged.
         """
-        await self._get_connection(using).indices.create(
+        return await self._get_connection(using).indices.create(
             index=self._name, body=self.to_dict(), **kwargs
         )
 
@@ -185,7 +185,9 @@ class AsyncIndex(IndexBase):
         )
         return bool(state["metadata"]["indices"][self._name]["state"] == "close")
 
-    async def save(self, using: Optional[AsyncUsingType] = None) -> None:
+    async def save(
+        self, using: Optional[AsyncUsingType] = None
+    ) -> "Optional[ObjectApiResponse[Any]]":
         """
         Sync the index definition with elasticsearch, creating the index if it
         doesn't exist and updating its settings and mappings if it does.
@@ -237,7 +239,9 @@ class AsyncIndex(IndexBase):
         # exception
         mappings = body.pop("mappings", {})
         if mappings:
-            await self.put_mapping(using=using, body=mappings)
+            return await self.put_mapping(using=using, body=mappings)
+
+        return None
 
     async def analyze(
         self, using: Optional[AsyncUsingType] = None, **kwargs: Any

--- a/elasticsearch_dsl/_async/index.py
+++ b/elasticsearch_dsl/_async/index.py
@@ -15,7 +15,7 @@
 #  specific language governing permissions and limitations
 #  under the License.
 
-from typing import TYPE_CHECKING, Any, Optional
+from typing import TYPE_CHECKING, Any, Dict, Optional
 
 from typing_extensions import Self
 
@@ -29,10 +29,18 @@ from .update_by_query import AsyncUpdateByQuery
 
 if TYPE_CHECKING:
     from elastic_transport import ObjectApiResponse
+    from elasticsearch import AsyncElasticsearch
 
 
 class AsyncIndexTemplate:
-    def __init__(self, name, template, index=None, order=None, **kwargs):
+    def __init__(
+        self,
+        name: str,
+        template: str,
+        index: Optional["AsyncIndex"] = None,
+        order: Optional[str] = None,
+        **kwargs: Any,
+    ):
         if index is None:
             self._index = AsyncIndex(template, **kwargs)
         else:
@@ -46,17 +54,19 @@ class AsyncIndexTemplate:
         self._template_name = name
         self.order = order
 
-    def __getattr__(self, attr_name):
+    def __getattr__(self, attr_name: str) -> Any:
         return getattr(self._index, attr_name)
 
-    def to_dict(self):
+    def to_dict(self) -> Dict[str, Any]:
         d = self._index.to_dict()
         d["index_patterns"] = [self._index._name]
         if self.order is not None:
             d["order"] = self.order
         return d
 
-    async def save(self, using=None):
+    async def save(
+        self, using: Optional[AsyncUsingType] = None
+    ) -> "ObjectApiResponse[Any]":
         es = get_connection(using or self._index._using)
         return await es.indices.put_template(
             name=self._template_name, body=self.to_dict()
@@ -64,6 +74,12 @@ class AsyncIndexTemplate:
 
 
 class AsyncIndex(IndexBase):
+    _using: AsyncUsingType
+
+    if TYPE_CHECKING:
+
+        def get_or_create_mapping(self) -> AsyncMapping: ...
+
     def __init__(self, name: str, using: AsyncUsingType = "default"):
         """
         :arg name: name of the index
@@ -71,14 +87,21 @@ class AsyncIndex(IndexBase):
         """
         super().__init__(name, AsyncMapping, using=using)
 
-    def _get_connection(self, using=None):
+    def _get_connection(
+        self, using: Optional[AsyncUsingType] = None
+    ) -> "AsyncElasticsearch":
         if self._name is None:
             raise ValueError("You cannot perform API calls on the default index.")
         return get_connection(using or self._using)
 
     connection = property(_get_connection)
 
-    def as_template(self, template_name, pattern=None, order=None):
+    def as_template(
+        self,
+        template_name: str,
+        pattern: Optional[str] = None,
+        order: Optional[str] = None,
+    ) -> AsyncIndexTemplate:
         # TODO: should we allow pattern to be a top-level arg?
         # or maybe have an IndexPattern that allows for it and have
         # Document._index be that?
@@ -86,7 +109,7 @@ class AsyncIndex(IndexBase):
             template_name, pattern or self._name, index=self, order=order
         )
 
-    async def load_mappings(self, using=None):
+    async def load_mappings(self, using: Optional[AsyncUsingType] = None) -> None:
         await self.get_or_create_mapping().update_from_es(
             self._name, using=using or self._using
         )
@@ -108,7 +131,7 @@ class AsyncIndex(IndexBase):
         :arg name: name of the index
         :arg using: connection alias to use, defaults to ``'default'``
         """
-        i = AsyncIndex(name or self._name, using=using or self._using)
+        i = self.__class__(name or self._name, using=using or self._using)
         i._settings = self._settings.copy()
         i._aliases = self._aliases.copy()
         i._analysis = self._analysis.copy()
@@ -117,7 +140,7 @@ class AsyncIndex(IndexBase):
             i._mapping = self._mapping._clone()
         return i
 
-    def search(self, using=None):
+    def search(self, using: Optional[AsyncUsingType] = None) -> AsyncSearch:
         """
         Return a :class:`~elasticsearch_dsl.Search` object searching over the
         index (or all the indices belonging to this template) and its
@@ -127,7 +150,9 @@ class AsyncIndex(IndexBase):
             using=using or self._using, index=self._name, doc_type=self._doc_types
         )
 
-    def updateByQuery(self, using=None):
+    def updateByQuery(
+        self, using: Optional[AsyncUsingType] = None
+    ) -> AsyncUpdateByQuery:
         """
         Return a :class:`~elasticsearch_dsl.UpdateByQuery` object searching over the index
         (or all the indices belonging to this template) and updating Documents that match
@@ -141,24 +166,26 @@ class AsyncIndex(IndexBase):
             index=self._name,
         )
 
-    async def create(self, using=None, **kwargs):
+    async def create(
+        self, using: Optional[AsyncUsingType] = None, **kwargs: Any
+    ) -> None:
         """
         Creates the index in elasticsearch.
 
         Any additional keyword arguments will be passed to
         ``Elasticsearch.indices.create`` unchanged.
         """
-        return await self._get_connection(using).indices.create(
+        await self._get_connection(using).indices.create(
             index=self._name, body=self.to_dict(), **kwargs
         )
 
-    async def is_closed(self, using=None):
+    async def is_closed(self, using: Optional[AsyncUsingType] = None) -> bool:
         state = await self._get_connection(using).cluster.state(
             index=self._name, metric="metadata"
         )
-        return state["metadata"]["indices"][self._name]["state"] == "close"
+        return bool(state["metadata"]["indices"][self._name]["state"] == "close")
 
-    async def save(self, using: Optional[AsyncUsingType] = None):
+    async def save(self, using: Optional[AsyncUsingType] = None) -> None:
         """
         Sync the index definition with elasticsearch, creating the index if it
         doesn't exist and updating its settings and mappings if it does.
@@ -212,7 +239,9 @@ class AsyncIndex(IndexBase):
         if mappings:
             await self.put_mapping(using=using, body=mappings)
 
-    async def analyze(self, using=None, **kwargs):
+    async def analyze(
+        self, using: Optional[AsyncUsingType] = None, **kwargs: Any
+    ) -> "ObjectApiResponse[Any]":
         """
         Perform the analysis process on a text and return the tokens breakdown
         of the text.
@@ -224,7 +253,9 @@ class AsyncIndex(IndexBase):
             index=self._name, **kwargs
         )
 
-    async def refresh(self, using=None, **kwargs):
+    async def refresh(
+        self, using: Optional[AsyncUsingType] = None, **kwargs: Any
+    ) -> "ObjectApiResponse[Any]":
         """
         Performs a refresh operation on the index.
 
@@ -235,7 +266,9 @@ class AsyncIndex(IndexBase):
             index=self._name, **kwargs
         )
 
-    async def flush(self, using=None, **kwargs):
+    async def flush(
+        self, using: Optional[AsyncUsingType] = None, **kwargs: Any
+    ) -> "ObjectApiResponse[Any]":
         """
         Performs a flush operation on the index.
 
@@ -246,7 +279,9 @@ class AsyncIndex(IndexBase):
             index=self._name, **kwargs
         )
 
-    async def get(self, using=None, **kwargs):
+    async def get(
+        self, using: Optional[AsyncUsingType] = None, **kwargs: Any
+    ) -> "ObjectApiResponse[Any]":
         """
         The get index API allows to retrieve information about the index.
 
@@ -255,7 +290,9 @@ class AsyncIndex(IndexBase):
         """
         return await self._get_connection(using).indices.get(index=self._name, **kwargs)
 
-    async def open(self, using=None, **kwargs):
+    async def open(
+        self, using: Optional[AsyncUsingType] = None, **kwargs: Any
+    ) -> "ObjectApiResponse[Any]":
         """
         Opens the index in elasticsearch.
 
@@ -266,7 +303,9 @@ class AsyncIndex(IndexBase):
             index=self._name, **kwargs
         )
 
-    async def close(self, using=None, **kwargs):
+    async def close(
+        self, using: Optional[AsyncUsingType] = None, **kwargs: Any
+    ) -> "ObjectApiResponse[Any]":
         """
         Closes the index in elasticsearch.
 
@@ -303,18 +342,9 @@ class AsyncIndex(IndexBase):
             await self._get_connection(using).indices.exists(index=self._name, **kwargs)
         )
 
-    async def exists_type(self, using=None, **kwargs):
-        """
-        Check if a type/types exists in the index.
-
-        Any additional keyword arguments will be passed to
-        ``Elasticsearch.indices.exists_type`` unchanged.
-        """
-        return await self._get_connection(using).indices.exists_type(
-            index=self._name, **kwargs
-        )
-
-    async def put_mapping(self, using=None, **kwargs):
+    async def put_mapping(
+        self, using: Optional[AsyncUsingType] = None, **kwargs: Any
+    ) -> "ObjectApiResponse[Any]":
         """
         Register specific mapping definition for a specific type.
 
@@ -325,7 +355,9 @@ class AsyncIndex(IndexBase):
             index=self._name, **kwargs
         )
 
-    async def get_mapping(self, using=None, **kwargs):
+    async def get_mapping(
+        self, using: Optional[AsyncUsingType] = None, **kwargs: Any
+    ) -> "ObjectApiResponse[Any]":
         """
         Retrieve specific mapping definition for a specific type.
 
@@ -336,7 +368,9 @@ class AsyncIndex(IndexBase):
             index=self._name, **kwargs
         )
 
-    async def get_field_mapping(self, using=None, **kwargs):
+    async def get_field_mapping(
+        self, using: Optional[AsyncUsingType] = None, **kwargs: Any
+    ) -> "ObjectApiResponse[Any]":
         """
         Retrieve mapping definition of a specific field.
 
@@ -347,7 +381,9 @@ class AsyncIndex(IndexBase):
             index=self._name, **kwargs
         )
 
-    async def put_alias(self, using=None, **kwargs):
+    async def put_alias(
+        self, using: Optional[AsyncUsingType] = None, **kwargs: Any
+    ) -> "ObjectApiResponse[Any]":
         """
         Create an alias for the index.
 
@@ -358,18 +394,24 @@ class AsyncIndex(IndexBase):
             index=self._name, **kwargs
         )
 
-    async def exists_alias(self, using=None, **kwargs):
+    async def exists_alias(
+        self, using: Optional[AsyncUsingType] = None, **kwargs: Any
+    ) -> bool:
         """
         Return a boolean indicating whether given alias exists for this index.
 
         Any additional keyword arguments will be passed to
         ``Elasticsearch.indices.exists_alias`` unchanged.
         """
-        return await self._get_connection(using).indices.exists_alias(
-            index=self._name, **kwargs
+        return bool(
+            await self._get_connection(using).indices.exists_alias(
+                index=self._name, **kwargs
+            )
         )
 
-    async def get_alias(self, using=None, **kwargs):
+    async def get_alias(
+        self, using: Optional[AsyncUsingType] = None, **kwargs: Any
+    ) -> "ObjectApiResponse[Any]":
         """
         Retrieve a specified alias.
 
@@ -380,7 +422,9 @@ class AsyncIndex(IndexBase):
             index=self._name, **kwargs
         )
 
-    async def delete_alias(self, using=None, **kwargs):
+    async def delete_alias(
+        self, using: Optional[AsyncUsingType] = None, **kwargs: Any
+    ) -> "ObjectApiResponse[Any]":
         """
         Delete specific alias.
 
@@ -391,7 +435,9 @@ class AsyncIndex(IndexBase):
             index=self._name, **kwargs
         )
 
-    async def get_settings(self, using=None, **kwargs):
+    async def get_settings(
+        self, using: Optional[AsyncUsingType] = None, **kwargs: Any
+    ) -> "ObjectApiResponse[Any]":
         """
         Retrieve settings for the index.
 
@@ -402,7 +448,9 @@ class AsyncIndex(IndexBase):
             index=self._name, **kwargs
         )
 
-    async def put_settings(self, using=None, **kwargs):
+    async def put_settings(
+        self, using: Optional[AsyncUsingType] = None, **kwargs: Any
+    ) -> "ObjectApiResponse[Any]":
         """
         Change specific index level settings in real time.
 
@@ -413,7 +461,9 @@ class AsyncIndex(IndexBase):
             index=self._name, **kwargs
         )
 
-    async def stats(self, using=None, **kwargs):
+    async def stats(
+        self, using: Optional[AsyncUsingType] = None, **kwargs: Any
+    ) -> "ObjectApiResponse[Any]":
         """
         Retrieve statistics on different operations happening on the index.
 
@@ -424,7 +474,9 @@ class AsyncIndex(IndexBase):
             index=self._name, **kwargs
         )
 
-    async def segments(self, using=None, **kwargs):
+    async def segments(
+        self, using: Optional[AsyncUsingType] = None, **kwargs: Any
+    ) -> "ObjectApiResponse[Any]":
         """
         Provide low level segments information that a Lucene index (shard
         level) is built with.
@@ -436,7 +488,9 @@ class AsyncIndex(IndexBase):
             index=self._name, **kwargs
         )
 
-    async def validate_query(self, using=None, **kwargs):
+    async def validate_query(
+        self, using: Optional[AsyncUsingType] = None, **kwargs: Any
+    ) -> "ObjectApiResponse[Any]":
         """
         Validate a potentially expensive query without executing it.
 
@@ -447,7 +501,9 @@ class AsyncIndex(IndexBase):
             index=self._name, **kwargs
         )
 
-    async def clear_cache(self, using=None, **kwargs):
+    async def clear_cache(
+        self, using: Optional[AsyncUsingType] = None, **kwargs: Any
+    ) -> "ObjectApiResponse[Any]":
         """
         Clear all caches or specific cached associated with the index.
 
@@ -458,7 +514,9 @@ class AsyncIndex(IndexBase):
             index=self._name, **kwargs
         )
 
-    async def recovery(self, using=None, **kwargs):
+    async def recovery(
+        self, using: Optional[AsyncUsingType] = None, **kwargs: Any
+    ) -> "ObjectApiResponse[Any]":
         """
         The indices recovery API provides insight into on-going shard
         recoveries for the index.
@@ -470,41 +528,9 @@ class AsyncIndex(IndexBase):
             index=self._name, **kwargs
         )
 
-    async def upgrade(self, using=None, **kwargs):
-        """
-        Upgrade the index to the latest format.
-
-        Any additional keyword arguments will be passed to
-        ``Elasticsearch.indices.upgrade`` unchanged.
-        """
-        return await self._get_connection(using).indices.upgrade(
-            index=self._name, **kwargs
-        )
-
-    async def get_upgrade(self, using=None, **kwargs):
-        """
-        Monitor how much of the index is upgraded.
-
-        Any additional keyword arguments will be passed to
-        ``Elasticsearch.indices.get_upgrade`` unchanged.
-        """
-        return await self._get_connection(using).indices.get_upgrade(
-            index=self._name, **kwargs
-        )
-
-    async def flush_synced(self, using=None, **kwargs):
-        """
-        Perform a normal flush, then add a generated unique marker (sync_id) to
-        all shards.
-
-        Any additional keyword arguments will be passed to
-        ``Elasticsearch.indices.flush_synced`` unchanged.
-        """
-        return await self._get_connection(using).indices.flush_synced(
-            index=self._name, **kwargs
-        )
-
-    async def shard_stores(self, using=None, **kwargs):
+    async def shard_stores(
+        self, using: Optional[AsyncUsingType] = None, **kwargs: Any
+    ) -> "ObjectApiResponse[Any]":
         """
         Provides store information for shard copies of the index. Store
         information reports on which nodes shard copies exist, the shard copy
@@ -518,7 +544,9 @@ class AsyncIndex(IndexBase):
             index=self._name, **kwargs
         )
 
-    async def forcemerge(self, using=None, **kwargs):
+    async def forcemerge(
+        self, using: Optional[AsyncUsingType] = None, **kwargs: Any
+    ) -> "ObjectApiResponse[Any]":
         """
         The force merge API allows to force merging of the index through an
         API. The merge relates to the number of segments a Lucene index holds
@@ -536,7 +564,9 @@ class AsyncIndex(IndexBase):
             index=self._name, **kwargs
         )
 
-    async def shrink(self, using=None, **kwargs):
+    async def shrink(
+        self, using: Optional[AsyncUsingType] = None, **kwargs: Any
+    ) -> "ObjectApiResponse[Any]":
         """
         The shrink index API allows you to shrink an existing index into a new
         index with fewer primary shards. The number of primary shards in the

--- a/elasticsearch_dsl/_async/mapping.py
+++ b/elasticsearch_dsl/_async/mapping.py
@@ -15,26 +15,35 @@
 #  specific language governing permissions and limitations
 #  under the License.
 
+from typing import List, Optional, Union
+
+from typing_extensions import Self
+
 from ..async_connections import get_connection
 from ..mapping_base import MappingBase
+from ..utils import AsyncUsingType
 
 
 class AsyncMapping(MappingBase):
     @classmethod
-    async def from_es(cls, index, using="default"):
+    async def from_es(
+        cls, index: Optional[Union[str, List[str]]], using: AsyncUsingType = "default"
+    ) -> Self:
         m = cls()
         await m.update_from_es(index, using)
         return m
 
-    async def update_from_es(self, index, using="default"):
+    async def update_from_es(
+        self, index: Optional[Union[str, List[str]]], using: AsyncUsingType = "default"
+    ) -> None:
         es = get_connection(using)
         raw = await es.indices.get_mapping(index=index)
         _, raw = raw.popitem()
         self._update_from_dict(raw["mappings"])
 
-    async def save(self, index, using="default"):
+    async def save(self, index: str, using: AsyncUsingType = "default") -> None:
         from .index import AsyncIndex
 
-        index = AsyncIndex(index, using=using)
-        index.mapping(self)
-        return await index.save()
+        i = AsyncIndex(index, using=using)
+        i.mapping(self)
+        await i.save()

--- a/elasticsearch_dsl/_async/search.py
+++ b/elasticsearch_dsl/_async/search.py
@@ -20,14 +20,11 @@ from typing import AsyncIterator, Generic
 
 from elasticsearch.exceptions import ApiError
 from elasticsearch.helpers import async_scan
-from typing_extensions import TypeVar
 
 from ..async_connections import get_connection
-from ..response import Hit, Response
+from ..response import Response
 from ..search_base import MultiSearchBase, SearchBase
-from ..utils import AttrDict
-
-_R = TypeVar("_R", default=Hit)
+from ..utils import _R, AttrDict
 
 
 class AsyncSearch(SearchBase[_R]):

--- a/elasticsearch_dsl/_async/search.py
+++ b/elasticsearch_dsl/_async/search.py
@@ -16,27 +16,30 @@
 #  under the License.
 
 import contextlib
-from typing import AsyncIterator, Generic
+from typing import Any, AsyncIterator, Dict, Iterator, List, Optional, cast
 
 from elasticsearch.exceptions import ApiError
 from elasticsearch.helpers import async_scan
+from typing_extensions import Self
 
 from ..async_connections import get_connection
 from ..response import Response
 from ..search_base import MultiSearchBase, SearchBase
-from ..utils import _R, AttrDict
+from ..utils import _R, AsyncUsingType, AttrDict, JSONType
 
 
 class AsyncSearch(SearchBase[_R]):
+    _using: AsyncUsingType
+
     def __aiter__(self) -> AsyncIterator[_R]:
         """
         Iterate over the hits.
         """
 
-        class ResultsIterator(Generic[_R]):
+        class ResultsIterator(AsyncIterator[_R]):
             def __init__(self, search: AsyncSearch[_R]):
                 self.search = search
-                self.iterator = None
+                self.iterator: Optional[Iterator[_R]] = None
 
             async def __anext__(self) -> _R:
                 if self.iterator is None:
@@ -48,22 +51,24 @@ class AsyncSearch(SearchBase[_R]):
 
         return ResultsIterator(self)
 
-    async def count(self):
+    async def count(self) -> int:
         """
         Return the number of hits matching the query and filters. Note that
         only the actual number is returned.
         """
-        if hasattr(self, "_response") and self._response.hits.total.relation == "eq":
-            return self._response.hits.total.value
+        if hasattr(self, "_response") and self._response.hits.total.relation == "eq":  # type: ignore[attr-defined]
+            return cast(int, self._response.hits.total.value)  # type: ignore[attr-defined]
 
         es = get_connection(self._using)
 
         d = self.to_dict(count=True)
         # TODO: failed shards detection
         resp = await es.count(
-            index=self._index, query=d.get("query", None), **self._params
+            index=self._index,
+            query=cast(Optional[Dict[str, Any]], d.get("query", None)),
+            **self._params,
         )
-        return resp["count"]
+        return cast(int, resp["count"])
 
     async def execute(self, ignore_cache: bool = False) -> Response[_R]:
         """
@@ -86,7 +91,7 @@ class AsyncSearch(SearchBase[_R]):
             )
         return self._response
 
-    async def scan(self):
+    async def scan(self) -> AsyncIterator[_R]:
         """
         Turn the search into a scan search and return a generator that will
         iterate over all the documents matching the query.
@@ -103,23 +108,27 @@ class AsyncSearch(SearchBase[_R]):
         async for hit in async_scan(
             es, query=self.to_dict(), index=self._index, **self._params
         ):
-            yield self._get_result(hit)
+            yield self._get_result(cast(AttrDict[JSONType], hit))
 
-    async def delete(self):
+    async def delete(self) -> AttrDict[JSONType]:
         """
         delete() executes the query by delegating to delete_by_query()
         """
 
         es = get_connection(self._using)
+        assert self._index is not None
 
         return AttrDict(
-            await es.delete_by_query(
-                index=self._index, body=self.to_dict(), **self._params
+            cast(
+                Dict[str, JSONType],
+                await es.delete_by_query(
+                    index=self._index, body=self.to_dict(), **self._params
+                ),
             )
         )
 
     @contextlib.asynccontextmanager
-    async def point_in_time(self, keep_alive="1m"):
+    async def point_in_time(self, keep_alive: str = "1m") -> AsyncIterator[Self]:
         """
         Open a point in time (pit) that can be used across several searches.
 
@@ -139,7 +148,7 @@ class AsyncSearch(SearchBase[_R]):
         yield search
         await es.close_point_in_time(id=pit["id"])
 
-    async def iterate(self, keep_alive="1m"):
+    async def iterate(self, keep_alive: str = "1m") -> AsyncIterator[_R]:
         """
         Return a generator that iterates over all the documents matching the query.
 
@@ -155,16 +164,20 @@ class AsyncSearch(SearchBase[_R]):
                     yield hit
                 if len(r.hits) == 0:
                     break
-                s = r.search_after()
+                s = s.search_after()
 
 
-class AsyncMultiSearch(MultiSearchBase):
+class AsyncMultiSearch(MultiSearchBase[_R]):
     """
     Combine multiple :class:`~elasticsearch_dsl.Search` objects into a single
     request.
     """
 
-    async def execute(self, ignore_cache=False, raise_on_error=True):
+    _using: AsyncUsingType
+
+    async def execute(
+        self, ignore_cache: bool = False, raise_on_error: bool = True
+    ) -> List[Response[_R]]:
         """
         Execute the multi search request and return a list of search results.
         """
@@ -175,7 +188,7 @@ class AsyncMultiSearch(MultiSearchBase):
                 index=self._index, body=self.to_dict(), **self._params
             )
 
-            out = []
+            out: List[Response[_R]] = []
             for s, r in zip(self._searches, responses["responses"]):
                 if r.get("error", False):
                     if raise_on_error:
@@ -190,16 +203,16 @@ class AsyncMultiSearch(MultiSearchBase):
         return self._response
 
 
-class AsyncEmptySearch(AsyncSearch):
-    async def count(self):
+class AsyncEmptySearch(AsyncSearch[_R]):
+    async def count(self) -> int:
         return 0
 
-    async def execute(self, ignore_cache=False):
+    async def execute(self, ignore_cache: bool = False) -> Response[_R]:
         return self._response_class(self, {"hits": {"total": 0, "hits": []}})
 
-    async def scan(self):
+    async def scan(self) -> AsyncIterator[_R]:
         return
         yield  # a bit strange, but this forces an empty generator function
 
-    async def delete(self):
-        return AttrDict({})
+    async def delete(self) -> AttrDict[JSONType]:
+        return AttrDict[JSONType]({})

--- a/elasticsearch_dsl/_async/update_by_query.py
+++ b/elasticsearch_dsl/_async/update_by_query.py
@@ -15,22 +15,33 @@
 #  specific language governing permissions and limitations
 #  under the License.
 
+from typing import TYPE_CHECKING
+
 from ..async_connections import get_connection
 from ..update_by_query_base import UpdateByQueryBase
+from ..utils import _R, AsyncUsingType
+
+if TYPE_CHECKING:
+    from ..response import UpdateByQueryResponse
 
 
-class AsyncUpdateByQuery(UpdateByQueryBase):
-    async def execute(self):
+class AsyncUpdateByQuery(UpdateByQueryBase[_R]):
+    _using: AsyncUsingType
+
+    async def execute(self) -> "UpdateByQueryResponse[_R]":
         """
         Execute the search and return an instance of ``Response`` wrapping all
         the data.
         """
         es = get_connection(self._using)
+        assert self._index is not None
 
         self._response = self._response_class(
             self,
-            await es.update_by_query(
-                index=self._index, **self.to_dict(), **self._params
-            ),
+            (
+                await es.update_by_query(
+                    index=self._index, **self.to_dict(), **self._params  # type: ignore
+                )
+            ).body,
         )
         return self._response

--- a/elasticsearch_dsl/_sync/document.py
+++ b/elasticsearch_dsl/_sync/document.py
@@ -80,7 +80,7 @@ class Document(DocumentBase, metaclass=IndexMeta):
 
     @classmethod
     def _get_using(cls, using: Optional[UsingType] = None) -> UsingType:
-        return using or cls._index._using
+        return cast(UsingType, using or cls._index._using)
 
     @classmethod
     def _get_connection(cls, using: Optional[UsingType] = None) -> "Elasticsearch":

--- a/elasticsearch_dsl/_sync/faceted_search.py
+++ b/elasticsearch_dsl/_sync/faceted_search.py
@@ -15,23 +15,34 @@
 #  specific language governing permissions and limitations
 #  under the License.
 
+from typing import TYPE_CHECKING
+
 from elasticsearch_dsl.faceted_search_base import FacetedResponse, FacetedSearchBase
 
+from ..utils import _R
 from .search import Search
 
+if TYPE_CHECKING:
+    from ..response import Response
 
-class FacetedSearch(FacetedSearchBase):
-    def search(self):
+
+class FacetedSearch(FacetedSearchBase[_R]):
+    _s: Search[_R]
+
+    def count(self) -> int:
+        return self._s.count()
+
+    def search(self) -> Search[_R]:
         """
         Returns the base Search object to which the facets are added.
 
         You can customize the query by overriding this method and returning a
         modified search object.
         """
-        s = Search(doc_type=self.doc_types, index=self.index, using=self.using)
+        s = Search[_R](doc_type=self.doc_types, index=self.index, using=self.using)
         return s.response_class(FacetedResponse)
 
-    def execute(self):
+    def execute(self) -> "Response[_R]":
         """
         Execute the search and return the response.
         """

--- a/elasticsearch_dsl/_sync/index.py
+++ b/elasticsearch_dsl/_sync/index.py
@@ -158,14 +158,16 @@ class Index(IndexBase):
             index=self._name,
         )
 
-    def create(self, using: Optional[UsingType] = None, **kwargs: Any) -> None:
+    def create(
+        self, using: Optional[UsingType] = None, **kwargs: Any
+    ) -> "ObjectApiResponse[Any]":
         """
         Creates the index in elasticsearch.
 
         Any additional keyword arguments will be passed to
         ``Elasticsearch.indices.create`` unchanged.
         """
-        self._get_connection(using).indices.create(
+        return self._get_connection(using).indices.create(
             index=self._name, body=self.to_dict(), **kwargs
         )
 
@@ -175,7 +177,9 @@ class Index(IndexBase):
         )
         return bool(state["metadata"]["indices"][self._name]["state"] == "close")
 
-    def save(self, using: Optional[UsingType] = None) -> None:
+    def save(
+        self, using: Optional[UsingType] = None
+    ) -> "Optional[ObjectApiResponse[Any]]":
         """
         Sync the index definition with elasticsearch, creating the index if it
         doesn't exist and updating its settings and mappings if it does.
@@ -227,7 +231,9 @@ class Index(IndexBase):
         # exception
         mappings = body.pop("mappings", {})
         if mappings:
-            self.put_mapping(using=using, body=mappings)
+            return self.put_mapping(using=using, body=mappings)
+
+        return None
 
     def analyze(
         self, using: Optional[UsingType] = None, **kwargs: Any

--- a/elasticsearch_dsl/_sync/mapping.py
+++ b/elasticsearch_dsl/_sync/mapping.py
@@ -15,26 +15,35 @@
 #  specific language governing permissions and limitations
 #  under the License.
 
+from typing import List, Optional, Union
+
+from typing_extensions import Self
+
 from ..connections import get_connection
 from ..mapping_base import MappingBase
+from ..utils import UsingType
 
 
 class Mapping(MappingBase):
     @classmethod
-    def from_es(cls, index, using="default"):
+    def from_es(
+        cls, index: Optional[Union[str, List[str]]], using: UsingType = "default"
+    ) -> Self:
         m = cls()
         m.update_from_es(index, using)
         return m
 
-    def update_from_es(self, index, using="default"):
+    def update_from_es(
+        self, index: Optional[Union[str, List[str]]], using: UsingType = "default"
+    ) -> None:
         es = get_connection(using)
         raw = es.indices.get_mapping(index=index)
         _, raw = raw.popitem()
         self._update_from_dict(raw["mappings"])
 
-    def save(self, index, using="default"):
+    def save(self, index: str, using: UsingType = "default") -> None:
         from .index import Index
 
-        index = Index(index, using=using)
-        index.mapping(self)
-        return index.save()
+        i = Index(index, using=using)
+        i.mapping(self)
+        i.save()

--- a/elasticsearch_dsl/_sync/search.py
+++ b/elasticsearch_dsl/_sync/search.py
@@ -16,27 +16,30 @@
 #  under the License.
 
 import contextlib
-from typing import Generic, Iterator
+from typing import Any, Dict, Iterator, List, Optional, cast
 
 from elasticsearch.exceptions import ApiError
 from elasticsearch.helpers import scan
+from typing_extensions import Self
 
 from ..connections import get_connection
 from ..response import Response
 from ..search_base import MultiSearchBase, SearchBase
-from ..utils import _R, AttrDict
+from ..utils import _R, AttrDict, JSONType, UsingType
 
 
 class Search(SearchBase[_R]):
+    _using: UsingType
+
     def __iter__(self) -> Iterator[_R]:
         """
         Iterate over the hits.
         """
 
-        class ResultsIterator(Generic[_R]):
+        class ResultsIterator(Iterator[_R]):
             def __init__(self, search: Search[_R]):
                 self.search = search
-                self.iterator = None
+                self.iterator: Optional[Iterator[_R]] = None
 
             def __next__(self) -> _R:
                 if self.iterator is None:
@@ -48,20 +51,24 @@ class Search(SearchBase[_R]):
 
         return ResultsIterator(self)
 
-    def count(self):
+    def count(self) -> int:
         """
         Return the number of hits matching the query and filters. Note that
         only the actual number is returned.
         """
-        if hasattr(self, "_response") and self._response.hits.total.relation == "eq":
-            return self._response.hits.total.value
+        if hasattr(self, "_response") and self._response.hits.total.relation == "eq":  # type: ignore[attr-defined]
+            return cast(int, self._response.hits.total.value)  # type: ignore[attr-defined]
 
         es = get_connection(self._using)
 
         d = self.to_dict(count=True)
         # TODO: failed shards detection
-        resp = es.count(index=self._index, query=d.get("query", None), **self._params)
-        return resp["count"]
+        resp = es.count(
+            index=self._index,
+            query=cast(Optional[Dict[str, Any]], d.get("query", None)),
+            **self._params,
+        )
+        return cast(int, resp["count"])
 
     def execute(self, ignore_cache: bool = False) -> Response[_R]:
         """
@@ -82,7 +89,7 @@ class Search(SearchBase[_R]):
             )
         return self._response
 
-    def scan(self):
+    def scan(self) -> Iterator[_R]:
         """
         Turn the search into a scan search and return a generator that will
         iterate over all the documents matching the query.
@@ -97,21 +104,27 @@ class Search(SearchBase[_R]):
         es = get_connection(self._using)
 
         for hit in scan(es, query=self.to_dict(), index=self._index, **self._params):
-            yield self._get_result(hit)
+            yield self._get_result(cast(AttrDict[JSONType], hit))
 
-    def delete(self):
+    def delete(self) -> AttrDict[JSONType]:
         """
         delete() executes the query by delegating to delete_by_query()
         """
 
         es = get_connection(self._using)
+        assert self._index is not None
 
         return AttrDict(
-            es.delete_by_query(index=self._index, body=self.to_dict(), **self._params)
+            cast(
+                Dict[str, JSONType],
+                es.delete_by_query(
+                    index=self._index, body=self.to_dict(), **self._params
+                ),
+            )
         )
 
     @contextlib.contextmanager
-    def point_in_time(self, keep_alive="1m"):
+    def point_in_time(self, keep_alive: str = "1m") -> Iterator[Self]:
         """
         Open a point in time (pit) that can be used across several searches.
 
@@ -129,7 +142,7 @@ class Search(SearchBase[_R]):
         yield search
         es.close_point_in_time(id=pit["id"])
 
-    def iterate(self, keep_alive="1m"):
+    def iterate(self, keep_alive: str = "1m") -> Iterator[_R]:
         """
         Return a generator that iterates over all the documents matching the query.
 
@@ -145,16 +158,20 @@ class Search(SearchBase[_R]):
                     yield hit
                 if len(r.hits) == 0:
                     break
-                s = r.search_after()
+                s = s.search_after()
 
 
-class MultiSearch(MultiSearchBase):
+class MultiSearch(MultiSearchBase[_R]):
     """
     Combine multiple :class:`~elasticsearch_dsl.Search` objects into a single
     request.
     """
 
-    def execute(self, ignore_cache=False, raise_on_error=True):
+    _using: UsingType
+
+    def execute(
+        self, ignore_cache: bool = False, raise_on_error: bool = True
+    ) -> List[Response[_R]]:
         """
         Execute the multi search request and return a list of search results.
         """
@@ -165,7 +182,7 @@ class MultiSearch(MultiSearchBase):
                 index=self._index, body=self.to_dict(), **self._params
             )
 
-            out = []
+            out: List[Response[_R]] = []
             for s, r in zip(self._searches, responses["responses"]):
                 if r.get("error", False):
                     if raise_on_error:
@@ -180,16 +197,16 @@ class MultiSearch(MultiSearchBase):
         return self._response
 
 
-class EmptySearch(Search):
-    def count(self):
+class EmptySearch(Search[_R]):
+    def count(self) -> int:
         return 0
 
-    def execute(self, ignore_cache=False):
+    def execute(self, ignore_cache: bool = False) -> Response[_R]:
         return self._response_class(self, {"hits": {"total": 0, "hits": []}})
 
-    def scan(self):
+    def scan(self) -> Iterator[_R]:
         return
         yield  # a bit strange, but this forces an empty generator function
 
-    def delete(self):
-        return AttrDict({})
+    def delete(self) -> AttrDict[JSONType]:
+        return AttrDict[JSONType]({})

--- a/elasticsearch_dsl/_sync/search.py
+++ b/elasticsearch_dsl/_sync/search.py
@@ -20,14 +20,11 @@ from typing import Generic, Iterator
 
 from elasticsearch.exceptions import ApiError
 from elasticsearch.helpers import scan
-from typing_extensions import TypeVar
 
 from ..connections import get_connection
-from ..response import Hit, Response
+from ..response import Response
 from ..search_base import MultiSearchBase, SearchBase
-from ..utils import AttrDict
-
-_R = TypeVar("_R", default=Hit)
+from ..utils import _R, AttrDict
 
 
 class Search(SearchBase[_R]):

--- a/elasticsearch_dsl/_sync/update_by_query.py
+++ b/elasticsearch_dsl/_sync/update_by_query.py
@@ -15,20 +15,33 @@
 #  specific language governing permissions and limitations
 #  under the License.
 
+from typing import TYPE_CHECKING
+
 from ..connections import get_connection
 from ..update_by_query_base import UpdateByQueryBase
+from ..utils import _R, UsingType
+
+if TYPE_CHECKING:
+    from ..response import UpdateByQueryResponse
 
 
-class UpdateByQuery(UpdateByQueryBase):
-    def execute(self):
+class UpdateByQuery(UpdateByQueryBase[_R]):
+    _using: UsingType
+
+    def execute(self) -> "UpdateByQueryResponse[_R]":
         """
         Execute the search and return an instance of ``Response`` wrapping all
         the data.
         """
         es = get_connection(self._using)
+        assert self._index is not None
 
         self._response = self._response_class(
             self,
-            es.update_by_query(index=self._index, **self.to_dict(), **self._params),
+            (
+                es.update_by_query(
+                    index=self._index, **self.to_dict(), **self._params  # type: ignore
+                )
+            ).body,
         )
         return self._response

--- a/elasticsearch_dsl/aggs.py
+++ b/elasticsearch_dsl/aggs.py
@@ -30,17 +30,12 @@ from typing import (
     cast,
 )
 
-from typing_extensions import TypeVar
-
-from .response import Hit
 from .response.aggs import AggResponse, BucketData, FieldBucketData, TopHitsData
-from .utils import AttrDict, DslBase, JSONType
+from .utils import _R, AttrDict, DslBase, JSONType
 
 if TYPE_CHECKING:
     from .query import Query
     from .search_base import SearchBase
-
-_R = TypeVar("_R", default=Hit)
 
 
 def A(

--- a/elasticsearch_dsl/faceted_search_base.py
+++ b/elasticsearch_dsl/faceted_search_base.py
@@ -18,6 +18,8 @@
 from datetime import datetime, timedelta
 from typing import TYPE_CHECKING, Any, Dict, Generic, List, Optional, Tuple, Union, cast
 
+from typing_extensions import Self
+
 from .aggs import A, Agg
 from .query import MatchAll, Nested, Query, Range, Terms
 from .response import Response
@@ -338,6 +340,10 @@ class FacetedSearchBase(Generic[_R]):
     facets: Dict[str, Facet[_R]] = {}
     using = "default"
 
+    if TYPE_CHECKING:
+
+        def search(self) -> "SearchBase[_R]": ...
+
     def __init__(
         self,
         query: Optional[Query] = None,
@@ -358,10 +364,7 @@ class FacetedSearchBase(Generic[_R]):
 
         self._s = self.build_search()
 
-    def count(self) -> int:
-        return self._s.count()
-
-    def __getitem__(self, k: Union[int, slice]) -> "FacetedSearchBase[_R]":
+    def __getitem__(self, k: Union[int, slice]) -> Self:
         self._s = self._s[k]
         return self
 
@@ -469,7 +472,3 @@ class FacetedSearchBase(Generic[_R]):
         s = self.sort(s)
         self.aggregate(s)
         return s
-
-    if TYPE_CHECKING:
-
-        def search(self) -> "SearchBase[_R]": ...

--- a/elasticsearch_dsl/faceted_search_base.py
+++ b/elasticsearch_dsl/faceted_search_base.py
@@ -18,19 +18,16 @@
 from datetime import datetime, timedelta
 from typing import TYPE_CHECKING, Any, Dict, Generic, List, Optional, Tuple, Union, cast
 
-from typing_extensions import TypeVar
-
 from .aggs import A, Agg
 from .query import MatchAll, Nested, Query, Range, Terms
-from .response import Hit, Response
-from .utils import AttrDict, JSONType
+from .response import Response
+from .utils import _R, AttrDict, JSONType
 
 if TYPE_CHECKING:
     from .response.aggs import BucketData
     from .search_base import SearchBase
 
 FilterValueType = Union[str, datetime]
-_R = TypeVar("_R", default=Hit)
 
 __all__ = [
     "FacetedSearchBase",

--- a/elasticsearch_dsl/response/__init__.py
+++ b/elasticsearch_dsl/response/__init__.py
@@ -28,9 +28,7 @@ from typing import (
     cast,
 )
 
-from typing_extensions import TypeVar
-
-from ..utils import AttrDict, AttrList, JSONType, _wrap
+from ..utils import _R, AttrDict, AttrList, JSONType, _wrap
 from .hit import Hit, HitMeta
 
 if TYPE_CHECKING:
@@ -38,8 +36,6 @@ if TYPE_CHECKING:
     from ..search_base import Request, SearchBase
 
 __all__ = ["Response", "AggResponse", "UpdateByQueryResponse", "Hit", "HitMeta"]
-
-_R = TypeVar("_R", default=Hit)
 
 
 class Response(AttrDict[JSONType], Generic[_R]):
@@ -115,7 +111,7 @@ class Response(AttrDict[JSONType], Generic[_R]):
     def aggs(self) -> "AggResponse[_R]":
         if not hasattr(self, "_aggs"):
             aggs = AggResponse[_R](
-                cast("Agg", self._search.aggs),
+                cast("Agg[_R]", self._search.aggs),
                 self._search,
                 cast(Dict[str, JSONType], self._d_.get("aggregations", {})),
             )

--- a/elasticsearch_dsl/response/__init__.py
+++ b/elasticsearch_dsl/response/__init__.py
@@ -33,13 +33,16 @@ from .hit import Hit, HitMeta
 
 if TYPE_CHECKING:
     from ..aggs import Agg
+    from ..faceted_search_base import FacetedSearchBase
     from ..search_base import Request, SearchBase
+    from ..update_by_query_base import UpdateByQueryBase
 
 __all__ = ["Response", "AggResponse", "UpdateByQueryResponse", "Hit", "HitMeta"]
 
 
 class Response(AttrDict[JSONType], Generic[_R]):
     _search: "SearchBase[_R]"
+    _faceted_search: "FacetedSearchBase[_R]"
     _doc_class: Optional[_R]
     _hits: List[_R]
 
@@ -73,11 +76,11 @@ class Response(AttrDict[JSONType], Generic[_R]):
     def __len__(self) -> int:
         return len(self.hits)
 
-    def __getstate__(self) -> Tuple[Dict[str, Any], "SearchBase[_R]", Optional[_R]]:  # type: ignore[override]
+    def __getstate__(self) -> Tuple[Dict[str, Any], "Request[_R]", Optional[_R]]:  # type: ignore[override]
         return self._d_, self._search, self._doc_class
 
     def __setstate__(
-        self, state: Tuple[Dict[str, Any], "SearchBase[_R]", Optional[_R]]  # type: ignore[override]
+        self, state: Tuple[Dict[str, Any], "Request[_R]", Optional[_R]]  # type: ignore[override]
     ) -> None:
         super(AttrDict, self).__setattr__("_d_", state[0])
         super(AttrDict, self).__setattr__("_search", state[1])
@@ -157,7 +160,7 @@ class AggResponse(AttrDict[JSONType], Generic[_R]):
     _meta: Dict[str, Any]
 
     def __init__(
-        self, aggs: "Agg[_R]", search: "SearchBase[_R]", data: Dict[str, JSONType]
+        self, aggs: "Agg[_R]", search: "Request[_R]", data: Dict[str, JSONType]
     ):
         super(AttrDict, self).__setattr__("_meta", {"search": search, "aggs": aggs})
         super().__init__(data)
@@ -175,9 +178,11 @@ class AggResponse(AttrDict[JSONType], Generic[_R]):
 
 
 class UpdateByQueryResponse(AttrDict[JSONType], Generic[_R]):
+    _search: "UpdateByQueryBase[_R]"
+
     def __init__(
         self,
-        search: "SearchBase[_R]",
+        search: "Request[_R]",
         response: Dict[str, Any],
         doc_class: Optional[_R] = None,
     ):

--- a/elasticsearch_dsl/response/aggs.py
+++ b/elasticsearch_dsl/response/aggs.py
@@ -17,23 +17,19 @@
 
 from typing import TYPE_CHECKING, Any, Dict, Iterator, List, Optional, Union, cast
 
-from typing_extensions import TypeVar
-
-from ..utils import AttrDict, AttrList, JSONType
-from . import AggResponse, Hit, Response
+from ..utils import _R, AttrDict, AttrList, JSONType
+from . import AggResponse, Response
 
 if TYPE_CHECKING:
     from ..aggs import Agg
     from ..field import Field
     from ..search_base import SearchBase
 
-_R = TypeVar("_R", default=Hit)
-
 
 class Bucket(AggResponse[_R]):
     def __init__(
         self,
-        aggs: "Agg",
+        aggs: "Agg[_R]",
         search: "SearchBase[_R]",
         data: Dict[str, JSONType],
         field: Optional["Field"] = None,
@@ -44,7 +40,7 @@ class Bucket(AggResponse[_R]):
 class FieldBucket(Bucket[_R]):
     def __init__(
         self,
-        aggs: "Agg",
+        aggs: "Agg[_R]",
         search: "SearchBase[_R]",
         data: Dict[str, JSONType],
         field: Optional["Field"] = None,

--- a/elasticsearch_dsl/search_base.py
+++ b/elasticsearch_dsl/search_base.py
@@ -33,19 +33,17 @@ from typing import (
     overload,
 )
 
-from typing_extensions import Self, TypeVar
+from typing_extensions import Self
 
 from .aggs import A, Agg, AggBase
 from .exceptions import IllegalOperation
 from .query import Bool, Q, Query
 from .response import Hit, Response
-from .utils import AnyUsingType, AttrDict, DslBase, JSONType, recursive_to_dict
+from .utils import _R, AnyUsingType, AttrDict, DslBase, JSONType, recursive_to_dict
 
 if TYPE_CHECKING:
     from .document_base import InstrumentedField
     from .field import Field, Object
-
-_R = TypeVar("_R", default=Hit)
 
 
 class QueryProxy(Generic[_R]):

--- a/elasticsearch_dsl/search_base.py
+++ b/elasticsearch_dsl/search_base.py
@@ -26,6 +26,7 @@ from typing import (
     Iterator,
     List,
     Optional,
+    Protocol,
     Tuple,
     Type,
     Union,
@@ -33,7 +34,7 @@ from typing import (
     overload,
 )
 
-from typing_extensions import Self
+from typing_extensions import Self, TypeVar
 
 from .aggs import A, Agg, AggBase
 from .exceptions import IllegalOperation
@@ -46,14 +47,21 @@ if TYPE_CHECKING:
     from .field import Field, Object
 
 
-class QueryProxy(Generic[_R]):
+class SupportsClone(Protocol):
+    def _clone(self) -> Self: ...
+
+
+_S = TypeVar("_S", bound=SupportsClone)
+
+
+class QueryProxy(Generic[_S]):
     """
     Simple proxy around DSL objects (queries) that can be called
     (to add query/post_filter) and also allows attribute access which is proxied to
     the wrapped query.
     """
 
-    def __init__(self, search: "SearchBase[_R]", attr_name: str):
+    def __init__(self, search: _S, attr_name: str):
         self._search = search
         self._proxied: Optional[Query] = None
         self._attr_name = attr_name
@@ -63,7 +71,7 @@ class QueryProxy(Generic[_R]):
 
     __bool__ = __nonzero__
 
-    def __call__(self, *args: Any, **kwargs: Any) -> "SearchBase[_R]":
+    def __call__(self, *args: Any, **kwargs: Any) -> _S:
         s = self._search._clone()
 
         # we cannot use self._proxied since we just cloned self._search and
@@ -87,16 +95,14 @@ class QueryProxy(Generic[_R]):
                 setattr(self._proxied, attr_name, value)
         super().__setattr__(attr_name, value)
 
-    def __getstate__(self) -> Tuple["SearchBase[_R]", Optional[Query], str]:
+    def __getstate__(self) -> Tuple[_S, Optional[Query], str]:
         return self._search, self._proxied, self._attr_name
 
-    def __setstate__(
-        self, state: Tuple["SearchBase[_R]", Optional[Query], str]
-    ) -> None:
+    def __setstate__(self, state: Tuple[_S, Optional[Query], str]) -> None:
         self._search, self._proxied, self._attr_name = state
 
 
-class ProxyDescriptor(Generic[_R]):
+class ProxyDescriptor(Generic[_S]):
     """
     Simple descriptor to enable setting of queries and filters as:
 
@@ -108,18 +114,18 @@ class ProxyDescriptor(Generic[_R]):
     def __init__(self, name: str):
         self._attr_name = f"_{name}_proxy"
 
-    def __get__(self, instance: "SearchBase[_R]", owner: object) -> QueryProxy[_R]:
-        return cast(QueryProxy[_R], getattr(instance, self._attr_name))
+    def __get__(self, instance: _S, owner: object) -> QueryProxy[_S]:
+        return cast(QueryProxy[_S], getattr(instance, self._attr_name))
 
-    def __set__(self, instance: "SearchBase[_R]", value: Dict[str, Any]) -> None:
-        proxy: QueryProxy[_R] = getattr(instance, self._attr_name)
+    def __set__(self, instance: _S, value: Dict[str, Any]) -> None:
+        proxy: QueryProxy[_S] = getattr(instance, self._attr_name)
         proxy._proxied = Q(value)
 
 
-class AggsProxy(AggBase, DslBase, Generic[_R]):
+class AggsProxy(AggBase, DslBase, Generic[_S]):
     name = "aggs"
 
-    def __init__(self, search: "SearchBase[_R]"):
+    def __init__(self, search: _S):
         self._base = cast("Agg", self)
         self._search = search
         self._params = {"aggs": {}}
@@ -344,12 +350,8 @@ class Request(Generic[_R]):
 
 
 class SearchBase(Request[_R]):
-    if TYPE_CHECKING:
-
-        def count(self) -> int: ...
-
-    query = ProxyDescriptor[_R]("query")
-    post_filter = ProxyDescriptor[_R]("post_filter")
+    query = ProxyDescriptor["SearchBase[_R]"]("query")
+    post_filter = ProxyDescriptor["SearchBase[_R]"]("post_filter")
     _response: Response[_R]
 
     def __init__(self, **kwargs: Any):
@@ -380,11 +382,11 @@ class SearchBase(Request[_R]):
         self._query_proxy = QueryProxy(self, "query")
         self._post_filter_proxy = QueryProxy(self, "post_filter")
 
-    def filter(self, *args: Any, **kwargs: Any) -> "SearchBase[_R]":
-        return self.query(Bool(filter=[Q(*args, **kwargs)]))
+    def filter(self, *args: Any, **kwargs: Any) -> Self:
+        return cast(Self, self.query(Bool(filter=[Q(*args, **kwargs)])))
 
-    def exclude(self, *args: Any, **kwargs: Any) -> "SearchBase[_R]":
-        return self.query(Bool(filter=[~Q(*args, **kwargs)]))
+    def exclude(self, *args: Any, **kwargs: Any) -> Self:
+        return cast(Self, self.query(Bool(filter=[~Q(*args, **kwargs)])))
 
     def __getitem__(self, n: Union[int, slice]) -> Self:
         """
@@ -435,7 +437,7 @@ class SearchBase(Request[_R]):
         return s
 
     @classmethod
-    def from_dict(cls, d: Dict[str, Any]) -> "SearchBase[_R]":
+    def from_dict(cls, d: Dict[str, Any]) -> Self:
         """
         Construct a new `Search` instance from a raw dict containing the search
         body. Useful when migrating from raw dictionaries.
@@ -818,7 +820,7 @@ class SearchBase(Request[_R]):
 
     def highlight(
         self, *fields: Union[str, "InstrumentedField"], **kwargs: Any
-    ) -> "SearchBase[_R]":
+    ) -> Self:
         """
         Request highlighting of some fields. All keyword arguments passed in will be
         used as parameters for all the fields in the ``fields`` parameter. Example::
@@ -900,7 +902,7 @@ class SearchBase(Request[_R]):
         s._suggest[name].update(kwargs)  # type: ignore[union-attr]
         return s
 
-    def search_after(self) -> "SearchBase[_R]":
+    def search_after(self) -> Self:
         """
         Return a ``Search`` instance that retrieves the next page of results.
 
@@ -928,7 +930,7 @@ class SearchBase(Request[_R]):
         """
         if not hasattr(self, "_response"):
             raise ValueError("A search must be executed before using search_after")
-        return self._response.search_after()
+        return cast(Self, self._response.search_after())
 
     def to_dict(self, count: bool = False, **kwargs: Any) -> Dict[str, JSONType]:
         """

--- a/elasticsearch_dsl/update_by_query_base.py
+++ b/elasticsearch_dsl/update_by_query_base.py
@@ -15,16 +15,20 @@
 #  specific language governing permissions and limitations
 #  under the License.
 
+from typing import Any, Dict, Type, cast
+
+from typing_extensions import Self
+
 from .query import Bool, Q
 from .response import UpdateByQueryResponse
 from .search_base import ProxyDescriptor, QueryProxy, Request
-from .utils import recursive_to_dict
+from .utils import _R, JSONType, recursive_to_dict
 
 
-class UpdateByQueryBase(Request):
-    query = ProxyDescriptor("query")
+class UpdateByQueryBase(Request[_R]):
+    query = ProxyDescriptor["UpdateByQueryBase[_R]"]("query")
 
-    def __init__(self, **kwargs):
+    def __init__(self, **kwargs: Any):
         """
         Update by query request to elasticsearch.
 
@@ -37,18 +41,18 @@ class UpdateByQueryBase(Request):
 
         """
         super().__init__(**kwargs)
-        self._response_class = UpdateByQueryResponse
-        self._script = {}
+        self._response_class = UpdateByQueryResponse[_R]
+        self._script: Dict[str, Any] = {}
         self._query_proxy = QueryProxy(self, "query")
 
-    def filter(self, *args, **kwargs):
-        return self.query(Bool(filter=[Q(*args, **kwargs)]))
+    def filter(self, *args: Any, **kwargs: Any) -> Self:
+        return cast(Self, self.query(Bool(filter=[Q(*args, **kwargs)])))
 
-    def exclude(self, *args, **kwargs):
-        return self.query(Bool(filter=[~Q(*args, **kwargs)]))
+    def exclude(self, *args: Any, **kwargs: Any) -> Self:
+        return cast(Self, self.query(Bool(filter=[~Q(*args, **kwargs)])))
 
     @classmethod
-    def from_dict(cls, d):
+    def from_dict(cls, d: Dict[str, Any]) -> Self:
         """
         Construct a new `UpdateByQuery` instance from a raw dict containing the search
         body. Useful when migrating from raw dictionaries.
@@ -69,7 +73,7 @@ class UpdateByQueryBase(Request):
         u.update_from_dict(d)
         return u
 
-    def _clone(self):
+    def _clone(self) -> Self:
         """
         Return a clone of the current search request. Performs a shallow copy
         of all the underlying objects. Used internally by most state modifying
@@ -82,7 +86,7 @@ class UpdateByQueryBase(Request):
         ubq.query._proxied = self.query._proxied
         return ubq
 
-    def response_class(self, cls):
+    def response_class(self, cls: Type[UpdateByQueryResponse[_R]]) -> Self:
         """
         Override the default wrapper used for the response.
         """
@@ -90,7 +94,7 @@ class UpdateByQueryBase(Request):
         ubq._response_class = cls
         return ubq
 
-    def update_from_dict(self, d):
+    def update_from_dict(self, d: Dict[str, Any]) -> Self:
         """
         Apply options from a serialized body to the current instance. Modifies
         the object in-place. Used mostly by ``from_dict``.
@@ -103,7 +107,7 @@ class UpdateByQueryBase(Request):
         self._extra.update(d)
         return self
 
-    def script(self, **kwargs):
+    def script(self, **kwargs: Any) -> Self:
         """
         Define update action to take:
         https://www.elastic.co/guide/en/elasticsearch/reference/current/modules-scripting-using.html
@@ -126,7 +130,7 @@ class UpdateByQueryBase(Request):
         ubq._script.update(kwargs)
         return ubq
 
-    def to_dict(self, **kwargs):
+    def to_dict(self, **kwargs: Any) -> Dict[str, JSONType]:
         """
         Serialize the search into the dictionary that will be sent over as the
         request'ubq body.

--- a/elasticsearch_dsl/utils.py
+++ b/elasticsearch_dsl/utils.py
@@ -38,7 +38,6 @@ from typing import (
 from typing_extensions import Self, TypeAlias, TypeVar
 
 from .exceptions import UnknownDslObject, ValidationException
-from .response import Hit
 
 if TYPE_CHECKING:
     from elastic_transport import ObjectApiResponse
@@ -47,6 +46,7 @@ if TYPE_CHECKING:
     from .document_base import DocumentOptions
     from .field import Field
     from .index_base import IndexBase
+    from .response import Hit  # noqa: F401
 
 UsingType: TypeAlias = Union[str, "Elasticsearch"]
 AsyncUsingType: TypeAlias = Union[str, "AsyncElasticsearch"]
@@ -57,7 +57,7 @@ JSONType: TypeAlias = Union[
 ]
 
 _ValT = TypeVar("_ValT")  # used by AttrDict
-_R = TypeVar("_R", default=Hit)  # used by Search and Response classes
+_R = TypeVar("_R", default="Hit")  # used by Search and Response classes
 
 SKIP_VALUES = ("", None)
 EXPAND__TO_DOT = True
@@ -219,6 +219,7 @@ class AttrDict(Generic[_ValT]):
         del self._d_[key]
 
     def __setattr__(self, name: str, value: _ValT) -> None:
+        print(self._d_)
         if name in self._d_ or not hasattr(self.__class__, name):
             self._d_[name] = value
         else:
@@ -295,7 +296,6 @@ class DslBase(metaclass=DslMeta):
           all values in the `must` attribute into Query objects)
     """
 
-    # _type_name: ClassVar[str]
     _param_defs: ClassVar[Dict[str, Dict[str, Union[str, bool]]]] = {}
 
     @classmethod

--- a/elasticsearch_dsl/utils.py
+++ b/elasticsearch_dsl/utils.py
@@ -31,14 +31,14 @@ from typing import (
     Optional,
     Tuple,
     Type,
-    TypeVar,
     Union,
     cast,
 )
 
-from typing_extensions import Self, TypeAlias
+from typing_extensions import Self, TypeAlias, TypeVar
 
 from .exceptions import UnknownDslObject, ValidationException
+from .response import Hit
 
 if TYPE_CHECKING:
     from elastic_transport import ObjectApiResponse
@@ -56,7 +56,8 @@ JSONType: TypeAlias = Union[
     int, bool, str, float, List["JSONType"], Dict[str, "JSONType"]
 ]
 
-_ValT = TypeVar("_ValT")
+_ValT = TypeVar("_ValT")  # used by AttrDict
+_R = TypeVar("_R", default=Hit)  # used by Search and Response classes
 
 SKIP_VALUES = ("", None)
 EXPAND__TO_DOT = True

--- a/noxfile.py
+++ b/noxfile.py
@@ -30,26 +30,7 @@ SOURCE_FILES = (
 )
 
 TYPED_FILES = (
-    "elasticsearch_dsl/async_connections.py",
-    "elasticsearch_dsl/connections.py",
-    "elasticsearch_dsl/aggs.py",
-    "elasticsearch_dsl/analysis.py",
-    "elasticsearch_dsl/document.py",
-    "elasticsearch_dsl/document_base.py",
-    "elasticsearch_dsl/exceptions.py",
-    "elasticsearch_dsl/faceted_search_base.py",
-    "elasticsearch_dsl/faceted_search.py",
-    "elasticsearch_dsl/field.py",
-    "elasticsearch_dsl/function.py",
-    "elasticsearch_dsl/query.py",
-    "elasticsearch_dsl/search_base.py",
-    "elasticsearch_dsl/serializer.py",
-    "elasticsearch_dsl/utils.py",
-    "elasticsearch_dsl/wrappers.py",
-    "elasticsearch_dsl/response/__init__.py",
-    "elasticsearch_dsl/response/aggs.py",
-    "elasticsearch_dsl/_async/document.py",
-    "elasticsearch_dsl/_sync/document.py",
+    # elasticsearch_dsl files are all assumed typed so they are omitted here
     "tests/test_connections.py",
     "tests/test_aggs.py",
     "tests/test_analysis.py",
@@ -129,7 +110,7 @@ def type_check(session):
 
     for line in mypy_output.split("\n"):
         filepath = line.partition(":")[0]
-        if filepath in TYPED_FILES:
+        if filepath.startswith("elasticsearch_dsl/") or filepath in TYPED_FILES:
             errors.append(line)
     if errors:
         session.error("\n" + "\n".join(errors))

--- a/noxfile.py
+++ b/noxfile.py
@@ -46,6 +46,8 @@ TYPED_FILES = (
     "elasticsearch_dsl/serializer.py",
     "elasticsearch_dsl/utils.py",
     "elasticsearch_dsl/wrappers.py",
+    "elasticsearch_dsl/response/__init__.py",
+    "elasticsearch_dsl/response/aggs.py",
     "elasticsearch_dsl/_async/document.py",
     "elasticsearch_dsl/_sync/document.py",
     "tests/test_connections.py",

--- a/tests/_async/test_search.py
+++ b/tests/_async/test_search.py
@@ -625,11 +625,11 @@ def test_exclude():
 
 @pytest.mark.asyncio
 async def test_delete_by_query(async_mock_client):
-    s = AsyncSearch(using="mock").query("match", lang="java")
+    s = AsyncSearch(using="mock", index="i").query("match", lang="java")
     await s.delete()
 
     async_mock_client.delete_by_query.assert_awaited_once_with(
-        index=None, body={"query": {"match": {"lang": "java"}}}
+        index=["i"], body={"query": {"match": {"lang": "java"}}}
     )
 
 

--- a/tests/_async/test_update_by_query.py
+++ b/tests/_async/test_update_by_query.py
@@ -140,11 +140,11 @@ def test_from_dict_doesnt_need_query():
 
 @pytest.mark.asyncio
 async def test_params_being_passed_to_search(async_mock_client):
-    ubq = AsyncUpdateByQuery(using="mock")
+    ubq = AsyncUpdateByQuery(using="mock", index="i")
     ubq = ubq.params(routing="42")
     await ubq.execute()
 
-    async_mock_client.update_by_query.assert_called_once_with(index=None, routing="42")
+    async_mock_client.update_by_query.assert_called_once_with(index=["i"], routing="42")
 
 
 def test_overwrite_script():

--- a/tests/_sync/test_search.py
+++ b/tests/_sync/test_search.py
@@ -623,11 +623,11 @@ def test_exclude():
 
 @pytest.mark.sync
 def test_delete_by_query(mock_client):
-    s = Search(using="mock").query("match", lang="java")
+    s = Search(using="mock", index="i").query("match", lang="java")
     s.delete()
 
     mock_client.delete_by_query.assert_called_once_with(
-        index=None, body={"query": {"match": {"lang": "java"}}}
+        index=["i"], body={"query": {"match": {"lang": "java"}}}
     )
 
 

--- a/tests/_sync/test_update_by_query.py
+++ b/tests/_sync/test_update_by_query.py
@@ -140,11 +140,11 @@ def test_from_dict_doesnt_need_query():
 
 @pytest.mark.sync
 def test_params_being_passed_to_search(mock_client):
-    ubq = UpdateByQuery(using="mock")
+    ubq = UpdateByQuery(using="mock", index="i")
     ubq = ubq.params(routing="42")
     ubq.execute()
 
-    mock_client.update_by_query.assert_called_once_with(index=None, routing="42")
+    mock_client.update_by_query.assert_called_once_with(index=["i"], routing="42")
 
 
 def test_overwrite_script():

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -190,6 +190,7 @@ async def async_write_client(write_client, async_client):
 def mock_client(dummy_response):
     client = Mock()
     client.search.return_value = dummy_response
+    client.update_by_query.return_value = dummy_response
     add_connection("mock", client)
 
     yield client
@@ -473,7 +474,7 @@ async def async_pull_request(async_write_client):
 
 
 @fixture
-def setup_ubq_tests(client):
+def setup_ubq_tests(client) -> str:
     index = "test-git"
     create_git_index(client, index)
     bulk(client, TEST_GIT_DATA, raise_on_error=True, refresh=True)

--- a/tests/test_integration/_async/test_update_by_query.py
+++ b/tests/test_integration/_async/test_update_by_query.py
@@ -42,7 +42,7 @@ async def test_update_by_query_no_script(async_write_client, setup_ubq_tests):
 
 
 @pytest.mark.asyncio
-async def test_update_by_query_with_script(async_write_client, setup_ubq_tests):
+async def test_update_by_query_with_script(async_write_client, setup_ubq_tests: str):
     index = setup_ubq_tests
 
     ubq = (
@@ -60,7 +60,7 @@ async def test_update_by_query_with_script(async_write_client, setup_ubq_tests):
 
 
 @pytest.mark.asyncio
-async def test_delete_by_query_with_script(async_write_client, setup_ubq_tests):
+async def test_delete_by_query_with_script(async_write_client, setup_ubq_tests: str):
     index = setup_ubq_tests
 
     ubq = (

--- a/tests/test_integration/_sync/test_update_by_query.py
+++ b/tests/test_integration/_sync/test_update_by_query.py
@@ -42,7 +42,7 @@ def test_update_by_query_no_script(write_client, setup_ubq_tests):
 
 
 @pytest.mark.sync
-def test_update_by_query_with_script(write_client, setup_ubq_tests):
+def test_update_by_query_with_script(write_client, setup_ubq_tests: str):
     index = setup_ubq_tests
 
     ubq = (
@@ -60,7 +60,7 @@ def test_update_by_query_with_script(write_client, setup_ubq_tests):
 
 
 @pytest.mark.sync
-def test_delete_by_query_with_script(write_client, setup_ubq_tests):
+def test_delete_by_query_with_script(write_client, setup_ubq_tests: str):
     index = setup_ubq_tests
 
     ubq = (

--- a/utils/run-unasync.py
+++ b/utils/run-unasync.py
@@ -86,6 +86,8 @@ def main(check=False):
 
     filepaths = []
     for root, _, filenames in os.walk(Path(__file__).absolute().parent.parent):
+        if "/site-packages" in root or "/." in root or "__pycache__" in root:
+            continue
         for filename in filenames:
             if filename.rpartition(".")[-1] in (
                 "py",


### PR DESCRIPTION
This change adds type hints to the remaining files in the library (not including tests and examples, which I'll do separately).

Interesting things to note:

- The `exists_type()`, `upgrade()` and `get_upgrade()` methods of the index do not exist in the 8.x low-level client, so I have removed them from this client as well.
- I have modified the type check action in noxfile.py to only use an include list for tests and examples, which currently have partial support for types. For the main library all files are all considered typed without the need to add them to the list.
- It is quite likely that some types will have to be refined once the tests and examples are typed.
- I have to think about adding some `Protocol` definitions to the response classes, so that they can have better types and need less/no casts. This will come later, so for now I have continued making the necessary casts to silence mypy.