### PR TITLE
make fields typed as lists optional

### DIFF
--- a/tests/_async/test_document.py
+++ b/tests/_async/test_document.py
@@ -707,28 +707,32 @@ def test_doc_with_type_hints():
     assert doc.s4 == "foo"
     with raises(ValidationException) as exc_info:
         doc.full_clean()
-    assert set(exc_info.value.args[0].keys()) == {"st", "li", "k1"}
+    assert set(exc_info.value.args[0].keys()) == {"st", "k1", "k2", "s1", "s2", "s3"}
 
     doc.st = "s"
     doc.li = [1, 2, 3]
-    doc.k1 = "k"
+    doc.k1 = "k1"
+    doc.k2 = "k2"
+    doc.s1 = "s1"
+    doc.s2 = "s2"
+    doc.s3 = "s3"
     doc.full_clean()
 
     doc.ob = TypedInnerDoc()
     with raises(ValidationException) as exc_info:
         doc.full_clean()
     assert set(exc_info.value.args[0].keys()) == {"ob"}
-    assert set(exc_info.value.args[0]["ob"][0].args[0].keys()) == {"st", "li"}
+    assert set(exc_info.value.args[0]["ob"][0].args[0].keys()) == {"st"}
 
     doc.ob.st = "s"
     doc.ob.li = [1]
     doc.full_clean()
 
-    doc.ns.append(TypedInnerDoc(st="s"))
+    doc.ns.append(TypedInnerDoc(li=[1, 2]))
     with raises(ValidationException) as exc_info:
         doc.full_clean()
 
-    doc.ns[0].li = [1, 2]
+    doc.ns[0].st = "s"
     doc.full_clean()
 
     doc.ip = "1.2.3.4"
@@ -749,8 +753,12 @@ def test_doc_with_type_hints():
             }
         ],
         "ip": "1.2.3.4",
-        "k1": "k",
+        "k1": "k1",
+        "k2": "k2",
         "k3": "foo",
+        "s1": "s1",
+        "s2": "s2",
+        "s3": "s3",
         "s4": "foo",
     }
 

--- a/tests/_sync/test_document.py
+++ b/tests/_sync/test_document.py
@@ -707,28 +707,32 @@ def test_doc_with_type_hints():
     assert doc.s4 == "foo"
     with raises(ValidationException) as exc_info:
         doc.full_clean()
-    assert set(exc_info.value.args[0].keys()) == {"st", "li", "k1"}
+    assert set(exc_info.value.args[0].keys()) == {"st", "k1", "k2", "s1", "s2", "s3"}
 
     doc.st = "s"
     doc.li = [1, 2, 3]
-    doc.k1 = "k"
+    doc.k1 = "k1"
+    doc.k2 = "k2"
+    doc.s1 = "s1"
+    doc.s2 = "s2"
+    doc.s3 = "s3"
     doc.full_clean()
 
     doc.ob = TypedInnerDoc()
     with raises(ValidationException) as exc_info:
         doc.full_clean()
     assert set(exc_info.value.args[0].keys()) == {"ob"}
-    assert set(exc_info.value.args[0]["ob"][0].args[0].keys()) == {"st", "li"}
+    assert set(exc_info.value.args[0]["ob"][0].args[0].keys()) == {"st"}
 
     doc.ob.st = "s"
     doc.ob.li = [1]
     doc.full_clean()
 
-    doc.ns.append(TypedInnerDoc(st="s"))
+    doc.ns.append(TypedInnerDoc(li=[1, 2]))
     with raises(ValidationException) as exc_info:
         doc.full_clean()
 
-    doc.ns[0].li = [1, 2]
+    doc.ns[0].st = "s"
     doc.full_clean()
 
     doc.ip = "1.2.3.4"
@@ -749,8 +753,12 @@ def test_doc_with_type_hints():
             }
         ],
         "ip": "1.2.3.4",
-        "k1": "k",
+        "k1": "k1",
+        "k2": "k2",
         "k3": "foo",
+        "s1": "s1",
+        "s2": "s2",
+        "s3": "s3",
         "s4": "foo",
     }
 


### PR DESCRIPTION
I'm trying to type the examples, and another common issue I'm seeing is related to lists, either those created with `multi=True` or by using a `Nested` field.

The issue is with the state of the `required` option of the field. When using the non-typed field creation option this isn't a problem. Both `Text(multi=True)` and `Nested(SomeDoc)` work well with their default setting of `required=False`.

When using the new type hint definitions, however, the default for a typed field is to be required, and to make a field not required you have to wrap the type with `Optional`. This is okay for a scalar field, but for a list it creates confusion, because in terms of Python typing it is expected that an empty list is a valid value for a required field, but a required DSL field considers an empty list the same as `None` and does not allow it.

With this change, I'm changing the field creation logic to make sure that any fields that are created via type hints have `required=False` even when `Optional` is not given in the type hint, so that they work in the expected way and allow the empty list as a valid value.

No behavior changes are made for fields that are created without type hints.