### PR TITLE
replace JSONType with Any

### DIFF
--- a/elasticsearch_dsl/_async/search.py
+++ b/elasticsearch_dsl/_async/search.py
@@ -25,7 +25,7 @@ from typing_extensions import Self
 from ..async_connections import get_connection
 from ..response import Response
 from ..search_base import MultiSearchBase, SearchBase
-from ..utils import _R, AsyncUsingType, AttrDict, JSONType
+from ..utils import _R, AsyncUsingType, AttrDict
 
 
 class AsyncSearch(SearchBase[_R]):
@@ -108,9 +108,9 @@ class AsyncSearch(SearchBase[_R]):
         async for hit in async_scan(
             es, query=self.to_dict(), index=self._index, **self._params
         ):
-            yield self._get_result(cast(AttrDict[JSONType], hit))
+            yield self._get_result(cast(AttrDict[Any], hit))
 
-    async def delete(self) -> AttrDict[JSONType]:
+    async def delete(self) -> AttrDict[Any]:
         """
         delete() executes the query by delegating to delete_by_query()
         """
@@ -120,7 +120,7 @@ class AsyncSearch(SearchBase[_R]):
 
         return AttrDict(
             cast(
-                Dict[str, JSONType],
+                Dict[str, Any],
                 await es.delete_by_query(
                     index=self._index, body=self.to_dict(), **self._params
                 ),
@@ -214,5 +214,5 @@ class AsyncEmptySearch(AsyncSearch[_R]):
         return
         yield  # a bit strange, but this forces an empty generator function
 
-    async def delete(self) -> AttrDict[JSONType]:
-        return AttrDict[JSONType]({})
+    async def delete(self) -> AttrDict[Any]:
+        return AttrDict[Any]({})

--- a/elasticsearch_dsl/_async/update_by_query.py
+++ b/elasticsearch_dsl/_async/update_by_query.py
@@ -40,7 +40,7 @@ class AsyncUpdateByQuery(UpdateByQueryBase[_R]):
             self,
             (
                 await es.update_by_query(
-                    index=self._index, **self.to_dict(), **self._params  # type: ignore
+                    index=self._index, **self.to_dict(), **self._params
                 )
             ).body,
         )

--- a/elasticsearch_dsl/_sync/search.py
+++ b/elasticsearch_dsl/_sync/search.py
@@ -25,7 +25,7 @@ from typing_extensions import Self
 from ..connections import get_connection
 from ..response import Response
 from ..search_base import MultiSearchBase, SearchBase
-from ..utils import _R, AttrDict, JSONType, UsingType
+from ..utils import _R, AttrDict, UsingType
 
 
 class Search(SearchBase[_R]):
@@ -104,9 +104,9 @@ class Search(SearchBase[_R]):
         es = get_connection(self._using)
 
         for hit in scan(es, query=self.to_dict(), index=self._index, **self._params):
-            yield self._get_result(cast(AttrDict[JSONType], hit))
+            yield self._get_result(cast(AttrDict[Any], hit))
 
-    def delete(self) -> AttrDict[JSONType]:
+    def delete(self) -> AttrDict[Any]:
         """
         delete() executes the query by delegating to delete_by_query()
         """
@@ -116,7 +116,7 @@ class Search(SearchBase[_R]):
 
         return AttrDict(
             cast(
-                Dict[str, JSONType],
+                Dict[str, Any],
                 es.delete_by_query(
                     index=self._index, body=self.to_dict(), **self._params
                 ),
@@ -208,5 +208,5 @@ class EmptySearch(Search[_R]):
         return
         yield  # a bit strange, but this forces an empty generator function
 
-    def delete(self) -> AttrDict[JSONType]:
-        return AttrDict[JSONType]({})
+    def delete(self) -> AttrDict[Any]:
+        return AttrDict[Any]({})

--- a/elasticsearch_dsl/_sync/update_by_query.py
+++ b/elasticsearch_dsl/_sync/update_by_query.py
@@ -39,9 +39,7 @@ class UpdateByQuery(UpdateByQueryBase[_R]):
         self._response = self._response_class(
             self,
             (
-                es.update_by_query(
-                    index=self._index, **self.to_dict(), **self._params  # type: ignore
-                )
+                es.update_by_query(index=self._index, **self.to_dict(), **self._params)
             ).body,
         )
         return self._response

--- a/elasticsearch_dsl/aggs.py
+++ b/elasticsearch_dsl/aggs.py
@@ -31,7 +31,7 @@ from typing import (
 )
 
 from .response.aggs import AggResponse, BucketData, FieldBucketData, TopHitsData
-from .utils import _R, AttrDict, DslBase, JSONType
+from .utils import _R, AttrDict, DslBase
 
 if TYPE_CHECKING:
     from .query import Query
@@ -96,10 +96,10 @@ class Agg(DslBase, Generic[_R]):
     def __contains__(self, key: str) -> bool:
         return False
 
-    def to_dict(self) -> Dict[str, JSONType]:
+    def to_dict(self) -> Dict[str, Any]:
         d = super().to_dict()
         if isinstance(d[self.name], dict):
-            n = cast(Dict[str, JSONType], d[self.name])
+            n = cast(Dict[str, Any], d[self.name])
             if "meta" in n:
                 d["meta"] = n.pop("meta")
         return d
@@ -170,7 +170,7 @@ class Bucket(AggBase[_R], Agg[_R]):
         # remember self for chaining
         self._base = self
 
-    def to_dict(self) -> Dict[str, JSONType]:
+    def to_dict(self) -> Dict[str, Any]:
         d = super(AggBase, self).to_dict()
         if isinstance(d[self.name], dict):
             n = cast(AttrDict[Any], d[self.name])
@@ -191,7 +191,7 @@ class Filter(Bucket[_R]):
             params["filter"] = filter
         super().__init__(**params)
 
-    def to_dict(self) -> Dict[str, JSONType]:
+    def to_dict(self) -> Dict[str, Any]:
         d = super().to_dict()
         if isinstance(d[self.name], dict):
             n = cast(AttrDict[Any], d[self.name])

--- a/elasticsearch_dsl/analysis.py
+++ b/elasticsearch_dsl/analysis.py
@@ -18,7 +18,7 @@
 from typing import Any, ClassVar, Dict, List, Optional, Union, cast
 
 from . import async_connections, connections
-from .utils import AsyncUsingType, AttrDict, DslBase, JSONType, UsingType, merge
+from .utils import AsyncUsingType, AttrDict, DslBase, UsingType, merge
 
 __all__ = ["tokenizer", "analyzer", "char_filter", "token_filter", "normalizer"]
 
@@ -52,7 +52,7 @@ class CustomAnalysis:
         self._name = filter_name
         super().__init__(**kwargs)
 
-    def to_dict(self) -> Dict[str, JSONType]:
+    def to_dict(self) -> Dict[str, Any]:
         # only name to present in lists
         return self._name  # type: ignore
 
@@ -109,7 +109,7 @@ class BuiltinAnalysis:
         self._name = name
         super().__init__()
 
-    def to_dict(self) -> Dict[str, JSONType]:
+    def to_dict(self) -> Dict[str, Any]:
         # only name to present in lists
         return self._name  # type: ignore
 

--- a/elasticsearch_dsl/document_base.py
+++ b/elasticsearch_dsl/document_base.py
@@ -36,7 +36,7 @@ from typing_extensions import dataclass_transform
 from .exceptions import ValidationException
 from .field import Binary, Boolean, Date, Field, Float, Integer, Nested, Object, Text
 from .mapping import Mapping
-from .utils import DOC_META_FIELDS, JSONType, ObjectBase
+from .utils import DOC_META_FIELDS, ObjectBase
 
 if TYPE_CHECKING:
     from elastic_transport import ObjectApiResponse
@@ -376,7 +376,7 @@ class DocumentBase(ObjectBase):
             ),
         )
 
-    def to_dict(self, include_meta: bool = False, skip_empty: bool = True) -> Dict[str, JSONType]:  # type: ignore[override]
+    def to_dict(self, include_meta: bool = False, skip_empty: bool = True) -> Dict[str, Any]:  # type: ignore[override]
         """
         Serialize the instance into a dictionary so that it can be saved in elasticsearch.
 

--- a/elasticsearch_dsl/faceted_search_base.py
+++ b/elasticsearch_dsl/faceted_search_base.py
@@ -23,7 +23,7 @@ from typing_extensions import Self
 from .aggs import A, Agg
 from .query import MatchAll, Nested, Query, Range, Terms
 from .response import Response
-from .utils import _R, AttrDict, JSONType
+from .utils import _R, AttrDict
 
 if TYPE_CHECKING:
     from .response.aggs import BucketData
@@ -137,9 +137,9 @@ class TermsFacet(Facet[_R]):
 class RangeFacet(Facet[_R]):
     agg_type = "range"
 
-    def _range_to_dict(self, range: Tuple[Any, Tuple[int, int]]) -> Dict[str, JSONType]:
+    def _range_to_dict(self, range: Tuple[Any, Tuple[int, int]]) -> Dict[str, Any]:
         key, _range = range
-        out: Dict[str, JSONType] = {"key": key}
+        out: Dict[str, Any] = {"key": key}
         if _range[0] is not None:
             out["from"] = _range[0]
         if _range[1] is not None:

--- a/elasticsearch_dsl/field.py
+++ b/elasticsearch_dsl/field.py
@@ -37,7 +37,7 @@ from dateutil import parser, tz
 
 from .exceptions import ValidationException
 from .query import Q
-from .utils import AttrDict, AttrList, DslBase, JSONType
+from .utils import AttrDict, AttrList, DslBase
 from .wrappers import Range
 
 if TYPE_CHECKING:
@@ -150,9 +150,9 @@ class Field(DslBase):
             raise ValidationException("Value required for this field.")
         return data
 
-    def to_dict(self) -> Dict[str, JSONType]:
+    def to_dict(self) -> Dict[str, Any]:
         d = super().to_dict()
-        name, value = cast(Tuple[str, Dict[str, JSONType]], d.popitem())
+        name, value = cast(Tuple[str, Dict[str, Any]], d.popitem())
         value["type"] = name
         return value
 
@@ -161,7 +161,7 @@ class CustomField(Field):
     name = "custom"
     _coerce = True
 
-    def to_dict(self) -> Dict[str, JSONType]:
+    def to_dict(self) -> Dict[str, Any]:
         if isinstance(self.builtin_type, Field):
             return self.builtin_type.to_dict()
 

--- a/elasticsearch_dsl/function.py
+++ b/elasticsearch_dsl/function.py
@@ -19,7 +19,7 @@ import collections.abc
 from copy import deepcopy
 from typing import Any, ClassVar, Dict, MutableMapping, Optional, Union, overload
 
-from .utils import DslBase, JSONType
+from .utils import DslBase
 
 
 @overload
@@ -89,7 +89,7 @@ class ScoreFunction(DslBase):
     }
     name: ClassVar[Optional[str]] = None
 
-    def to_dict(self) -> Dict[str, JSONType]:
+    def to_dict(self) -> Dict[str, Any]:
         d = super().to_dict()
         # filter and query dicts should be at the same level as us
         for k in self._param_defs:
@@ -107,7 +107,7 @@ class ScriptScore(ScoreFunction):
 class BoostFactor(ScoreFunction):
     name = "boost_factor"
 
-    def to_dict(self) -> Dict[str, JSONType]:
+    def to_dict(self) -> Dict[str, Any]:
         d = super().to_dict()
         if self.name is not None:
             val = d[self.name]

--- a/elasticsearch_dsl/mapping_base.py
+++ b/elasticsearch_dsl/mapping_base.py
@@ -22,7 +22,7 @@ from typing import Any, Dict, Iterator, List, Optional, Tuple, cast
 from typing_extensions import Self
 
 from .field import Field, Nested, Text, construct_field
-from .utils import DslBase, JSONType
+from .utils import DslBase
 
 META_FIELDS = frozenset(
     (
@@ -205,7 +205,7 @@ class MappingBase:
         self._meta[name] = kwargs if params is None else params
         return self
 
-    def to_dict(self) -> Dict[str, JSONType]:
+    def to_dict(self) -> Dict[str, Any]:
         meta = self._meta
 
         # hard coded serialization of analyzers in _all

--- a/elasticsearch_dsl/response/__init__.py
+++ b/elasticsearch_dsl/response/__init__.py
@@ -28,7 +28,7 @@ from typing import (
     cast,
 )
 
-from ..utils import _R, AttrDict, AttrList, JSONType, _wrap
+from ..utils import _R, AttrDict, AttrList, _wrap
 from .hit import Hit, HitMeta
 
 if TYPE_CHECKING:
@@ -40,7 +40,7 @@ if TYPE_CHECKING:
 __all__ = ["Response", "AggResponse", "UpdateByQueryResponse", "Hit", "HitMeta"]
 
 
-class Response(AttrDict[JSONType], Generic[_R]):
+class Response(AttrDict[Any], Generic[_R]):
     _search: "SearchBase[_R]"
     _faceted_search: "FacetedSearchBase[_R]"
     _doc_class: Optional[_R]
@@ -92,7 +92,7 @@ class Response(AttrDict[JSONType], Generic[_R]):
     @property
     def hits(self) -> List[_R]:
         if not hasattr(self, "_hits"):
-            h = cast(AttrDict[JSONType], self._d_["hits"])
+            h = cast(AttrDict[Any], self._d_["hits"])
 
             try:
                 hits = AttrList(list(map(self._search._get_result, h["hits"])))
@@ -116,7 +116,7 @@ class Response(AttrDict[JSONType], Generic[_R]):
             aggs = AggResponse[_R](
                 cast("Agg[_R]", self._search.aggs),
                 self._search,
-                cast(Dict[str, JSONType], self._d_.get("aggregations", {})),
+                cast(Dict[str, Any], self._d_.get("aggregations", {})),
             )
 
             # avoid assigning _aggs into self._d_
@@ -156,12 +156,10 @@ class Response(AttrDict[JSONType], Generic[_R]):
         return self._search.extra(search_after=self.hits[-1].meta.sort)  # type: ignore
 
 
-class AggResponse(AttrDict[JSONType], Generic[_R]):
+class AggResponse(AttrDict[Any], Generic[_R]):
     _meta: Dict[str, Any]
 
-    def __init__(
-        self, aggs: "Agg[_R]", search: "Request[_R]", data: Dict[str, JSONType]
-    ):
+    def __init__(self, aggs: "Agg[_R]", search: "Request[_R]", data: Dict[str, Any]):
         super(AttrDict, self).__setattr__("_meta", {"search": search, "aggs": aggs})
         super().__init__(data)
 
@@ -177,7 +175,7 @@ class AggResponse(AttrDict[JSONType], Generic[_R]):
             yield self[name]
 
 
-class UpdateByQueryResponse(AttrDict[JSONType], Generic[_R]):
+class UpdateByQueryResponse(AttrDict[Any], Generic[_R]):
     _search: "UpdateByQueryBase[_R]"
 
     def __init__(

--- a/elasticsearch_dsl/response/aggs.py
+++ b/elasticsearch_dsl/response/aggs.py
@@ -17,7 +17,7 @@
 
 from typing import TYPE_CHECKING, Any, Dict, Iterator, List, Optional, Union, cast
 
-from ..utils import _R, AttrDict, AttrList, JSONType
+from ..utils import _R, AttrDict, AttrList
 from . import AggResponse, Response
 
 if TYPE_CHECKING:
@@ -31,7 +31,7 @@ class Bucket(AggResponse[_R]):
         self,
         aggs: "Agg[_R]",
         search: "SearchBase[_R]",
-        data: Dict[str, JSONType],
+        data: Dict[str, Any],
         field: Optional["Field"] = None,
     ):
         super().__init__(aggs, search, data)
@@ -42,7 +42,7 @@ class FieldBucket(Bucket[_R]):
         self,
         aggs: "Agg[_R]",
         search: "SearchBase[_R]",
-        data: Dict[str, JSONType],
+        data: Dict[str, Any],
         field: Optional["Field"] = None,
     ):
         if field:
@@ -52,9 +52,9 @@ class FieldBucket(Bucket[_R]):
 
 class BucketData(AggResponse[_R]):
     _bucket_class = Bucket
-    _buckets: Union[AttrDict[JSONType], AttrList]
+    _buckets: Union[AttrDict[Any], AttrList]
 
-    def _wrap_bucket(self, data: Dict[str, JSONType]) -> Bucket[_R]:
+    def _wrap_bucket(self, data: Dict[str, Any]) -> Bucket[_R]:
         return self._bucket_class(
             self._meta["aggs"],
             self._meta["search"],
@@ -74,16 +74,16 @@ class BucketData(AggResponse[_R]):
         return super().__getitem__(key)
 
     @property
-    def buckets(self) -> Union[AttrDict[JSONType], AttrList]:
+    def buckets(self) -> Union[AttrDict[Any], AttrList]:
         if not hasattr(self, "_buckets"):
             field = getattr(self._meta["aggs"], "field", None)
             if field:
                 self._meta["field"] = self._meta["search"]._resolve_field(field)
-            bs = cast(Union[Dict[str, JSONType], List[JSONType]], self._d_["buckets"])
+            bs = cast(Union[Dict[str, Any], List[Any]], self._d_["buckets"])
             if isinstance(bs, list):
                 ret = AttrList(bs, obj_wrapper=self._wrap_bucket)
             else:
-                ret = AttrDict[JSONType]({k: self._wrap_bucket(bs[k]) for k in bs})  # type: ignore
+                ret = AttrDict[Any]({k: self._wrap_bucket(bs[k]) for k in bs})  # type: ignore
             super(AttrDict, self).__setattr__("_buckets", ret)
         return self._buckets
 

--- a/elasticsearch_dsl/response/hit.py
+++ b/elasticsearch_dsl/response/hit.py
@@ -17,16 +17,16 @@
 
 from typing import Any, Dict, List, Tuple, cast
 
-from ..utils import AttrDict, HitMeta, JSONType
+from ..utils import AttrDict, HitMeta
 
 
-class Hit(AttrDict[JSONType]):
-    def __init__(self, document: Dict[str, JSONType]):
-        data: Dict[str, JSONType] = {}
+class Hit(AttrDict[Any]):
+    def __init__(self, document: Dict[str, Any]):
+        data: Dict[str, Any] = {}
         if "_source" in document:
-            data = cast(Dict[str, JSONType], document["_source"])
+            data = cast(Dict[str, Any], document["_source"])
         if "fields" in document:
-            data.update(cast(Dict[str, JSONType], document["fields"]))
+            data.update(cast(Dict[str, Any], document["fields"]))
 
         super().__init__(data)
         # assign meta as attribute and not as key in self._d_

--- a/elasticsearch_dsl/update_by_query_base.py
+++ b/elasticsearch_dsl/update_by_query_base.py
@@ -22,7 +22,7 @@ from typing_extensions import Self
 from .query import Bool, Q
 from .response import UpdateByQueryResponse
 from .search_base import ProxyDescriptor, QueryProxy, Request
-from .utils import _R, JSONType, recursive_to_dict
+from .utils import _R, recursive_to_dict
 
 
 class UpdateByQueryBase(Request[_R]):
@@ -130,7 +130,7 @@ class UpdateByQueryBase(Request[_R]):
         ubq._script.update(kwargs)
         return ubq
 
-    def to_dict(self, **kwargs: Any) -> Dict[str, JSONType]:
+    def to_dict(self, **kwargs: Any) -> Dict[str, Any]:
         """
         Serialize the search into the dictionary that will be sent over as the
         request'ubq body.

--- a/elasticsearch_dsl/utils.py
+++ b/elasticsearch_dsl/utils.py
@@ -52,10 +52,6 @@ UsingType: TypeAlias = Union[str, "Elasticsearch"]
 AsyncUsingType: TypeAlias = Union[str, "AsyncElasticsearch"]
 AnyUsingType: TypeAlias = Union[str, "Elasticsearch", "AsyncElasticsearch"]
 
-JSONType: TypeAlias = Union[
-    int, bool, str, float, List["JSONType"], Dict[str, "JSONType"]
-]
-
 _ValT = TypeVar("_ValT")  # used by AttrDict
 _R = TypeVar("_R", default="Hit")  # used by Search and Response classes
 
@@ -401,7 +397,7 @@ class DslBase(metaclass=DslMeta):
             return AttrDict(value)
         return value
 
-    def to_dict(self) -> Dict[str, JSONType]:
+    def to_dict(self) -> Dict[str, Any]:
         """
         Serialize the DSL object to plain dict
         """
@@ -447,7 +443,7 @@ class DslBase(metaclass=DslMeta):
         return c
 
 
-class HitMeta(AttrDict[JSONType]):
+class HitMeta(AttrDict[Any]):
     def __init__(
         self,
         document: Dict[str, Any],
@@ -464,7 +460,7 @@ class HitMeta(AttrDict[JSONType]):
         super().__init__(d)
 
 
-class ObjectBase(AttrDict[JSONType]):
+class ObjectBase(AttrDict[Any]):
     _doc_type: "DocumentOptions"
     _index: "IndexBase"
     meta: HitMeta
@@ -537,10 +533,10 @@ class ObjectBase(AttrDict[JSONType]):
                 v = f.deserialize(v)
             setattr(self, k, v)
 
-    def __getstate__(self) -> Tuple[Dict[str, JSONType], Dict[str, JSONType]]:  # type: ignore[override]
+    def __getstate__(self) -> Tuple[Dict[str, Any], Dict[str, Any]]:  # type: ignore[override]
         return self.to_dict(), self.meta._d_
 
-    def __setstate__(self, state: Tuple[Dict[str, JSONType], Dict[str, JSONType]]) -> None:  # type: ignore[override]
+    def __setstate__(self, state: Tuple[Dict[str, Any], Dict[str, Any]]) -> None:  # type: ignore[override]
         data, meta = state
         super(AttrDict, self).__setattr__("_d_", {})
         super(AttrDict, self).__setattr__("meta", HitMeta(meta))
@@ -565,7 +561,7 @@ class ObjectBase(AttrDict[JSONType]):
         else:
             super().__setattr__(name, value)
 
-    def to_dict(self, skip_empty: bool = True) -> Dict[str, JSONType]:
+    def to_dict(self, skip_empty: bool = True) -> Dict[str, Any]:
         out = {}
         for k, v in self._d_.items():
             # if this is a mapped field,
@@ -599,7 +595,7 @@ class ObjectBase(AttrDict[JSONType]):
                 errors.setdefault(name, []).append(e)
 
             if name in self._d_ or data not in ([], {}, None):
-                self._d_[name] = cast(JSONType, data)
+                self._d_[name] = cast(Any, data)
 
         if validate and errors:
             raise ValidationException(errors)


### PR DESCRIPTION
One of the issues I'm facing when trying to type the examples is that JSONType was used in many places to represent responses from the API. Because this is an imperfect type hint, it requires adding casts all over the place.

With this change I'm removing `JSONType` and replacing it with `Any`. This matches the commonly used `ObjectApiResponse[Any]` from the low-level client, and lets mypy digest attribute accesses without generating warnings, in things like `self.meta.inner_hits.answer.hits`. Just by making this change a few type ignores can be removed, and no new typing errors appeared.

I think in the future I will revisit this and create proper types for the response structure, but for now I think `Any` is the best choice.