### PR TITLE
Type hints for tests and examples

### DIFF
--- a/elasticsearch_dsl/__init__.py
+++ b/elasticsearch_dsl/__init__.py
@@ -16,7 +16,7 @@
 #  under the License.
 
 from . import connections
-from .aggs import A
+from .aggs import A, Agg
 from .analysis import analyzer, char_filter, normalizer, token_filter, tokenizer
 from .document import AsyncDocument, Document
 from .document_base import InnerDoc, M, MetaField, mapped_field
@@ -81,7 +81,8 @@ from .field import (
 from .function import SF
 from .index import AsyncIndex, AsyncIndexTemplate, Index, IndexTemplate
 from .mapping import AsyncMapping, Mapping
-from .query import Q
+from .query import Q, Query
+from .response import AggResponse, Response, UpdateByQueryResponse
 from .search import (
     AsyncEmptySearch,
     AsyncMultiSearch,
@@ -99,6 +100,8 @@ __version__ = VERSION
 __versionstr__ = ".".join(map(str, VERSION))
 __all__ = [
     "A",
+    "Agg",
+    "AggResponse",
     "AsyncDocument",
     "AsyncEmptySearch",
     "AsyncFacetedSearch",
@@ -158,11 +161,13 @@ __all__ = [
     "Object",
     "Percolator",
     "Q",
+    "Query",
     "Range",
     "RangeFacet",
     "RangeField",
     "RankFeature",
     "RankFeatures",
+    "Response",
     "SF",
     "ScaledFloat",
     "Search",
@@ -174,6 +179,7 @@ __all__ = [
     "TokenCount",
     "UnknownDslObject",
     "UpdateByQuery",
+    "UpdateByQueryResponse",
     "ValidationException",
     "analyzer",
     "char_filter",

--- a/elasticsearch_dsl/_async/index.py
+++ b/elasticsearch_dsl/_async/index.py
@@ -38,7 +38,7 @@ class AsyncIndexTemplate:
         name: str,
         template: str,
         index: Optional["AsyncIndex"] = None,
-        order: Optional[str] = None,
+        order: Optional[int] = None,
         **kwargs: Any,
     ):
         if index is None:
@@ -100,7 +100,7 @@ class AsyncIndex(IndexBase):
         self,
         template_name: str,
         pattern: Optional[str] = None,
-        order: Optional[str] = None,
+        order: Optional[int] = None,
     ) -> AsyncIndexTemplate:
         # TODO: should we allow pattern to be a top-level arg?
         # or maybe have an IndexPattern that allows for it and have

--- a/elasticsearch_dsl/_async/search.py
+++ b/elasticsearch_dsl/_async/search.py
@@ -16,7 +16,16 @@
 #  under the License.
 
 import contextlib
-from typing import Any, AsyncIterator, Dict, Iterator, List, Optional, cast
+from typing import (
+    TYPE_CHECKING,
+    Any,
+    AsyncIterator,
+    Dict,
+    Iterator,
+    List,
+    Optional,
+    cast,
+)
 
 from elasticsearch.exceptions import ApiError
 from elasticsearch.helpers import async_scan
@@ -68,6 +77,7 @@ class AsyncSearch(SearchBase[_R]):
             query=cast(Optional[Dict[str, Any]], d.get("query", None)),
             **self._params,
         )
+
         return cast(int, resp["count"])
 
     async def execute(self, ignore_cache: bool = False) -> Response[_R]:
@@ -174,6 +184,10 @@ class AsyncMultiSearch(MultiSearchBase[_R]):
     """
 
     _using: AsyncUsingType
+
+    if TYPE_CHECKING:
+
+        def add(self, search: AsyncSearch[_R]) -> Self: ...  # type: ignore[override]
 
     async def execute(
         self, ignore_cache: bool = False, raise_on_error: bool = True

--- a/elasticsearch_dsl/_sync/index.py
+++ b/elasticsearch_dsl/_sync/index.py
@@ -38,7 +38,7 @@ class IndexTemplate:
         name: str,
         template: str,
         index: Optional["Index"] = None,
-        order: Optional[str] = None,
+        order: Optional[int] = None,
         **kwargs: Any,
     ):
         if index is None:
@@ -94,7 +94,7 @@ class Index(IndexBase):
         self,
         template_name: str,
         pattern: Optional[str] = None,
-        order: Optional[str] = None,
+        order: Optional[int] = None,
     ) -> IndexTemplate:
         # TODO: should we allow pattern to be a top-level arg?
         # or maybe have an IndexPattern that allows for it and have

--- a/elasticsearch_dsl/_sync/search.py
+++ b/elasticsearch_dsl/_sync/search.py
@@ -16,7 +16,7 @@
 #  under the License.
 
 import contextlib
-from typing import Any, Dict, Iterator, List, Optional, cast
+from typing import TYPE_CHECKING, Any, Dict, Iterator, List, Optional, cast
 
 from elasticsearch.exceptions import ApiError
 from elasticsearch.helpers import scan
@@ -68,6 +68,7 @@ class Search(SearchBase[_R]):
             query=cast(Optional[Dict[str, Any]], d.get("query", None)),
             **self._params,
         )
+
         return cast(int, resp["count"])
 
     def execute(self, ignore_cache: bool = False) -> Response[_R]:
@@ -168,6 +169,10 @@ class MultiSearch(MultiSearchBase[_R]):
     """
 
     _using: UsingType
+
+    if TYPE_CHECKING:
+
+        def add(self, search: Search[_R]) -> Self: ...  # type: ignore[override]
 
     def execute(
         self, ignore_cache: bool = False, raise_on_error: bool = True

--- a/elasticsearch_dsl/aggs.py
+++ b/elasticsearch_dsl/aggs.py
@@ -140,7 +140,12 @@ class AggBase(Generic[_R]):
         return iter(self.aggs)
 
     def _agg(
-        self, bucket: bool, name: str, agg_type: str, *args: Any, **params: Any
+        self,
+        bucket: bool,
+        name: str,
+        agg_type: Union[Dict[str, Any], Agg[_R], str],
+        *args: Any,
+        **params: Any,
     ) -> Agg[_R]:
         agg = self[name] = A(agg_type, *args, **params)
 
@@ -151,14 +156,32 @@ class AggBase(Generic[_R]):
         else:
             return self._base
 
-    def metric(self, name: str, agg_type: str, *args: Any, **params: Any) -> Agg[_R]:
+    def metric(
+        self,
+        name: str,
+        agg_type: Union[Dict[str, Any], Agg[_R], str],
+        *args: Any,
+        **params: Any,
+    ) -> Agg[_R]:
         return self._agg(False, name, agg_type, *args, **params)
 
-    def bucket(self, name: str, agg_type: str, *args: Any, **params: Any) -> Agg[_R]:
-        return self._agg(True, name, agg_type, *args, **params)
+    def bucket(
+        self,
+        name: str,
+        agg_type: Union[Dict[str, Any], Agg[_R], str],
+        *args: Any,
+        **params: Any,
+    ) -> "Bucket[_R]":
+        return cast("Bucket[_R]", self._agg(True, name, agg_type, *args, **params))
 
-    def pipeline(self, name: str, agg_type: str, *args: Any, **params: Any) -> Agg[_R]:
-        return self._agg(False, name, agg_type, *args, **params)
+    def pipeline(
+        self,
+        name: str,
+        agg_type: Union[Dict[str, Any], Agg[_R], str],
+        *args: Any,
+        **params: Any,
+    ) -> "Pipeline[_R]":
+        return cast("Pipeline[_R]", self._agg(False, name, agg_type, *args, **params))
 
     def result(self, search: "SearchBase[_R]", data: Any) -> AttrDict[Any]:
         return BucketData(self, search, data)  # type: ignore

--- a/elasticsearch_dsl/document_base.py
+++ b/elasticsearch_dsl/document_base.py
@@ -195,9 +195,7 @@ class DocumentOptions:
                 field = None
                 field_args: List[Any] = []
                 field_kwargs: Dict[str, Any] = {}
-                if not isinstance(type_, type):
-                    raise TypeError(f"Cannot map type {type_}")
-                elif issubclass(type_, InnerDoc):
+                if isinstance(type_, type) and issubclass(type_, InnerDoc):
                     # object or nested field
                     field = Nested if multi else Object
                     field_args = [type_]

--- a/elasticsearch_dsl/field.py
+++ b/elasticsearch_dsl/field.py
@@ -225,9 +225,9 @@ class Object(Field):
     def _wrap(self, data: Dict[str, Any]) -> "InnerDoc":
         return self._doc_class.from_es(data, data_only=True)
 
-    def empty(self) -> Union["InnerDoc", AttrList]:
+    def empty(self) -> Union["InnerDoc", AttrList[Any]]:
         if self._multi:
-            return AttrList([], self._wrap)
+            return AttrList[Any]([], self._wrap)
         return self._empty()
 
     def to_dict(self) -> Dict[str, Any]:

--- a/elasticsearch_dsl/response/aggs.py
+++ b/elasticsearch_dsl/response/aggs.py
@@ -52,7 +52,7 @@ class FieldBucket(Bucket[_R]):
 
 class BucketData(AggResponse[_R]):
     _bucket_class = Bucket
-    _buckets: Union[AttrDict[Any], AttrList]
+    _buckets: Union[AttrDict[Any], AttrList[Any]]
 
     def _wrap_bucket(self, data: Dict[str, Any]) -> Bucket[_R]:
         return self._bucket_class(
@@ -70,11 +70,11 @@ class BucketData(AggResponse[_R]):
 
     def __getitem__(self, key: Any) -> Any:
         if isinstance(key, (int, slice)):
-            return cast(AttrList, self.buckets)[key]
+            return cast(AttrList[Any], self.buckets)[key]
         return super().__getitem__(key)
 
     @property
-    def buckets(self) -> Union[AttrDict[Any], AttrList]:
+    def buckets(self) -> Union[AttrDict[Any], AttrList[Any]]:
         if not hasattr(self, "_buckets"):
             field = getattr(self._meta["aggs"], "field", None)
             if field:

--- a/elasticsearch_dsl/search_base.py
+++ b/elasticsearch_dsl/search_base.py
@@ -122,11 +122,11 @@ class ProxyDescriptor(Generic[_S]):
         proxy._proxied = Q(value)
 
 
-class AggsProxy(AggBase, DslBase, Generic[_S]):
+class AggsProxy(AggBase[_R], DslBase):
     name = "aggs"
 
-    def __init__(self, search: _S):
-        self._base = cast("Agg", self)
+    def __init__(self, search: "SearchBase[_R]"):
+        self._base = cast("Agg[_R]", self)
         self._search = search
         self._params = {"aggs": {}}
 
@@ -367,7 +367,7 @@ class SearchBase(Request[_R]):
         """
         super().__init__(**kwargs)
 
-        self.aggs = AggsProxy(self)
+        self.aggs = AggsProxy[_R](self)
         self._sort: List[Union[str, Dict[str, Dict[str, str]]]] = []
         self._knn: List[Dict[str, Any]] = []
         self._rank: Dict[str, Any] = {}

--- a/elasticsearch_dsl/update_by_query_base.py
+++ b/elasticsearch_dsl/update_by_query_base.py
@@ -15,7 +15,7 @@
 #  specific language governing permissions and limitations
 #  under the License.
 
-from typing import Any, Dict, Type, cast
+from typing import Any, Dict, Type
 
 from typing_extensions import Self
 
@@ -26,7 +26,7 @@ from .utils import _R, recursive_to_dict
 
 
 class UpdateByQueryBase(Request[_R]):
-    query = ProxyDescriptor["UpdateByQueryBase[_R]"]("query")
+    query = ProxyDescriptor[Self]("query")
 
     def __init__(self, **kwargs: Any):
         """
@@ -46,10 +46,10 @@ class UpdateByQueryBase(Request[_R]):
         self._query_proxy = QueryProxy(self, "query")
 
     def filter(self, *args: Any, **kwargs: Any) -> Self:
-        return cast(Self, self.query(Bool(filter=[Q(*args, **kwargs)])))
+        return self.query(Bool(filter=[Q(*args, **kwargs)]))
 
     def exclude(self, *args: Any, **kwargs: Any) -> Self:
-        return cast(Self, self.query(Bool(filter=[~Q(*args, **kwargs)])))
+        return self.query(Bool(filter=[~Q(*args, **kwargs)]))
 
     @classmethod
     def from_dict(cls, d: Dict[str, Any]) -> Self:

--- a/elasticsearch_dsl/utils.py
+++ b/elasticsearch_dsl/utils.py
@@ -215,7 +215,6 @@ class AttrDict(Generic[_ValT]):
         del self._d_[key]
 
     def __setattr__(self, name: str, value: _ValT) -> None:
-        print(self._d_)
         if name in self._d_ or not hasattr(self.__class__, name):
             self._d_[name] = value
         else:

--- a/elasticsearch_dsl/utils.py
+++ b/elasticsearch_dsl/utils.py
@@ -86,9 +86,9 @@ def _wrap(val: Any, obj_wrapper: Optional[Callable[[Any], Any]] = None) -> Any:
     return val
 
 
-class AttrList:
+class AttrList(Generic[_ValT]):
     def __init__(
-        self, l: List[Any], obj_wrapper: Optional[Callable[[Any], Any]] = None
+        self, l: List[_ValT], obj_wrapper: Optional[Callable[[_ValT], Any]] = None
     ):
         # make iterables into lists
         if not isinstance(l, list):
@@ -111,10 +111,10 @@ class AttrList:
     def __getitem__(self, k: Union[int, slice]) -> Any:
         l = self._l_[k]
         if isinstance(k, slice):
-            return AttrList(l, obj_wrapper=self._obj_wrapper)
+            return AttrList[_ValT](l, obj_wrapper=self._obj_wrapper)  # type: ignore[arg-type]
         return _wrap(l, self._obj_wrapper)
 
-    def __setitem__(self, k: int, value: Any) -> None:
+    def __setitem__(self, k: int, value: _ValT) -> None:
         self._l_[k] = value
 
     def __iter__(self) -> Iterator[Any]:
@@ -131,15 +131,15 @@ class AttrList:
     def __getattr__(self, name: str) -> Any:
         return getattr(self._l_, name)
 
-    def __getstate__(self) -> Tuple[List[Any], Optional[Callable[[Any], Any]]]:
+    def __getstate__(self) -> Tuple[List[_ValT], Optional[Callable[[_ValT], Any]]]:
         return self._l_, self._obj_wrapper
 
     def __setstate__(
-        self, state: Tuple[List[Any], Optional[Callable[[Any], Any]]]
+        self, state: Tuple[List[_ValT], Optional[Callable[[_ValT], Any]]]
     ) -> None:
         self._l_, self._obj_wrapper = state
 
-    def to_list(self) -> List[Any]:
+    def to_list(self) -> List[_ValT]:
         return self._l_
 
 

--- a/examples/alias_migration.py
+++ b/examples/alias_migration.py
@@ -48,6 +48,8 @@ PATTERN = ALIAS + "-*"
 
 class BlogPost(Document):
     if TYPE_CHECKING:
+        # definitions here help type checkers understand additional arguments
+        # that are allowed in the constructor
         _id: int
 
     title: str

--- a/examples/alias_migration.py
+++ b/examples/alias_migration.py
@@ -40,7 +40,7 @@ from datetime import datetime
 from fnmatch import fnmatch
 from typing import TYPE_CHECKING, Any, Dict, List, Optional
 
-from elasticsearch_dsl import Document, Keyword, M, connections, mapped_field
+from elasticsearch_dsl import Document, Keyword, connections, mapped_field
 
 ALIAS = "test-blog"
 PATTERN = ALIAS + "-*"
@@ -50,10 +50,10 @@ class BlogPost(Document):
     if TYPE_CHECKING:
         _id: int
 
-    title: M[str]
-    tags: M[List[str]] = mapped_field(Keyword(multi=True))
-    content: M[str]
-    published: M[Optional[datetime]]
+    title: str
+    tags: List[str] = mapped_field(Keyword())
+    content: str
+    published: Optional[datetime] = mapped_field(default=None)
 
     def is_published(self) -> bool:
         return bool(self.published and datetime.now() > self.published)
@@ -142,7 +142,6 @@ def main() -> None:
         title="Hello World!",
         tags=["testing", "dummy"],
         content=open(__file__).read(),
-        published=None,
     )
     bp.save(refresh=True)
 

--- a/examples/async/alias_migration.py
+++ b/examples/async/alias_migration.py
@@ -41,7 +41,7 @@ from datetime import datetime
 from fnmatch import fnmatch
 from typing import TYPE_CHECKING, Any, Dict, List, Optional
 
-from elasticsearch_dsl import AsyncDocument, Keyword, M, async_connections, mapped_field
+from elasticsearch_dsl import AsyncDocument, Keyword, async_connections, mapped_field
 
 ALIAS = "test-blog"
 PATTERN = ALIAS + "-*"
@@ -51,10 +51,10 @@ class BlogPost(AsyncDocument):
     if TYPE_CHECKING:
         _id: int
 
-    title: M[str]
-    tags: M[List[str]] = mapped_field(Keyword(multi=True))
-    content: M[str]
-    published: M[Optional[datetime]]
+    title: str
+    tags: List[str] = mapped_field(Keyword())
+    content: str
+    published: Optional[datetime] = mapped_field(default=None)
 
     def is_published(self) -> bool:
         return bool(self.published and datetime.now() > self.published)
@@ -143,7 +143,6 @@ async def main() -> None:
         title="Hello World!",
         tags=["testing", "dummy"],
         content=open(__file__).read(),
-        published=None,
     )
     await bp.save(refresh=True)
 

--- a/examples/async/alias_migration.py
+++ b/examples/async/alias_migration.py
@@ -49,6 +49,8 @@ PATTERN = ALIAS + "-*"
 
 class BlogPost(AsyncDocument):
     if TYPE_CHECKING:
+        # definitions here help type checkers understand additional arguments
+        # that are allowed in the constructor
         _id: int
 
     title: str

--- a/examples/async/alias_migration.py
+++ b/examples/async/alias_migration.py
@@ -39,24 +39,28 @@ import asyncio
 import os
 from datetime import datetime
 from fnmatch import fnmatch
+from typing import TYPE_CHECKING, Any, Dict, List, Optional
 
-from elasticsearch_dsl import AsyncDocument, Date, Keyword, Text, async_connections
+from elasticsearch_dsl import AsyncDocument, Keyword, M, async_connections, mapped_field
 
 ALIAS = "test-blog"
 PATTERN = ALIAS + "-*"
 
 
 class BlogPost(AsyncDocument):
-    title = Text()
-    published = Date()
-    tags = Keyword(multi=True)
-    content = Text()
+    if TYPE_CHECKING:
+        _id: int
 
-    def is_published(self):
-        return self.published and datetime.now() > self.published
+    title: M[str]
+    tags: M[List[str]] = mapped_field(Keyword(multi=True))
+    content: M[str]
+    published: M[Optional[datetime]]
+
+    def is_published(self) -> bool:
+        return bool(self.published and datetime.now() > self.published)
 
     @classmethod
-    def _matches(cls, hit):
+    def _matches(cls, hit: Dict[str, Any]) -> bool:
         # override _matches to match indices in a pattern instead of just ALIAS
         # hit is the raw dict as returned by elasticsearch
         return fnmatch(hit["_index"], PATTERN)
@@ -69,7 +73,7 @@ class BlogPost(AsyncDocument):
         settings = {"number_of_shards": 1, "number_of_replicas": 0}
 
 
-async def setup():
+async def setup() -> None:
     """
     Create the index template in elasticsearch specifying the mappings and any
     settings to be used. This can be run at any time, ideally at every new code
@@ -86,7 +90,7 @@ async def setup():
         await migrate(move_data=False)
 
 
-async def migrate(move_data=True, update_alias=True):
+async def migrate(move_data: bool = True, update_alias: bool = True) -> None:
     """
     Upgrade function that creates a new index for the data. Optionally it also can
     (and by default will) reindex previous copy of the data into the new index
@@ -126,7 +130,7 @@ async def migrate(move_data=True, update_alias=True):
         )
 
 
-async def main():
+async def main() -> None:
     # initiate the default connection to elasticsearch
     async_connections.create_connection(hosts=[os.environ["ELASTICSEARCH_URL"]])
 
@@ -139,6 +143,7 @@ async def main():
         title="Hello World!",
         tags=["testing", "dummy"],
         content=open(__file__).read(),
+        published=None,
     )
     await bp.save(refresh=True)
 

--- a/examples/async/completion.py
+++ b/examples/async/completion.py
@@ -29,15 +29,18 @@ that does ascii folding.
 import asyncio
 import os
 from itertools import permutations
+from typing import TYPE_CHECKING, Any, Dict, Optional
 
 from elasticsearch_dsl import (
     AsyncDocument,
     Completion,
     Keyword,
     Long,
+    M,
     Text,
     analyzer,
     async_connections,
+    mapped_field,
     token_filter,
 )
 
@@ -51,13 +54,16 @@ ascii_fold = analyzer(
 
 
 class Person(AsyncDocument):
-    name = Text(fields={"keyword": Keyword()})
-    popularity = Long()
+    name: M[str] = mapped_field(Text(fields={"keyword": Keyword()}))
+    popularity: M[int] = mapped_field(Long())
 
     # completion field with a custom analyzer
-    suggest = Completion(analyzer=ascii_fold)
+    suggest: Dict[str, Any] = mapped_field(Completion(analyzer=ascii_fold), init=False)
 
-    def clean(self):
+    if TYPE_CHECKING:
+        _id: Optional[int] = mapped_field(default=None)
+
+    def clean(self) -> None:
         """
         Automatically construct the suggestion input and weight by taking all
         possible permutations of Person's name as ``input`` and taking their
@@ -73,7 +79,7 @@ class Person(AsyncDocument):
         settings = {"number_of_shards": 1, "number_of_replicas": 0}
 
 
-async def main():
+async def main() -> None:
     # initiate the default connection to elasticsearch
     async_connections.create_connection(hosts=[os.environ["ELASTICSEARCH_URL"]])
 

--- a/examples/async/completion.py
+++ b/examples/async/completion.py
@@ -54,6 +54,8 @@ ascii_fold = analyzer(
 
 class Person(AsyncDocument):
     if TYPE_CHECKING:
+        # definitions here help type checkers understand additional arguments
+        # that are allowed in the constructor
         _id: Optional[int] = mapped_field(default=None)
 
     name: str = mapped_field(Text(fields={"keyword": Keyword()}), default="")

--- a/examples/async/completion.py
+++ b/examples/async/completion.py
@@ -36,7 +36,6 @@ from elasticsearch_dsl import (
     Completion,
     Keyword,
     Long,
-    M,
     Text,
     analyzer,
     async_connections,
@@ -54,14 +53,14 @@ ascii_fold = analyzer(
 
 
 class Person(AsyncDocument):
-    name: M[str] = mapped_field(Text(fields={"keyword": Keyword()}))
-    popularity: M[int] = mapped_field(Long())
+    if TYPE_CHECKING:
+        _id: Optional[int] = mapped_field(default=None)
+
+    name: str = mapped_field(Text(fields={"keyword": Keyword()}), default="")
+    popularity: int = mapped_field(Long(), default=0)
 
     # completion field with a custom analyzer
     suggest: Dict[str, Any] = mapped_field(Completion(analyzer=ascii_fold), init=False)
-
-    if TYPE_CHECKING:
-        _id: Optional[int] = mapped_field(default=None)
 
     def clean(self) -> None:
         """

--- a/examples/async/composite_agg.py
+++ b/examples/async/composite_agg.py
@@ -36,9 +36,11 @@ async def scan_aggs(
 
     async def run_search(**kwargs: Any) -> Response:
         s = search[:0]
-        s.aggs.bucket("comp", "composite", sources=source_aggs, size=size, **kwargs)
+        bucket = s.aggs.bucket(
+            "comp", "composite", sources=source_aggs, size=size, **kwargs
+        )
         for agg_name, agg in inner_aggs.items():
-            s.aggs["comp"][agg_name] = agg
+            bucket[agg_name] = agg
         return await s.execute()
 
     response = await run_search()

--- a/examples/async/parent_child.py
+++ b/examples/async/parent_child.py
@@ -193,9 +193,10 @@ class Question(Post):
 
 class Answer(Post):
     if TYPE_CHECKING:
-        is_accepted: M[bool]
         _routing: str
         _index: AsyncIndex
+
+    is_accepted: M[bool]
 
     @classmethod
     def _matches(cls, hit: Dict[str, Any]) -> bool:

--- a/examples/async/parent_child.py
+++ b/examples/async/parent_child.py
@@ -89,6 +89,8 @@ class Post(AsyncDocument):
     author: User
 
     if TYPE_CHECKING:
+        # definitions here help type checkers understand additional arguments
+        # that are allowed in the constructor
         _routing: str = mapped_field(default=None)
         _index: AsyncIndex = mapped_field(default=None)
         _id: Optional[int] = mapped_field(default=None)

--- a/examples/async/percolate.py
+++ b/examples/async/percolate.py
@@ -37,6 +37,8 @@ class BlogPost(AsyncDocument):
     """
 
     if TYPE_CHECKING:
+        # definitions here help type checkers understand additional arguments
+        # that are allowed in the constructor
         _id: int
 
     content: Optional[str]

--- a/examples/async/percolate.py
+++ b/examples/async/percolate.py
@@ -17,15 +17,18 @@
 
 import asyncio
 import os
+from typing import TYPE_CHECKING, Any, List, Optional
 
 from elasticsearch_dsl import (
     AsyncDocument,
     AsyncSearch,
     Keyword,
+    M,
     Percolator,
     Q,
-    Text,
+    Query,
     async_connections,
+    mapped_field,
 )
 
 
@@ -34,13 +37,18 @@ class BlogPost(AsyncDocument):
     Blog posts that will be automatically tagged based on percolation queries.
     """
 
-    content = Text()
-    tags = Keyword(multi=True)
+    if TYPE_CHECKING:
+        _id: int
+
+    content: M[Optional[str]]
+    tags: M[List[str]] = mapped_field(
+        Keyword(multi=True, required=False), default_factory=list
+    )
 
     class Index:
         name = "test-blogpost"
 
-    async def add_tags(self):
+    async def add_tags(self) -> None:
         # run a percolation to automatically tag the blog post.
         s = AsyncSearch(index="test-percolator")
         s = s.query(
@@ -54,9 +62,9 @@ class BlogPost(AsyncDocument):
         # make sure tags are unique
         self.tags = list(set(self.tags))
 
-    async def save(self, **kwargs):
+    async def save(self, **kwargs: Any) -> None:  # type: ignore[override]
         await self.add_tags()
-        return await super().save(**kwargs)
+        await super().save(**kwargs)
 
 
 class PercolatorDoc(AsyncDocument):
@@ -64,22 +72,25 @@ class PercolatorDoc(AsyncDocument):
     Document class used for storing the percolation queries.
     """
 
+    if TYPE_CHECKING:
+        _id: str
+
     # relevant fields from BlogPost must be also present here for the queries
     # to be able to use them. Another option would be to use document
     # inheritance but save() would have to be reset to normal behavior.
-    content = Text()
+    content: M[Optional[str]]
 
     # the percolator query to be run against the doc
-    query = Percolator()
+    query: M[Query] = mapped_field(Percolator())
     # list of tags to append to a document
-    tags = Keyword(multi=True)
+    tags: M[List[str]] = mapped_field(Keyword(multi=True))
 
     class Index:
         name = "test-percolator"
         settings = {"number_of_shards": 1, "number_of_replicas": 0}
 
 
-async def setup():
+async def setup() -> None:
     # create the percolator index if it doesn't exist
     if not await PercolatorDoc._index.exists():
         await PercolatorDoc.init()
@@ -88,11 +99,12 @@ async def setup():
     await PercolatorDoc(
         _id="python",
         tags=["programming", "development", "python"],
+        content="",
         query=Q("match", content="python"),
     ).save(refresh=True)
 
 
-async def main():
+async def main() -> None:
     # initiate the default connection to elasticsearch
     async_connections.create_connection(hosts=[os.environ["ELASTICSEARCH_URL"]])
 

--- a/examples/async/percolate.py
+++ b/examples/async/percolate.py
@@ -23,7 +23,6 @@ from elasticsearch_dsl import (
     AsyncDocument,
     AsyncSearch,
     Keyword,
-    M,
     Percolator,
     Q,
     Query,
@@ -40,10 +39,8 @@ class BlogPost(AsyncDocument):
     if TYPE_CHECKING:
         _id: int
 
-    content: M[Optional[str]]
-    tags: M[List[str]] = mapped_field(
-        Keyword(multi=True, required=False), default_factory=list
-    )
+    content: Optional[str]
+    tags: List[str] = mapped_field(Keyword(), default_factory=list)
 
     class Index:
         name = "test-blogpost"
@@ -78,12 +75,12 @@ class PercolatorDoc(AsyncDocument):
     # relevant fields from BlogPost must be also present here for the queries
     # to be able to use them. Another option would be to use document
     # inheritance but save() would have to be reset to normal behavior.
-    content: M[Optional[str]]
+    content: Optional[str]
 
     # the percolator query to be run against the doc
-    query: M[Query] = mapped_field(Percolator())
+    query: Query = mapped_field(Percolator())
     # list of tags to append to a document
-    tags: M[List[str]] = mapped_field(Keyword(multi=True))
+    tags: List[str] = mapped_field(Keyword(multi=True))
 
     class Index:
         name = "test-percolator"

--- a/examples/async/search_as_you_type.py
+++ b/examples/async/search_as_you_type.py
@@ -50,6 +50,8 @@ ascii_fold = analyzer(
 
 class Person(AsyncDocument):
     if TYPE_CHECKING:
+        # definitions here help type checkers understand additional arguments
+        # that are allowed in the constructor
         _id: Optional[int] = mapped_field(default=None)
 
     name: str = mapped_field(SearchAsYouType(max_shingle_size=3), default="")

--- a/examples/async/search_as_you_type.py
+++ b/examples/async/search_as_you_type.py
@@ -27,12 +27,14 @@ To custom analyzer with ascii folding allow search to work in different language
 
 import asyncio
 import os
+from typing import TYPE_CHECKING, Optional
 
 from elasticsearch_dsl import (
     AsyncDocument,
     SearchAsYouType,
     analyzer,
     async_connections,
+    mapped_field,
     token_filter,
 )
 from elasticsearch_dsl.query import MultiMatch
@@ -47,7 +49,10 @@ ascii_fold = analyzer(
 
 
 class Person(AsyncDocument):
-    name = SearchAsYouType(max_shingle_size=3)
+    if TYPE_CHECKING:
+        _id: Optional[int] = mapped_field(default=None)
+
+    name: str = mapped_field(SearchAsYouType(max_shingle_size=3), default="")
 
     class Index:
         name = "test-search-as-you-type"

--- a/examples/async/search_as_you_type.py
+++ b/examples/async/search_as_you_type.py
@@ -54,7 +54,7 @@ class Person(AsyncDocument):
         settings = {"number_of_shards": 1, "number_of_replicas": 0}
 
 
-async def main():
+async def main() -> None:
     # initiate the default connection to elasticsearch
     async_connections.create_connection(hosts=[os.environ["ELASTICSEARCH_URL"]])
 
@@ -82,7 +82,7 @@ async def main():
     for text in ("já", "Cimr", "toulouse", "Henri Tou", "a"):
         s = Person.search()
 
-        s.query = MultiMatch(
+        s.query = MultiMatch(  # type: ignore[assignment]
             query=text,
             type="bool_prefix",
             fields=["name", "name._2gram", "name._3gram"],

--- a/examples/async/sparse_vectors.py
+++ b/examples/async/sparse_vectors.py
@@ -64,7 +64,7 @@ import asyncio
 import json
 import os
 from datetime import datetime
-from typing import Dict, List, Optional
+from typing import Any, Dict, List, Optional
 from urllib.request import urlopen
 
 import nltk  # type: ignore
@@ -75,7 +75,6 @@ from elasticsearch_dsl import (
     AsyncSearch,
     InnerDoc,
     Keyword,
-    M,
     Q,
     SparseVector,
     async_connections,
@@ -89,8 +88,8 @@ nltk.download("punkt", quiet=True)
 
 
 class Passage(InnerDoc):
-    content: M[Optional[str]]
-    embedding: M[Dict[str, float]] = mapped_field(SparseVector(), init=False)
+    content: Optional[str]
+    embedding: Dict[str, float] = mapped_field(SparseVector(), init=False)
 
 
 class WorkplaceDoc(AsyncDocument):
@@ -98,16 +97,16 @@ class WorkplaceDoc(AsyncDocument):
         name = "workplace_documents_sparse"
         settings = {"default_pipeline": "elser_ingest_pipeline"}
 
-    name: M[Optional[str]]
-    summary: M[Optional[str]]
-    content: M[Optional[str]]
-    created: M[Optional[str]]
-    updated: M[Optional[datetime]]
-    url: M[Optional[str]] = mapped_field(Keyword())
-    category: M[Optional[str]] = mapped_field(Keyword())
-    passages: M[List[Passage]] = mapped_field(default=[])
+    name: str
+    summary: str
+    content: str
+    created: datetime
+    updated: Optional[datetime]
+    url: str = mapped_field(Keyword())
+    category: str = mapped_field(Keyword())
+    passages: List[Passage] = mapped_field(default=[])
 
-    _model = None
+    _model: Any = None
 
     def clean(self) -> None:
         # split the content into sentences

--- a/examples/async/sparse_vectors.py
+++ b/examples/async/sparse_vectors.py
@@ -63,21 +63,23 @@ import argparse
 import asyncio
 import json
 import os
+from datetime import datetime
+from typing import Dict, List, Optional
 from urllib.request import urlopen
 
-import nltk
+import nltk  # type: ignore
 from tqdm import tqdm
 
 from elasticsearch_dsl import (
     AsyncDocument,
-    Date,
+    AsyncSearch,
     InnerDoc,
     Keyword,
-    Nested,
+    M,
     Q,
     SparseVector,
-    Text,
     async_connections,
+    mapped_field,
 )
 
 DATASET_URL = "https://raw.githubusercontent.com/elastic/elasticsearch-labs/main/datasets/workplace-documents.json"
@@ -87,8 +89,8 @@ nltk.download("punkt", quiet=True)
 
 
 class Passage(InnerDoc):
-    content = Text()
-    embedding = SparseVector()
+    content: M[Optional[str]]
+    embedding: M[Dict[str, float]] = mapped_field(SparseVector(), init=False)
 
 
 class WorkplaceDoc(AsyncDocument):
@@ -96,18 +98,18 @@ class WorkplaceDoc(AsyncDocument):
         name = "workplace_documents_sparse"
         settings = {"default_pipeline": "elser_ingest_pipeline"}
 
-    name = Text()
-    summary = Text()
-    content = Text()
-    created = Date()
-    updated = Date()
-    url = Keyword()
-    category = Keyword()
-    passages = Nested(Passage)
+    name: M[Optional[str]]
+    summary: M[Optional[str]]
+    content: M[Optional[str]]
+    created: M[Optional[str]]
+    updated: M[Optional[datetime]]
+    url: M[Optional[str]] = mapped_field(Keyword())
+    category: M[Optional[str]] = mapped_field(Keyword())
+    passages: M[List[Passage]] = mapped_field(default=[])
 
     _model = None
 
-    def clean(self):
+    def clean(self) -> None:
         # split the content into sentences
         passages = nltk.sent_tokenize(self.content)
 
@@ -116,7 +118,7 @@ class WorkplaceDoc(AsyncDocument):
             self.passages.append(Passage(content=passage))
 
 
-async def create():
+async def create() -> None:
 
     # create the index
     await WorkplaceDoc._index.delete(ignore_unavailable=True)
@@ -139,7 +141,7 @@ async def create():
         await doc.save()
 
 
-async def search(query):
+async def search(query: str) -> AsyncSearch[WorkplaceDoc]:
     return WorkplaceDoc.search()[:5].query(
         "nested",
         path="passages",
@@ -154,7 +156,7 @@ async def search(query):
     )
 
 
-def parse_args():
+def parse_args() -> argparse.Namespace:
     parser = argparse.ArgumentParser(description="Vector database with Elasticsearch")
     parser.add_argument(
         "--recreate-index", action="store_true", help="Recreate and populate the index"
@@ -168,7 +170,7 @@ def parse_args():
     return parser.parse_args()
 
 
-async def main():
+async def main() -> None:
     args = parse_args()
 
     # initiate the default connection to elasticsearch

--- a/examples/async/vectors.py
+++ b/examples/async/vectors.py
@@ -48,7 +48,7 @@ import asyncio
 import json
 import os
 from datetime import datetime
-from typing import List, Optional, cast
+from typing import Any, List, Optional, cast
 from urllib.request import urlopen
 
 import nltk  # type: ignore
@@ -72,32 +72,34 @@ MODEL_NAME = "all-MiniLM-L6-v2"
 # initialize sentence tokenizer
 nltk.download("punkt", quiet=True)
 
+# this will be the embedding model
+embedding_model: Any = None
+
 
 class Passage(InnerDoc):
-    content: M[str]
-    embedding: M[List[float]] = mapped_field(DenseVector())
+    content: str
+    embedding: List[float] = mapped_field(DenseVector())
 
 
 class WorkplaceDoc(AsyncDocument):
     class Index:
         name = "workplace_documents"
 
-    name: M[str]
-    summary: M[str]
-    content: M[str]
-    created: M[datetime]
-    updated: M[Optional[datetime]]
-    url: M[str] = mapped_field(Keyword(required=True))
-    category: M[str] = mapped_field(Keyword(required=True))
+    name: str
+    summary: str
+    content: str
+    created: datetime
+    updated: Optional[datetime]
+    url: str = mapped_field(Keyword(required=True))
+    category: str = mapped_field(Keyword(required=True))
     passages: M[List[Passage]] = mapped_field(default=[])
-
-    _model = None
 
     @classmethod
     def get_embedding(cls, input: str) -> List[float]:
-        if cls._model is None:
-            cls._model = SentenceTransformer(MODEL_NAME)
-        return cast(List[float], list(cls._model.encode(input)))
+        global embedding_model
+        if embedding_model is None:
+            embedding_model = SentenceTransformer(MODEL_NAME)
+        return cast(List[float], list(embedding_model.encode(input)))
 
     def clean(self) -> None:
         # split the content into sentences

--- a/examples/completion.py
+++ b/examples/completion.py
@@ -53,6 +53,8 @@ ascii_fold = analyzer(
 
 class Person(Document):
     if TYPE_CHECKING:
+        # definitions here help type checkers understand additional arguments
+        # that are allowed in the constructor
         _id: Optional[int] = mapped_field(default=None)
 
     name: str = mapped_field(Text(fields={"keyword": Keyword()}), default="")

--- a/examples/completion.py
+++ b/examples/completion.py
@@ -35,7 +35,6 @@ from elasticsearch_dsl import (
     Document,
     Keyword,
     Long,
-    M,
     Text,
     analyzer,
     connections,
@@ -53,14 +52,14 @@ ascii_fold = analyzer(
 
 
 class Person(Document):
-    name: M[str] = mapped_field(Text(fields={"keyword": Keyword()}))
-    popularity: M[int] = mapped_field(Long())
+    if TYPE_CHECKING:
+        _id: Optional[int] = mapped_field(default=None)
+
+    name: str = mapped_field(Text(fields={"keyword": Keyword()}), default="")
+    popularity: int = mapped_field(Long(), default=0)
 
     # completion field with a custom analyzer
     suggest: Dict[str, Any] = mapped_field(Completion(analyzer=ascii_fold), init=False)
-
-    if TYPE_CHECKING:
-        _id: Optional[int] = mapped_field(default=None)
 
     def clean(self) -> None:
         """

--- a/examples/composite_agg.py
+++ b/examples/composite_agg.py
@@ -16,18 +16,24 @@
 #  under the License.
 
 import os
+from typing import Any, Dict, Iterator, List, Optional, Union
 
-from elasticsearch_dsl import A, Search, connections
+from elasticsearch_dsl import A, Agg, Response, Search, connections
 
 
-def scan_aggs(search, source_aggs, inner_aggs={}, size=10):
+def scan_aggs(
+    search: Search,
+    source_aggs: Union[Dict[str, Agg], List[Dict[str, Agg]]],
+    inner_aggs: Dict[str, Agg] = {},
+    size: Optional[int] = 10,
+) -> Iterator[Response]:
     """
     Helper function used to iterate over all possible bucket combinations of
     ``source_aggs``, returning results of ``inner_aggs`` for each. Uses the
     ``composite`` aggregation under the hood to perform this.
     """
 
-    def run_search(**kwargs):
+    def run_search(**kwargs: Any) -> Response:
         s = search[:0]
         s.aggs.bucket("comp", "composite", sources=source_aggs, size=size, **kwargs)
         for agg_name, agg in inner_aggs.items():
@@ -45,7 +51,7 @@ def scan_aggs(search, source_aggs, inner_aggs={}, size=10):
         response = run_search(after=after)
 
 
-def main():
+def main() -> None:
     # initiate the default connection to elasticsearch
     connections.create_connection(hosts=[os.environ["ELASTICSEARCH_URL"]])
 

--- a/examples/composite_agg.py
+++ b/examples/composite_agg.py
@@ -35,9 +35,11 @@ def scan_aggs(
 
     def run_search(**kwargs: Any) -> Response:
         s = search[:0]
-        s.aggs.bucket("comp", "composite", sources=source_aggs, size=size, **kwargs)
+        bucket = s.aggs.bucket(
+            "comp", "composite", sources=source_aggs, size=size, **kwargs
+        )
         for agg_name, agg in inner_aggs.items():
-            s.aggs["comp"][agg_name] = agg
+            bucket[agg_name] = agg
         return s.execute()
 
     response = run_search()

--- a/examples/parent_child.py
+++ b/examples/parent_child.py
@@ -41,19 +41,21 @@ It is used to showcase several key features of elasticsearch-dsl:
 """
 import os
 from datetime import datetime
+from typing import TYPE_CHECKING, Any, Dict, List, Optional, cast
 
 from elasticsearch_dsl import (
-    Boolean,
     Date,
     Document,
+    Index,
     InnerDoc,
     Join,
     Keyword,
     Long,
-    Nested,
-    Object,
+    M,
+    Search,
     Text,
     connections,
+    mapped_field,
 )
 
 
@@ -62,11 +64,11 @@ class User(InnerDoc):
     Class used to represent a denormalized user stored on other objects.
     """
 
-    id = Long(required=True)
-    signed_up = Date()
-    username = Text(fields={"keyword": Keyword()}, required=True)
-    email = Text(fields={"keyword": Keyword()})
-    location = Text(fields={"keyword": Keyword()})
+    id: M[int] = mapped_field(Long(required=True))
+    signed_up: M[Optional[datetime]] = mapped_field(Date())
+    username: M[str] = mapped_field(Text(fields={"keyword": Keyword()}, required=True))
+    email: M[Optional[str]] = mapped_field(Text(fields={"keyword": Keyword()}))
+    location: M[Optional[str]] = mapped_field(Text(fields={"keyword": Keyword()}))
 
 
 class Comment(InnerDoc):
@@ -74,9 +76,9 @@ class Comment(InnerDoc):
     Class wrapper for nested comment objects.
     """
 
-    author = Object(User, required=True)
-    created = Date(required=True)
-    content = Text(required=True)
+    author: M[User]
+    created: M[datetime]
+    content: M[str]
 
 
 class Post(Document):
@@ -84,14 +86,14 @@ class Post(Document):
     Base class for Question and Answer containing the common fields.
     """
 
-    author = Object(User, required=True)
-    created = Date(required=True)
-    body = Text(required=True)
-    comments = Nested(Comment)
-    question_answer = Join(relations={"question": "answer"})
+    author: M[User]
+    created: M[Optional[datetime]]
+    body: str
+    question_answer: M[Any] = mapped_field(Join(relations={"question": "answer"}))
+    comments: M[List[Comment]]
 
     @classmethod
-    def _matches(cls, hit):
+    def _matches(cls, hit: Dict[str, Any]) -> bool:
         # Post is an abstract class, make sure it never gets used for
         # deserialization
         return False
@@ -103,35 +105,50 @@ class Post(Document):
             "number_of_replicas": 0,
         }
 
-    def add_comment(self, user, content, created=None, commit=True):
+    def add_comment(
+        self,
+        user: User,
+        content: str,
+        created: Optional[datetime] = None,
+        commit: Optional[bool] = True,
+    ) -> Comment:
         c = Comment(author=user, content=content, created=created or datetime.now())
         self.comments.append(c)
         if commit:
             self.save()
         return c
 
-    def save(self, **kwargs):
+    def save(self, **kwargs: Any) -> None:  # type: ignore[override]
         # if there is no date, use now
         if self.created is None:
             self.created = datetime.now()
-        return super().save(**kwargs)
+        super().save(**kwargs)
 
 
 class Question(Post):
-    # use multi True so that .tags will return empty list if not present
-    tags = Keyword(multi=True)
-    title = Text(fields={"keyword": Keyword()})
+    if TYPE_CHECKING:
+        _id: Optional[int]
+
+    tags: M[List[str]]  # .tags will return empty list if not present
+    title: M[str] = mapped_field(Text(fields={"keyword": Keyword()}))
 
     @classmethod
-    def _matches(cls, hit):
+    def _matches(cls, hit: Dict[str, Any]) -> bool:
         """Use Question class for parent documents"""
-        return hit["_source"]["question_answer"] == "question"
+        return bool(hit["_source"]["question_answer"] == "question")
 
     @classmethod
-    def search(cls, **kwargs):
+    def search(cls, **kwargs: Any) -> Search:  # type: ignore[override]
         return cls._index.search(**kwargs).filter("term", question_answer="question")
 
-    def add_answer(self, user, body, created=None, accepted=False, commit=True):
+    def add_answer(
+        self,
+        user: User,
+        body: str,
+        created: Optional[datetime] = None,
+        accepted: bool = False,
+        commit: Optional[bool] = True,
+    ) -> "Answer":
         answer = Answer(
             # required make sure the answer is stored in the same shard
             _routing=self.meta.id,
@@ -143,13 +160,14 @@ class Question(Post):
             author=user,
             created=created,
             body=body,
-            accepted=accepted,
+            is_accepted=accepted,
+            comments=[],
         )
         if commit:
             answer.save()
         return answer
 
-    def search_answers(self):
+    def search_answers(self) -> Search:
         # search only our index
         s = Answer.search()
         # filter for answers belonging to us
@@ -158,25 +176,28 @@ class Question(Post):
         s = s.params(routing=self.meta.id)
         return s
 
-    def get_answers(self):
+    def get_answers(self) -> List[Any]:
         """
         Get answers either from inner_hits already present or by searching
         elasticsearch.
         """
         if "inner_hits" in self.meta and "answer" in self.meta.inner_hits:
-            return self.meta.inner_hits.answer.hits
+            return cast(List[Any], self.meta.inner_hits.answer.hits)
         return [a for a in self.search_answers()]
 
-    def save(self, **kwargs):
+    def save(self, **kwargs: Any) -> None:  # type: ignore[override]
         self.question_answer = "question"
-        return super().save(**kwargs)
+        super().save(**kwargs)
 
 
 class Answer(Post):
-    is_accepted = Boolean()
+    if TYPE_CHECKING:
+        is_accepted: M[bool]
+        _routing: str
+        _index: Index
 
     @classmethod
-    def _matches(cls, hit):
+    def _matches(cls, hit: Dict[str, Any]) -> bool:
         """Use Answer class for child documents with child name 'answer'"""
         return (
             isinstance(hit["_source"]["question_answer"], dict)
@@ -184,31 +205,31 @@ class Answer(Post):
         )
 
     @classmethod
-    def search(cls, **kwargs):
+    def search(cls, **kwargs: Any) -> Search:  # type: ignore[override]
         return cls._index.search(**kwargs).exclude("term", question_answer="question")
 
-    def get_question(self):
+    def get_question(self) -> Optional[Question]:
         # cache question in self.meta
         # any attributes set on self would be interpreted as fields
         if "question" not in self.meta:
             self.meta.question = Question.get(
                 id=self.question_answer.parent, index=self.meta.index
             )
-        return self.meta.question
+        return cast(Optional[Question], self.meta.question)
 
-    def save(self, **kwargs):
+    def save(self, **kwargs: Any) -> None:  # type: ignore[override]
         # set routing to parents id automatically
         self.meta.routing = self.question_answer.parent
-        return super().save(**kwargs)
+        super().save(**kwargs)
 
 
-def setup():
+def setup() -> None:
     """Create an IndexTemplate and save it into elasticsearch."""
     index_template = Post._index.as_template("base")
     index_template.save()
 
 
-def main():
+def main() -> Answer:
     # initiate the default connection to elasticsearch
     connections.create_connection(hosts=[os.environ["ELASTICSEARCH_URL"]])
 
@@ -240,6 +261,9 @@ def main():
         body="""
         I want to use elasticsearch, how do I do it from Python?
         """,
+        created=datetime.now(),
+        question_answer={},
+        comments=[],
     )
     question.save()
     answer = question.add_answer(honza, "Just use `elasticsearch-py`!")

--- a/examples/parent_child.py
+++ b/examples/parent_child.py
@@ -51,7 +51,6 @@ from elasticsearch_dsl import (
     Join,
     Keyword,
     Long,
-    M,
     Search,
     Text,
     connections,
@@ -64,11 +63,11 @@ class User(InnerDoc):
     Class used to represent a denormalized user stored on other objects.
     """
 
-    id: M[int] = mapped_field(Long(required=True))
-    signed_up: M[Optional[datetime]] = mapped_field(Date())
-    username: M[str] = mapped_field(Text(fields={"keyword": Keyword()}, required=True))
-    email: M[Optional[str]] = mapped_field(Text(fields={"keyword": Keyword()}))
-    location: M[Optional[str]] = mapped_field(Text(fields={"keyword": Keyword()}))
+    id: int = mapped_field(Long())
+    signed_up: Optional[datetime] = mapped_field(Date())
+    username: str = mapped_field(Text(fields={"keyword": Keyword()}))
+    email: Optional[str] = mapped_field(Text(fields={"keyword": Keyword()}))
+    location: Optional[str] = mapped_field(Text(fields={"keyword": Keyword()}))
 
 
 class Comment(InnerDoc):
@@ -76,9 +75,9 @@ class Comment(InnerDoc):
     Class wrapper for nested comment objects.
     """
 
-    author: M[User]
-    created: M[datetime]
-    content: M[str]
+    author: User
+    created: datetime
+    content: str
 
 
 class Post(Document):
@@ -86,11 +85,19 @@ class Post(Document):
     Base class for Question and Answer containing the common fields.
     """
 
-    author: M[User]
-    created: M[Optional[datetime]]
-    body: str
-    question_answer: M[Any] = mapped_field(Join(relations={"question": "answer"}))
-    comments: M[List[Comment]]
+    author: User
+
+    if TYPE_CHECKING:
+        _routing: str = mapped_field(default=None)
+        _index: Index = mapped_field(default=None)
+        _id: Optional[int] = mapped_field(default=None)
+
+    created: Optional[datetime] = mapped_field(default=None)
+    body: str = mapped_field(default="")
+    comments: List[Comment] = mapped_field(default_factory=list)
+    question_answer: Any = mapped_field(
+        Join(relations={"question": "answer"}), default_factory=dict
+    )
 
     @classmethod
     def _matches(cls, hit: Dict[str, Any]) -> bool:
@@ -126,11 +133,10 @@ class Post(Document):
 
 
 class Question(Post):
-    if TYPE_CHECKING:
-        _id: Optional[int]
-
-    tags: M[List[str]]  # .tags will return empty list if not present
-    title: M[str] = mapped_field(Text(fields={"keyword": Keyword()}))
+    tags: List[str] = mapped_field(
+        default_factory=list
+    )  # .tags will return empty list if not present
+    title: str = mapped_field(Text(fields={"keyword": Keyword()}), default="")
 
     @classmethod
     def _matches(cls, hit: Dict[str, Any]) -> bool:
@@ -161,7 +167,6 @@ class Question(Post):
             created=created,
             body=body,
             is_accepted=accepted,
-            comments=[],
         )
         if commit:
             answer.save()
@@ -191,11 +196,7 @@ class Question(Post):
 
 
 class Answer(Post):
-    if TYPE_CHECKING:
-        _routing: str
-        _index: Index
-
-    is_accepted: M[bool]
+    is_accepted: bool = mapped_field(default=False)
 
     @classmethod
     def _matches(cls, hit: Dict[str, Any]) -> bool:
@@ -262,9 +263,6 @@ def main() -> Answer:
         body="""
         I want to use elasticsearch, how do I do it from Python?
         """,
-        created=datetime.now(),
-        question_answer={},
-        comments=[],
     )
     question.save()
     answer = question.add_answer(honza, "Just use `elasticsearch-py`!")

--- a/examples/parent_child.py
+++ b/examples/parent_child.py
@@ -88,6 +88,8 @@ class Post(Document):
     author: User
 
     if TYPE_CHECKING:
+        # definitions here help type checkers understand additional arguments
+        # that are allowed in the constructor
         _routing: str = mapped_field(default=None)
         _index: Index = mapped_field(default=None)
         _id: Optional[int] = mapped_field(default=None)

--- a/examples/parent_child.py
+++ b/examples/parent_child.py
@@ -192,9 +192,10 @@ class Question(Post):
 
 class Answer(Post):
     if TYPE_CHECKING:
-        is_accepted: M[bool]
         _routing: str
         _index: Index
+
+    is_accepted: M[bool]
 
     @classmethod
     def _matches(cls, hit: Dict[str, Any]) -> bool:

--- a/examples/percolate.py
+++ b/examples/percolate.py
@@ -21,7 +21,6 @@ from typing import TYPE_CHECKING, Any, List, Optional
 from elasticsearch_dsl import (
     Document,
     Keyword,
-    M,
     Percolator,
     Q,
     Query,
@@ -39,10 +38,8 @@ class BlogPost(Document):
     if TYPE_CHECKING:
         _id: int
 
-    content: M[Optional[str]]
-    tags: M[List[str]] = mapped_field(
-        Keyword(multi=True, required=False), default_factory=list
-    )
+    content: Optional[str]
+    tags: List[str] = mapped_field(Keyword(), default_factory=list)
 
     class Index:
         name = "test-blogpost"
@@ -77,12 +74,12 @@ class PercolatorDoc(Document):
     # relevant fields from BlogPost must be also present here for the queries
     # to be able to use them. Another option would be to use document
     # inheritance but save() would have to be reset to normal behavior.
-    content: M[Optional[str]]
+    content: Optional[str]
 
     # the percolator query to be run against the doc
-    query: M[Query] = mapped_field(Percolator())
+    query: Query = mapped_field(Percolator())
     # list of tags to append to a document
-    tags: M[List[str]] = mapped_field(Keyword(multi=True))
+    tags: List[str] = mapped_field(Keyword(multi=True))
 
     class Index:
         name = "test-percolator"

--- a/examples/percolate.py
+++ b/examples/percolate.py
@@ -36,6 +36,8 @@ class BlogPost(Document):
     """
 
     if TYPE_CHECKING:
+        # definitions here help type checkers understand additional arguments
+        # that are allowed in the constructor
         _id: int
 
     content: Optional[str]

--- a/examples/search_as_you_type.py
+++ b/examples/search_as_you_type.py
@@ -53,7 +53,7 @@ class Person(Document):
         settings = {"number_of_shards": 1, "number_of_replicas": 0}
 
 
-def main():
+def main() -> None:
     # initiate the default connection to elasticsearch
     connections.create_connection(hosts=[os.environ["ELASTICSEARCH_URL"]])
 
@@ -81,7 +81,7 @@ def main():
     for text in ("já", "Cimr", "toulouse", "Henri Tou", "a"):
         s = Person.search()
 
-        s.query = MultiMatch(
+        s.query = MultiMatch(  # type: ignore[assignment]
             query=text,
             type="bool_prefix",
             fields=["name", "name._2gram", "name._3gram"],

--- a/examples/search_as_you_type.py
+++ b/examples/search_as_you_type.py
@@ -49,6 +49,8 @@ ascii_fold = analyzer(
 
 class Person(Document):
     if TYPE_CHECKING:
+        # definitions here help type checkers understand additional arguments
+        # that are allowed in the constructor
         _id: Optional[int] = mapped_field(default=None)
 
     name: str = mapped_field(SearchAsYouType(max_shingle_size=3), default="")

--- a/examples/search_as_you_type.py
+++ b/examples/search_as_you_type.py
@@ -26,12 +26,14 @@ To custom analyzer with ascii folding allow search to work in different language
 """
 
 import os
+from typing import TYPE_CHECKING, Optional
 
 from elasticsearch_dsl import (
     Document,
     SearchAsYouType,
     analyzer,
     connections,
+    mapped_field,
     token_filter,
 )
 from elasticsearch_dsl.query import MultiMatch
@@ -46,7 +48,10 @@ ascii_fold = analyzer(
 
 
 class Person(Document):
-    name = SearchAsYouType(max_shingle_size=3)
+    if TYPE_CHECKING:
+        _id: Optional[int] = mapped_field(default=None)
+
+    name: str = mapped_field(SearchAsYouType(max_shingle_size=3), default="")
 
     class Index:
         name = "test-search-as-you-type"

--- a/examples/sparse_vectors.py
+++ b/examples/sparse_vectors.py
@@ -63,7 +63,7 @@ import argparse
 import json
 import os
 from datetime import datetime
-from typing import Dict, List, Optional
+from typing import Any, Dict, List, Optional
 from urllib.request import urlopen
 
 import nltk  # type: ignore
@@ -73,7 +73,6 @@ from elasticsearch_dsl import (
     Document,
     InnerDoc,
     Keyword,
-    M,
     Q,
     Search,
     SparseVector,
@@ -88,8 +87,8 @@ nltk.download("punkt", quiet=True)
 
 
 class Passage(InnerDoc):
-    content: M[Optional[str]]
-    embedding: M[Dict[str, float]] = mapped_field(SparseVector(), init=False)
+    content: Optional[str]
+    embedding: Dict[str, float] = mapped_field(SparseVector(), init=False)
 
 
 class WorkplaceDoc(Document):
@@ -97,16 +96,16 @@ class WorkplaceDoc(Document):
         name = "workplace_documents_sparse"
         settings = {"default_pipeline": "elser_ingest_pipeline"}
 
-    name: M[Optional[str]]
-    summary: M[Optional[str]]
-    content: M[Optional[str]]
-    created: M[Optional[str]]
-    updated: M[Optional[datetime]]
-    url: M[Optional[str]] = mapped_field(Keyword())
-    category: M[Optional[str]] = mapped_field(Keyword())
-    passages: M[List[Passage]] = mapped_field(default=[])
+    name: str
+    summary: str
+    content: str
+    created: datetime
+    updated: Optional[datetime]
+    url: str = mapped_field(Keyword())
+    category: str = mapped_field(Keyword())
+    passages: List[Passage] = mapped_field(default=[])
 
-    _model = None
+    _model: Any = None
 
     def clean(self) -> None:
         # split the content into sentences

--- a/noxfile.py
+++ b/noxfile.py
@@ -15,8 +15,6 @@
 #  specific language governing permissions and limitations
 #  under the License.
 
-import subprocess
-
 import nox
 
 SOURCE_FILES = (
@@ -38,8 +36,6 @@ TYPED_FILES = (
     "tests/test_query.py",
     "tests/test_utils.py",
     "tests/test_wrappers.py",
-    "examples/vectors.py",
-    "examples/async/vectors.py",
 )
 
 
@@ -94,26 +90,15 @@ def lint(session):
 @nox.session(python="3.8")
 def type_check(session):
     session.install("mypy", ".[develop]")
-    errors = []
-    popen = subprocess.Popen(
-        "mypy --strict --implicit-reexport --explicit-package-bases elasticsearch_dsl tests examples",
-        env=session.env,
-        shell=True,
-        stdout=subprocess.PIPE,
-        stderr=subprocess.STDOUT,
+    session.run(
+        "mypy",
+        "--strict",
+        "--implicit-reexport",
+        "--explicit-package-bases",
+        "elasticsearch_dsl",
+        "tests",
+        "examples",
     )
-
-    mypy_output = ""
-    while popen.poll() is None:
-        mypy_output += popen.stdout.read(8192).decode()
-    mypy_output += popen.stdout.read().decode()
-
-    for line in mypy_output.split("\n"):
-        filepath = line.partition(":")[0]
-        if filepath.startswith("elasticsearch_dsl/") or filepath in TYPED_FILES:
-            errors.append(line)
-    if errors:
-        session.error("\n" + "\n".join(errors))
 
 
 @nox.session()

--- a/noxfile.py
+++ b/noxfile.py
@@ -27,17 +27,6 @@ SOURCE_FILES = (
     "utils/",
 )
 
-TYPED_FILES = (
-    # elasticsearch_dsl files are all assumed typed so they are omitted here
-    "tests/test_connections.py",
-    "tests/test_aggs.py",
-    "tests/test_analysis.py",
-    "tests/test_field.py",
-    "tests/test_query.py",
-    "tests/test_utils.py",
-    "tests/test_wrappers.py",
-)
-
 
 @nox.session(
     python=[

--- a/noxfile.py
+++ b/noxfile.py
@@ -89,7 +89,7 @@ def lint(session):
 
 @nox.session(python="3.8")
 def type_check(session):
-    session.install("mypy", ".[develop]")
+    session.install(".[develop]")
     session.run(
         "mypy",
         "--strict",
@@ -97,6 +97,10 @@ def type_check(session):
         "--explicit-package-bases",
         "elasticsearch_dsl",
         "tests",
+        "examples",
+    )
+    session.run(
+        "pyright",
         "examples",
     )
 

--- a/setup.py
+++ b/setup.py
@@ -46,17 +46,19 @@ develop_requires = [
     "pytest-asyncio",
     "pytz",
     "coverage",
-    # typing support
-    "types-python-dateutil",
-    "types-pytz",
     # the following three are used by the vectors example and its tests
     "nltk",
     "sentence_transformers",
     "tqdm",
-    "types-tqdm",
     # Override Read the Docs default (sphinx<2 and sphinx-rtd-theme<0.5)
     "sphinx>2",
     "sphinx-rtd-theme>0.5",
+    # typing support
+    "mypy",
+    "pyright",
+    "types-python-dateutil",
+    "types-pytz",
+    "types-tqdm",
 ]
 
 setup(

--- a/setup.py
+++ b/setup.py
@@ -48,6 +48,7 @@ develop_requires = [
     "coverage",
     # typing support
     "types-python-dateutil",
+    "types-pytz",
     # the following three are used by the vectors example and its tests
     "nltk",
     "sentence_transformers",

--- a/tests/_async/test_document.py
+++ b/tests/_async/test_document.py
@@ -727,7 +727,6 @@ def test_doc_with_type_hints() -> None:
     doc.ob = TypedInnerDoc(li=[1])
     with raises(ValidationException) as exc_info:
         doc.full_clean()
-    print(exc_info.value.args)
     assert set(exc_info.value.args[0].keys()) == {"ob"}
     assert set(exc_info.value.args[0]["ob"][0].args[0].keys()) == {"st"}
 

--- a/tests/_async/test_document.py
+++ b/tests/_async/test_document.py
@@ -713,12 +713,22 @@ def test_doc_with_type_hints() -> None:
     assert doc.s4 == "foo"
     with raises(ValidationException) as exc_info:
         doc.full_clean()
-    assert set(exc_info.value.args[0].keys()) == {"st", "k1", "k2", "s1", "s2", "s3"}
+    assert set(exc_info.value.args[0].keys()) == {
+        "st",
+        "k1",
+        "k2",
+        "ob",
+        "s1",
+        "s2",
+        "s3",
+    }
 
     doc.st = "s"
     doc.li = [1, 2, 3]
     doc.k1 = "k1"
     doc.k2 = "k2"
+    doc.ob.st = "s"
+    doc.ob.li = [1]
     doc.s1 = "s1"
     doc.s2 = "s2"
     doc.s3 = "s3"
@@ -731,9 +741,6 @@ def test_doc_with_type_hints() -> None:
     assert set(exc_info.value.args[0]["ob"][0].args[0].keys()) == {"st"}
 
     doc.ob.st = "s"
-    doc.ob.li = [1]
-    doc.full_clean()
-
     doc.ns.append(TypedInnerDoc(li=[1, 2]))
     with raises(ValidationException) as exc_info:
         doc.full_clean()

--- a/tests/_async/test_document.py
+++ b/tests/_async/test_document.py
@@ -15,12 +15,18 @@
 #  specific language governing permissions and limitations
 #  under the License.
 
+# this file creates several documents using bad or no types because
+# these are still supported and should be kept functional in spite
+# of not having appropriate type hints. For that reason the comment
+# below disables many mypy checks that fails as a result of this.
+# mypy: disable-error-code="assignment, index, arg-type, call-arg, operator, comparison-overlap, attr-defined"
+
 import codecs
 import ipaddress
 import pickle
 from datetime import datetime
 from hashlib import md5
-from typing import List, Optional
+from typing import Any, Dict, List, Optional
 
 import pytest
 from pytest import raises
@@ -94,10 +100,10 @@ class Secret(str):
 class SecretField(field.CustomField):
     builtin_type = "text"
 
-    def _serialize(self, data):
+    def _serialize(self, data: Any) -> Any:
         return codecs.encode(data, "rot_13")
 
-    def _deserialize(self, data):
+    def _deserialize(self, data: Any) -> Any:
         if isinstance(data, Secret):
             return data
         return Secret(codecs.decode(data, "rot_13"))
@@ -131,9 +137,9 @@ class Host(AsyncDocument):
         name = "test-host"
 
 
-def test_range_serializes_properly():
+def test_range_serializes_properly() -> None:
     class D(AsyncDocument):
-        lr = field.LongRange()
+        lr: Range[int] = field.LongRange()
 
     d = D(lr=Range(lt=42))
     assert 40 in d.lr
@@ -144,7 +150,7 @@ def test_range_serializes_properly():
     assert {"lr": {"lt": 42}} == d.to_dict()
 
 
-def test_range_deserializes_properly():
+def test_range_deserializes_properly() -> None:
     class D(InnerDoc):
         lr = field.LongRange()
 
@@ -154,13 +160,13 @@ def test_range_deserializes_properly():
     assert 47 not in d.lr
 
 
-def test_resolve_nested():
+def test_resolve_nested() -> None:
     nested, field = NestedSecret._index.resolve_nested("secrets.title")
     assert nested == ["secrets"]
     assert field is NestedSecret._doc_type.mapping["secrets"]["title"]
 
 
-def test_conflicting_mapping_raises_error_in_index_to_dict():
+def test_conflicting_mapping_raises_error_in_index_to_dict() -> None:
     class A(AsyncDocument):
         name = field.Text()
 
@@ -175,18 +181,18 @@ def test_conflicting_mapping_raises_error_in_index_to_dict():
         i.to_dict()
 
 
-def test_ip_address_serializes_properly():
+def test_ip_address_serializes_properly() -> None:
     host = Host(ip=ipaddress.IPv4Address("10.0.0.1"))
 
     assert {"ip": "10.0.0.1"} == host.to_dict()
 
 
-def test_matches_uses_index():
+def test_matches_uses_index() -> None:
     assert SimpleCommit._matches({"_index": "test-git"})
     assert not SimpleCommit._matches({"_index": "not-test-git"})
 
 
-def test_matches_with_no_name_always_matches():
+def test_matches_with_no_name_always_matches() -> None:
     class D(AsyncDocument):
         pass
 
@@ -194,7 +200,7 @@ def test_matches_with_no_name_always_matches():
     assert D._matches({"_index": "whatever"})
 
 
-def test_matches_accepts_wildcards():
+def test_matches_accepts_wildcards() -> None:
     class MyDoc(AsyncDocument):
         class Index:
             name = "my-*"
@@ -203,7 +209,7 @@ def test_matches_accepts_wildcards():
     assert not MyDoc._matches({"_index": "not-my-index"})
 
 
-def test_assigning_attrlist_to_field():
+def test_assigning_attrlist_to_field() -> None:
     sc = SimpleCommit()
     l = ["README", "README.rst"]
     sc.files = utils.AttrList(l)
@@ -211,13 +217,13 @@ def test_assigning_attrlist_to_field():
     assert sc.to_dict()["files"] is l
 
 
-def test_optional_inner_objects_are_not_validated_if_missing():
+def test_optional_inner_objects_are_not_validated_if_missing() -> None:
     d = OptionalObjectWithRequiredField()
 
-    assert d.full_clean() is None
+    d.full_clean()
 
 
-def test_custom_field():
+def test_custom_field() -> None:
     s = SecretDoc(title=Secret("Hello"))
 
     assert {"title": "Uryyb"} == s.to_dict()
@@ -228,13 +234,13 @@ def test_custom_field():
     assert isinstance(s.title, Secret)
 
 
-def test_custom_field_mapping():
+def test_custom_field_mapping() -> None:
     assert {
         "properties": {"title": {"index": "no", "type": "text"}}
     } == SecretDoc._doc_type.mapping.to_dict()
 
 
-def test_custom_field_in_nested():
+def test_custom_field_in_nested() -> None:
     s = NestedSecret()
     s.secrets.append(SecretDoc(title=Secret("Hello")))
 
@@ -242,7 +248,7 @@ def test_custom_field_in_nested():
     assert s.secrets[0].title == "Hello"
 
 
-def test_multi_works_after_doc_has_been_saved():
+def test_multi_works_after_doc_has_been_saved() -> None:
     c = SimpleCommit()
     c.full_clean()
     c.files.append("setup.py")
@@ -250,7 +256,7 @@ def test_multi_works_after_doc_has_been_saved():
     assert c.to_dict() == {"files": ["setup.py"]}
 
 
-def test_multi_works_in_nested_after_doc_has_been_serialized():
+def test_multi_works_in_nested_after_doc_has_been_serialized() -> None:
     # Issue #359
     c = DocWithNested(comments=[Comment(title="First!")])
 
@@ -259,18 +265,18 @@ def test_multi_works_in_nested_after_doc_has_been_serialized():
     assert [] == c.comments[0].tags
 
 
-def test_null_value_for_object():
+def test_null_value_for_object() -> None:
     d = MyDoc(inner=None)
 
     assert d.inner is None
 
 
-def test_inherited_doc_types_can_override_index():
+def test_inherited_doc_types_can_override_index() -> None:
     class MyDocDifferentIndex(MySubDoc):
         class Index:
             name = "not-default-index"
             settings = {"number_of_replicas": 0}
-            aliases = {"a": {}}
+            aliases: Dict[str, Any] = {"a": {}}
             analyzers = [analyzer("my_analizer", tokenizer="keyword")]
 
     assert MyDocDifferentIndex._index._name == "not-default-index"
@@ -297,7 +303,7 @@ def test_inherited_doc_types_can_override_index():
     }
 
 
-def test_to_dict_with_meta():
+def test_to_dict_with_meta() -> None:
     d = MySubDoc(title="hello")
     d.meta.routing = "some-parent"
 
@@ -308,28 +314,28 @@ def test_to_dict_with_meta():
     } == d.to_dict(True)
 
 
-def test_to_dict_with_meta_includes_custom_index():
+def test_to_dict_with_meta_includes_custom_index() -> None:
     d = MySubDoc(title="hello")
     d.meta.index = "other-index"
 
     assert {"_index": "other-index", "_source": {"title": "hello"}} == d.to_dict(True)
 
 
-def test_to_dict_without_skip_empty_will_include_empty_fields():
+def test_to_dict_without_skip_empty_will_include_empty_fields() -> None:
     d = MySubDoc(tags=[], title=None, inner={})
 
     assert {} == d.to_dict()
     assert {"tags": [], "title": None, "inner": {}} == d.to_dict(skip_empty=False)
 
 
-def test_attribute_can_be_removed():
+def test_attribute_can_be_removed() -> None:
     d = MyDoc(title="hello")
 
     del d.title
     assert "title" not in d._d_
 
 
-def test_doc_type_can_be_correctly_pickled():
+def test_doc_type_can_be_correctly_pickled() -> None:
     d = DocWithNested(
         title="Hello World!", comments=[Comment(title="hellp")], meta={"id": 42}
     )
@@ -344,7 +350,7 @@ def test_doc_type_can_be_correctly_pickled():
     assert isinstance(d2.comments[0], Comment)
 
 
-def test_meta_is_accessible_even_on_empty_doc():
+def test_meta_is_accessible_even_on_empty_doc() -> None:
     d = MyDoc()
     d.meta
 
@@ -352,7 +358,7 @@ def test_meta_is_accessible_even_on_empty_doc():
     d.meta
 
 
-def test_meta_field_mapping():
+def test_meta_field_mapping() -> None:
     class User(AsyncDocument):
         username = field.Text()
 
@@ -371,7 +377,7 @@ def test_meta_field_mapping():
     } == User._doc_type.mapping.to_dict()
 
 
-def test_multi_value_fields():
+def test_multi_value_fields() -> None:
     class Blog(AsyncDocument):
         tags = field.Keyword(multi=True)
 
@@ -382,19 +388,19 @@ def test_multi_value_fields():
     assert ["search", "python"] == b.tags
 
 
-def test_docs_with_properties():
+def test_docs_with_properties() -> None:
     class User(AsyncDocument):
-        pwd_hash = field.Text()
+        pwd_hash: str = field.Text()
 
-        def check_password(self, pwd):
+        def check_password(self, pwd: bytes) -> bool:
             return md5(pwd).hexdigest() == self.pwd_hash
 
         @property
-        def password(self):
+        def password(self) -> None:
             raise AttributeError("readonly")
 
         @password.setter
-        def password(self, pwd):
+        def password(self, pwd: bytes) -> None:
             self.pwd_hash = md5(pwd).hexdigest()
 
     u = User(pwd_hash=md5(b"secret").hexdigest())
@@ -410,7 +416,7 @@ def test_docs_with_properties():
         u.password
 
 
-def test_nested_can_be_assigned_to():
+def test_nested_can_be_assigned_to() -> None:
     d1 = DocWithNested(comments=[Comment(title="First!")])
     d2 = DocWithNested()
 
@@ -421,13 +427,13 @@ def test_nested_can_be_assigned_to():
     assert isinstance(d2.comments[0], Comment)
 
 
-def test_nested_can_be_none():
+def test_nested_can_be_none() -> None:
     d = DocWithNested(comments=None, title="Hello World!")
 
     assert {"title": "Hello World!"} == d.to_dict()
 
 
-def test_nested_defaults_to_list_and_can_be_updated():
+def test_nested_defaults_to_list_and_can_be_updated() -> None:
     md = DocWithNested()
 
     assert [] == md.comments
@@ -436,7 +442,7 @@ def test_nested_defaults_to_list_and_can_be_updated():
     assert {"comments": [{"title": "hello World!"}]} == md.to_dict()
 
 
-def test_to_dict_is_recursive_and_can_cope_with_multi_values():
+def test_to_dict_is_recursive_and_can_cope_with_multi_values() -> None:
     md = MyDoc(name=["a", "b", "c"])
     md.inner = [MyInner(old_field="of1"), MyInner(old_field="of2")]
 
@@ -448,13 +454,13 @@ def test_to_dict_is_recursive_and_can_cope_with_multi_values():
     } == md.to_dict()
 
 
-def test_to_dict_ignores_empty_collections():
+def test_to_dict_ignores_empty_collections() -> None:
     md = MySubDoc(name="", address={}, count=0, valid=False, tags=[])
 
     assert {"name": "", "count": 0, "valid": False} == md.to_dict()
 
 
-def test_declarative_mapping_definition():
+def test_declarative_mapping_definition() -> None:
     assert issubclass(MyDoc, AsyncDocument)
     assert hasattr(MyDoc, "_doc_type")
     assert {
@@ -467,7 +473,7 @@ def test_declarative_mapping_definition():
     } == MyDoc._doc_type.mapping.to_dict()
 
 
-def test_you_can_supply_own_mapping_instance():
+def test_you_can_supply_own_mapping_instance() -> None:
     class MyD(AsyncDocument):
         title = field.Text()
 
@@ -481,7 +487,7 @@ def test_you_can_supply_own_mapping_instance():
     } == MyD._doc_type.mapping.to_dict()
 
 
-def test_document_can_be_created_dynamically():
+def test_document_can_be_created_dynamically() -> None:
     n = datetime.now()
     md = MyDoc(title="hello")
     md.name = "My Fancy Document!"
@@ -502,14 +508,14 @@ def test_document_can_be_created_dynamically():
     } == md.to_dict()
 
 
-def test_invalid_date_will_raise_exception():
+def test_invalid_date_will_raise_exception() -> None:
     md = MyDoc()
     md.created_at = "not-a-date"
     with raises(ValidationException):
         md.full_clean()
 
 
-def test_document_inheritance():
+def test_document_inheritance() -> None:
     assert issubclass(MySubDoc, MyDoc)
     assert issubclass(MySubDoc, AsyncDocument)
     assert hasattr(MySubDoc, "_doc_type")
@@ -523,7 +529,7 @@ def test_document_inheritance():
     } == MySubDoc._doc_type.mapping.to_dict()
 
 
-def test_child_class_can_override_parent():
+def test_child_class_can_override_parent() -> None:
     class A(AsyncDocument):
         o = field.Object(dynamic=False, properties={"a": field.Text()})
 
@@ -541,7 +547,7 @@ def test_child_class_can_override_parent():
     } == B._doc_type.mapping.to_dict()
 
 
-def test_meta_fields_are_stored_in_meta_and_ignored_by_to_dict():
+def test_meta_fields_are_stored_in_meta_and_ignored_by_to_dict() -> None:
     md = MySubDoc(meta={"id": 42}, name="My First doc!")
 
     md.meta.index = "my-index"
@@ -551,7 +557,7 @@ def test_meta_fields_are_stored_in_meta_and_ignored_by_to_dict():
     assert {"id": 42, "index": "my-index"} == md.meta.to_dict()
 
 
-def test_index_inheritance():
+def test_index_inheritance() -> None:
     assert issubclass(MyMultiSubDoc, MySubDoc)
     assert issubclass(MyMultiSubDoc, MyDoc2)
     assert issubclass(MyMultiSubDoc, AsyncDocument)
@@ -568,7 +574,7 @@ def test_index_inheritance():
     } == MyMultiSubDoc._doc_type.mapping.to_dict()
 
 
-def test_meta_fields_can_be_set_directly_in_init():
+def test_meta_fields_can_be_set_directly_in_init() -> None:
     p = object()
     md = MyDoc(_id=p, title="Hello World!")
 
@@ -576,27 +582,27 @@ def test_meta_fields_can_be_set_directly_in_init():
 
 
 @pytest.mark.asyncio
-async def test_save_no_index(async_mock_client):
+async def test_save_no_index(async_mock_client: Any) -> None:
     md = MyDoc()
     with raises(ValidationException):
         await md.save(using="mock")
 
 
 @pytest.mark.asyncio
-async def test_delete_no_index(async_mock_client):
+async def test_delete_no_index(async_mock_client: Any) -> None:
     md = MyDoc()
     with raises(ValidationException):
         await md.delete(using="mock")
 
 
 @pytest.mark.asyncio
-async def test_update_no_fields():
+async def test_update_no_fields() -> None:
     md = MyDoc()
     with raises(IllegalOperation):
         await md.update()
 
 
-def test_search_with_custom_alias_and_index():
+def test_search_with_custom_alias_and_index() -> None:
     search_object = MyDoc.search(
         using="staging", index=["custom_index1", "custom_index2"]
     )
@@ -605,7 +611,7 @@ def test_search_with_custom_alias_and_index():
     assert search_object._index == ["custom_index1", "custom_index2"]
 
 
-def test_from_es_respects_underscored_non_meta_fields():
+def test_from_es_respects_underscored_non_meta_fields() -> None:
     doc = {
         "_index": "test-index",
         "_id": "elasticsearch",
@@ -629,7 +635,7 @@ def test_from_es_respects_underscored_non_meta_fields():
     assert c._tagline == "You know, for search"
 
 
-def test_nested_and_object_inner_doc():
+def test_nested_and_object_inner_doc() -> None:
     class MySubDocWithNested(MyDoc):
         nested_inner = field.Nested(MyInner)
 
@@ -646,7 +652,7 @@ def test_nested_and_object_inner_doc():
     }
 
 
-def test_doc_with_type_hints():
+def test_doc_with_type_hints() -> None:
     class TypedInnerDoc(InnerDoc):
         st: M[str]
         dt: M[Optional[datetime]]
@@ -656,16 +662,16 @@ def test_doc_with_type_hints():
         st: str
         dt: Optional[datetime]
         li: List[int]
-        ob: Optional[TypedInnerDoc]
-        ns: Optional[List[TypedInnerDoc]]
+        ob: TypedInnerDoc
+        ns: List[TypedInnerDoc]
         ip: Optional[str] = field.Ip()
         k1: str = field.Keyword(required=True)
         k2: M[str] = field.Keyword()
         k3: str = mapped_field(field.Keyword(), default="foo")
-        k4: M[Optional[str]] = mapped_field(field.Keyword())
+        k4: M[Optional[str]] = mapped_field(field.Keyword())  # type: ignore[misc]
         s1: Secret = SecretField()
         s2: M[Secret] = SecretField()
-        s3: Secret = mapped_field(SecretField())
+        s3: Secret = mapped_field(SecretField())  # type: ignore[misc]
         s4: M[Optional[Secret]] = mapped_field(
             SecretField(), default_factory=lambda: "foo"
         )
@@ -718,9 +724,10 @@ def test_doc_with_type_hints():
     doc.s3 = "s3"
     doc.full_clean()
 
-    doc.ob = TypedInnerDoc()
+    doc.ob = TypedInnerDoc(li=[1])
     with raises(ValidationException) as exc_info:
         doc.full_clean()
+    print(exc_info.value.args)
     assert set(exc_info.value.args[0].keys()) == {"ob"}
     assert set(exc_info.value.args[0]["ob"][0].args[0].keys()) == {"st"}
 
@@ -766,7 +773,7 @@ def test_doc_with_type_hints():
     assert s.to_dict() == {"sort": ["st", {"dt": {"order": "desc"}}, "ob.st"]}
 
 
-def test_instrumented_field():
+def test_instrumented_field() -> None:
     class Child(InnerDoc):
         st: M[str]
 

--- a/tests/_async/test_faceted_search.py
+++ b/tests/_async/test_faceted_search.py
@@ -28,10 +28,10 @@ from elasticsearch_dsl.faceted_search import (
 
 class BlogSearch(AsyncFacetedSearch):
     doc_types = ["user", "post"]
-    fields = (
+    fields = [
         "title^5",
         "body",
-    )
+    ]
 
     facets = {
         "category": TermsFacet(field="category.raw"),
@@ -39,7 +39,7 @@ class BlogSearch(AsyncFacetedSearch):
     }
 
 
-def test_query_is_created_properly():
+def test_query_is_created_properly() -> None:
     bs = BlogSearch("python search")
     s = bs.build_search()
 
@@ -56,13 +56,13 @@ def test_query_is_created_properly():
             },
         },
         "query": {
-            "multi_match": {"fields": ("title^5", "body"), "query": "python search"}
+            "multi_match": {"fields": ["title^5", "body"], "query": "python search"}
         },
         "highlight": {"fields": {"body": {}, "title": {}}},
     } == s.to_dict()
 
 
-def test_query_is_created_properly_with_sort_tuple():
+def test_query_is_created_properly_with_sort_tuple() -> None:
     bs = BlogSearch("python search", sort=("category", "-title"))
     s = bs.build_search()
 
@@ -79,14 +79,14 @@ def test_query_is_created_properly_with_sort_tuple():
             },
         },
         "query": {
-            "multi_match": {"fields": ("title^5", "body"), "query": "python search"}
+            "multi_match": {"fields": ["title^5", "body"], "query": "python search"}
         },
         "highlight": {"fields": {"body": {}, "title": {}}},
         "sort": ["category", {"title": {"order": "desc"}}],
     } == s.to_dict()
 
 
-def test_filter_is_applied_to_search_but_not_relevant_facet():
+def test_filter_is_applied_to_search_but_not_relevant_facet() -> None:
     bs = BlogSearch("python search", filters={"category": "elastic"})
     s = bs.build_search()
 
@@ -103,13 +103,13 @@ def test_filter_is_applied_to_search_but_not_relevant_facet():
         },
         "post_filter": {"terms": {"category.raw": ["elastic"]}},
         "query": {
-            "multi_match": {"fields": ("title^5", "body"), "query": "python search"}
+            "multi_match": {"fields": ["title^5", "body"], "query": "python search"}
         },
         "highlight": {"fields": {"body": {}, "title": {}}},
     } == s.to_dict()
 
 
-def test_filters_are_applied_to_search_ant_relevant_facets():
+def test_filters_are_applied_to_search_ant_relevant_facets() -> None:
     bs = BlogSearch(
         "python search", filters={"category": "elastic", "tags": ["python", "django"]}
     )
@@ -135,17 +135,17 @@ def test_filters_are_applied_to_search_ant_relevant_facets():
             },
         },
         "query": {
-            "multi_match": {"fields": ("title^5", "body"), "query": "python search"}
+            "multi_match": {"fields": ["title^5", "body"], "query": "python search"}
         },
         "post_filter": {"bool": {}},
         "highlight": {"fields": {"body": {}, "title": {}}},
     } == d
 
 
-def test_date_histogram_facet_with_1970_01_01_date():
+def test_date_histogram_facet_with_1970_01_01_date() -> None:
     dhf = DateHistogramFacet()
-    assert dhf.get_value({"key": None}) == datetime(1970, 1, 1, 0, 0)
-    assert dhf.get_value({"key": 0}) == datetime(1970, 1, 1, 0, 0)
+    assert dhf.get_value({"key": None}) == datetime(1970, 1, 1, 0, 0)  # type: ignore[arg-type]
+    assert dhf.get_value({"key": 0}) == datetime(1970, 1, 1, 0, 0)  # type: ignore[arg-type]
 
 
 @pytest.mark.parametrize(
@@ -175,7 +175,7 @@ def test_date_histogram_facet_with_1970_01_01_date():
         ("fixed_interval", "1h"),
     ],
 )
-def test_date_histogram_interval_types(interval_type, interval):
+def test_date_histogram_interval_types(interval_type: str, interval: str) -> None:
     dhf = DateHistogramFacet(field="@timestamp", **{interval_type: interval})
     assert dhf.get_aggregation().to_dict() == {
         "date_histogram": {
@@ -187,14 +187,14 @@ def test_date_histogram_interval_types(interval_type, interval):
     dhf.get_value_filter(datetime.now())
 
 
-def test_date_histogram_no_interval_keyerror():
+def test_date_histogram_no_interval_keyerror() -> None:
     dhf = DateHistogramFacet(field="@timestamp")
     with pytest.raises(KeyError) as e:
         dhf.get_value_filter(datetime.now())
     assert str(e.value) == "'interval'"
 
 
-def test_params_added_to_search():
+def test_params_added_to_search() -> None:
     bs = BlogSearch("python search")
     assert bs._s._params == {}
     bs.params(routing="42")

--- a/tests/_async/test_index.py
+++ b/tests/_async/test_index.py
@@ -17,6 +17,7 @@
 
 import string
 from random import choice
+from typing import Any, Dict
 
 import pytest
 from pytest import raises
@@ -36,7 +37,7 @@ class Post(AsyncDocument):
     published_from = Date()
 
 
-def test_multiple_doc_types_will_combine_mappings():
+def test_multiple_doc_types_will_combine_mappings() -> None:
     class User(AsyncDocument):
         username = Text()
 
@@ -54,16 +55,16 @@ def test_multiple_doc_types_will_combine_mappings():
     } == i.to_dict()
 
 
-def test_search_is_limited_to_index_name():
+def test_search_is_limited_to_index_name() -> None:
     i = AsyncIndex("my-index")
     s = i.search()
 
     assert s._index == ["my-index"]
 
 
-def test_cloned_index_has_copied_settings_and_using():
+def test_cloned_index_has_copied_settings_and_using() -> None:
     client = object()
-    i = AsyncIndex("my-index", using=client)
+    i = AsyncIndex("my-index", using=client)  # type: ignore[arg-type]
     i.settings(number_of_shards=1)
 
     i2 = i.clone("my-other-index")
@@ -74,13 +75,13 @@ def test_cloned_index_has_copied_settings_and_using():
     assert i._settings is not i2._settings
 
 
-def test_cloned_index_has_analysis_attribute():
+def test_cloned_index_has_analysis_attribute() -> None:
     """
     Regression test for Issue #582 in which `AsyncIndex.clone()` was not copying
     over the `_analysis` attribute.
     """
     client = object()
-    i = AsyncIndex("my-index", using=client)
+    i = AsyncIndex("my-index", using=client)  # type: ignore[arg-type]
 
     random_analyzer_name = "".join(choice(string.ascii_letters) for _ in range(100))
     random_analyzer = analyzer(
@@ -94,7 +95,7 @@ def test_cloned_index_has_analysis_attribute():
     assert i.to_dict()["settings"]["analysis"] == i2.to_dict()["settings"]["analysis"]
 
 
-def test_settings_are_saved():
+def test_settings_are_saved() -> None:
     i = AsyncIndex("i")
     i.settings(number_of_replicas=0)
     i.settings(number_of_shards=1)
@@ -102,7 +103,7 @@ def test_settings_are_saved():
     assert {"settings": {"number_of_shards": 1, "number_of_replicas": 0}} == i.to_dict()
 
 
-def test_registered_doc_type_included_in_to_dict():
+def test_registered_doc_type_included_in_to_dict() -> None:
     i = AsyncIndex("i", using="alias")
     i.document(Post)
 
@@ -116,7 +117,7 @@ def test_registered_doc_type_included_in_to_dict():
     } == i.to_dict()
 
 
-def test_registered_doc_type_included_in_search():
+def test_registered_doc_type_included_in_search() -> None:
     i = AsyncIndex("i", using="alias")
     i.document(Post)
 
@@ -125,9 +126,9 @@ def test_registered_doc_type_included_in_search():
     assert s._doc_type == [Post]
 
 
-def test_aliases_add_to_object():
+def test_aliases_add_to_object() -> None:
     random_alias = "".join(choice(string.ascii_letters) for _ in range(100))
-    alias_dict = {random_alias: {}}
+    alias_dict: Dict[str, Any] = {random_alias: {}}
 
     index = AsyncIndex("i", using="alias")
     index.aliases(**alias_dict)
@@ -135,9 +136,9 @@ def test_aliases_add_to_object():
     assert index._aliases == alias_dict
 
 
-def test_aliases_returned_from_to_dict():
+def test_aliases_returned_from_to_dict() -> None:
     random_alias = "".join(choice(string.ascii_letters) for _ in range(100))
-    alias_dict = {random_alias: {}}
+    alias_dict: Dict[str, Any] = {random_alias: {}}
 
     index = AsyncIndex("i", using="alias")
     index.aliases(**alias_dict)
@@ -145,7 +146,7 @@ def test_aliases_returned_from_to_dict():
     assert index._aliases == index.to_dict()["aliases"] == alias_dict
 
 
-def test_analyzers_added_to_object():
+def test_analyzers_added_to_object() -> None:
     random_analyzer_name = "".join(choice(string.ascii_letters) for _ in range(100))
     random_analyzer = analyzer(
         random_analyzer_name, tokenizer="standard", filter="standard"
@@ -161,7 +162,7 @@ def test_analyzers_added_to_object():
     }
 
 
-def test_analyzers_returned_from_to_dict():
+def test_analyzers_returned_from_to_dict() -> None:
     random_analyzer_name = "".join(choice(string.ascii_letters) for _ in range(100))
     random_analyzer = analyzer(
         random_analyzer_name, tokenizer="standard", filter="standard"
@@ -174,7 +175,7 @@ def test_analyzers_returned_from_to_dict():
     ] == {"filter": ["standard"], "type": "custom", "tokenizer": "standard"}
 
 
-def test_conflicting_analyzer_raises_error():
+def test_conflicting_analyzer_raises_error() -> None:
     i = AsyncIndex("i")
     i.analyzer("my_analyzer", tokenizer="whitespace", filter=["lowercase", "stop"])
 
@@ -182,7 +183,7 @@ def test_conflicting_analyzer_raises_error():
         i.analyzer("my_analyzer", tokenizer="keyword", filter=["lowercase", "stop"])
 
 
-def test_index_template_can_have_order():
+def test_index_template_can_have_order() -> None:
     i = AsyncIndex("i-*")
     it = i.as_template("i", order=2)
 
@@ -190,7 +191,7 @@ def test_index_template_can_have_order():
 
 
 @pytest.mark.asyncio
-async def test_index_template_save_result(async_mock_client):
+async def test_index_template_save_result(async_mock_client: Any) -> None:
     it = AsyncIndexTemplate("test-template", "test-*")
 
     assert await it.save(using="mock") == await async_mock_client.indices.put_template()

--- a/tests/_async/test_mapping.py
+++ b/tests/_async/test_mapping.py
@@ -20,7 +20,7 @@ import json
 from elasticsearch_dsl import AsyncMapping, Keyword, Nested, Text, analysis
 
 
-def test_mapping_can_has_fields():
+def test_mapping_can_has_fields() -> None:
     m = AsyncMapping()
     m.field("name", "text").field("tags", "keyword")
 
@@ -29,7 +29,7 @@ def test_mapping_can_has_fields():
     } == m.to_dict()
 
 
-def test_mapping_update_is_recursive():
+def test_mapping_update_is_recursive() -> None:
     m1 = AsyncMapping()
     m1.field("title", "text")
     m1.field("author", "object")
@@ -62,7 +62,7 @@ def test_mapping_update_is_recursive():
     } == m1.to_dict()
 
 
-def test_properties_can_iterate_over_all_the_fields():
+def test_properties_can_iterate_over_all_the_fields() -> None:
     m = AsyncMapping()
     m.field("f1", "text", test_attr="f1", fields={"f2": Keyword(test_attr="f2")})
     m.field("f3", Nested(test_attr="f3", properties={"f4": Text(test_attr="f4")}))
@@ -72,7 +72,7 @@ def test_properties_can_iterate_over_all_the_fields():
     }
 
 
-def test_mapping_can_collect_all_analyzers_and_normalizers():
+def test_mapping_can_collect_all_analyzers_and_normalizers() -> None:
     a1 = analysis.analyzer(
         "my_analyzer1",
         tokenizer="keyword",
@@ -145,7 +145,7 @@ def test_mapping_can_collect_all_analyzers_and_normalizers():
     assert json.loads(json.dumps(m.to_dict())) == m.to_dict()
 
 
-def test_mapping_can_collect_multiple_analyzers():
+def test_mapping_can_collect_multiple_analyzers() -> None:
     a1 = analysis.analyzer(
         "my_analyzer1",
         tokenizer="keyword",
@@ -191,7 +191,7 @@ def test_mapping_can_collect_multiple_analyzers():
     } == m._collect_analysis()
 
 
-def test_even_non_custom_analyzers_can_have_params():
+def test_even_non_custom_analyzers_can_have_params() -> None:
     a1 = analysis.analyzer("whitespace", type="pattern", pattern=r"\\s+")
     m = AsyncMapping()
     m.field("title", "text", analyzer=a1)
@@ -201,14 +201,14 @@ def test_even_non_custom_analyzers_can_have_params():
     } == m._collect_analysis()
 
 
-def test_resolve_field_can_resolve_multifields():
+def test_resolve_field_can_resolve_multifields() -> None:
     m = AsyncMapping()
     m.field("title", "text", fields={"keyword": Keyword()})
 
     assert isinstance(m.resolve_field("title.keyword"), Keyword)
 
 
-def test_resolve_nested():
+def test_resolve_nested() -> None:
     m = AsyncMapping()
     m.field("n1", "nested", properties={"n2": Nested(properties={"k1": Keyword()})})
     m.field("k2", "keyword")

--- a/tests/_async/test_search.py
+++ b/tests/_async/test_search.py
@@ -16,61 +16,62 @@
 #  under the License.
 
 from copy import deepcopy
+from typing import Any
 
 import pytest
 from pytest import raises
 
-from elasticsearch_dsl import A, AsyncEmptySearch, AsyncSearch, Document, Q, query
+from elasticsearch_dsl import AsyncEmptySearch, AsyncSearch, Document, Q, query
 from elasticsearch_dsl.exceptions import IllegalOperation
 
 
-def test_expand__to_dot_is_respected():
+def test_expand__to_dot_is_respected() -> None:
     s = AsyncSearch().query("match", a__b=42, _expand__to_dot=False)
 
     assert {"query": {"match": {"a__b": 42}}} == s.to_dict()
 
 
 @pytest.mark.asyncio
-async def test_execute_uses_cache():
+async def test_execute_uses_cache() -> None:
     s = AsyncSearch()
     r = object()
-    s._response = r
+    s._response = r  # type: ignore[assignment]
 
     assert r is await s.execute()
 
 
 @pytest.mark.asyncio
-async def test_cache_can_be_ignored(async_mock_client):
+async def test_cache_can_be_ignored(async_mock_client: Any) -> None:
     s = AsyncSearch(using="mock")
     r = object()
-    s._response = r
+    s._response = r  # type: ignore[assignment]
     await s.execute(ignore_cache=True)
 
     async_mock_client.search.assert_awaited_once_with(index=None, body={})
 
 
 @pytest.mark.asyncio
-async def test_iter_iterates_over_hits():
+async def test_iter_iterates_over_hits() -> None:
     s = AsyncSearch()
-    s._response = [1, 2, 3]
+    s._response = [1, 2, 3]  # type: ignore[assignment]
 
     assert [1, 2, 3] == [hit async for hit in s]
 
 
-def test_cache_isnt_cloned():
+def test_cache_isnt_cloned() -> None:
     s = AsyncSearch()
-    s._response = object()
+    s._response = object()  # type: ignore[assignment]
 
     assert not hasattr(s._clone(), "_response")
 
 
-def test_search_starts_with_no_query():
+def test_search_starts_with_no_query() -> None:
     s = AsyncSearch()
 
     assert s.query._proxied is None
 
 
-def test_search_query_combines_query():
+def test_search_query_combines_query() -> None:
     s = AsyncSearch()
 
     s2 = s.query("match", f=42)
@@ -82,19 +83,19 @@ def test_search_query_combines_query():
     assert s3.query._proxied == query.Bool(must=[query.Match(f=42), query.Match(f=43)])
 
 
-def test_query_can_be_assigned_to():
+def test_query_can_be_assigned_to() -> None:
     s = AsyncSearch()
 
     q = Q("match", title="python")
-    s.query = q
+    s.query = q  # type: ignore
 
     assert s.query._proxied is q
 
 
-def test_query_can_be_wrapped():
+def test_query_can_be_wrapped() -> None:
     s = AsyncSearch().query("match", title="python")
 
-    s.query = Q("function_score", query=s.query, field_value_factor={"field": "rating"})
+    s.query = Q("function_score", query=s.query, field_value_factor={"field": "rating"})  # type: ignore
 
     assert {
         "query": {
@@ -106,29 +107,29 @@ def test_query_can_be_wrapped():
     } == s.to_dict()
 
 
-def test_using():
+def test_using() -> None:
     o = object()
     o2 = object()
     s = AsyncSearch(using=o)
     assert s._using is o
-    s2 = s.using(o2)
+    s2 = s.using(o2)  # type: ignore[arg-type]
     assert s._using is o
     assert s2._using is o2
 
 
-def test_methods_are_proxied_to_the_query():
+def test_methods_are_proxied_to_the_query() -> None:
     s = AsyncSearch().query("match_all")
 
     assert s.query.to_dict() == {"match_all": {}}
 
 
-def test_query_always_returns_search():
+def test_query_always_returns_search() -> None:
     s = AsyncSearch()
 
     assert isinstance(s.query("match", f=42), AsyncSearch)
 
 
-def test_source_copied_on_clone():
+def test_source_copied_on_clone() -> None:
     s = AsyncSearch().source(False)
     assert s._clone()._source == s._source
     assert s._clone()._source is False
@@ -142,7 +143,7 @@ def test_source_copied_on_clone():
     assert s3._clone()._source == ["some", "fields"]
 
 
-def test_copy_clones():
+def test_copy_clones() -> None:
     from copy import copy
 
     s1 = AsyncSearch().source(["some", "fields"])
@@ -152,7 +153,7 @@ def test_copy_clones():
     assert s1 is not s2
 
 
-def test_aggs_allow_two_metric():
+def test_aggs_allow_two_metric() -> None:
     s = AsyncSearch()
 
     s.aggs.metric("a", "max", field="a").metric("b", "max", field="b")
@@ -162,7 +163,7 @@ def test_aggs_allow_two_metric():
     }
 
 
-def test_aggs_get_copied_on_change():
+def test_aggs_get_copied_on_change() -> None:
     s = AsyncSearch().query("match_all")
     s.aggs.bucket("per_tag", "terms", field="f").metric(
         "max_score", "max", field="score"
@@ -175,7 +176,7 @@ def test_aggs_get_copied_on_change():
     s4 = s3._clone()
     s4.aggs.metric("max_score", "max", field="score")
 
-    d = {
+    d: Any = {
         "query": {"match_all": {}},
         "aggs": {
             "per_tag": {
@@ -194,7 +195,7 @@ def test_aggs_get_copied_on_change():
     assert d == s4.to_dict()
 
 
-def test_search_index():
+def test_search_index() -> None:
     s = AsyncSearch(index="i")
     assert s._index == ["i"]
     s = s.index("i2")
@@ -225,7 +226,7 @@ def test_search_index():
     assert s2._index == ["i", "i2", "i3", "i4", "i5"]
 
 
-def test_doc_type_document_class():
+def test_doc_type_document_class() -> None:
     class MyDocument(Document):
         pass
 
@@ -238,15 +239,15 @@ def test_doc_type_document_class():
     assert s._doc_type_map == {}
 
 
-def test_knn():
+def test_knn() -> None:
     s = AsyncSearch()
 
     with raises(TypeError):
-        s.knn()
+        s.knn()  # type: ignore[call-arg]
     with raises(TypeError):
-        s.knn("field")
+        s.knn("field")  # type: ignore[call-arg]
     with raises(TypeError):
-        s.knn("field", 5)
+        s.knn("field", 5)  # type: ignore[call-arg]
     with raises(ValueError):
         s.knn("field", 5, 100)
     with raises(ValueError):
@@ -294,7 +295,7 @@ def test_knn():
     } == s.to_dict()
 
 
-def test_rank():
+def test_rank() -> None:
     s = AsyncSearch()
     s.rank(rrf=False)
     assert {} == s.to_dict()
@@ -306,7 +307,7 @@ def test_rank():
     assert {"rank": {"rrf": {"window_size": 50, "rank_constant": 20}}} == s.to_dict()
 
 
-def test_sort():
+def test_sort() -> None:
     s = AsyncSearch()
     s = s.sort("fielda", "-fieldb")
 
@@ -318,7 +319,7 @@ def test_sort():
     assert AsyncSearch().to_dict() == s.to_dict()
 
 
-def test_sort_by_score():
+def test_sort_by_score() -> None:
     s = AsyncSearch()
     s = s.sort("_score")
     assert {"sort": ["_score"]} == s.to_dict()
@@ -328,7 +329,7 @@ def test_sort_by_score():
         s.sort("-_score")
 
 
-def test_collapse():
+def test_collapse() -> None:
     s = AsyncSearch()
 
     inner_hits = {"name": "most_recent", "size": 5, "sort": [{"@timestamp": "desc"}]}
@@ -360,7 +361,7 @@ def test_collapse():
     assert AsyncSearch().to_dict() == s.to_dict()
 
 
-def test_slice():
+def test_slice() -> None:
     s = AsyncSearch()
     assert {"from": 3, "size": 7} == s[3:10].to_dict()
     assert {"size": 5} == s[:5].to_dict()
@@ -383,7 +384,7 @@ def test_slice():
         s[-3:-2]
 
 
-def test_index():
+def test_index() -> None:
     s = AsyncSearch()
     assert {"from": 3, "size": 1} == s[3].to_dict()
     assert {"from": 3, "size": 1} == s[3][0].to_dict()
@@ -393,7 +394,7 @@ def test_index():
         s[-3]
 
 
-def test_search_to_dict():
+def test_search_to_dict() -> None:
     s = AsyncSearch()
     assert {} == s.to_dict()
 
@@ -422,7 +423,7 @@ def test_search_to_dict():
     assert {"size": 5, "from": 42} == s.to_dict()
 
 
-def test_complex_example():
+def test_complex_example() -> None:
     s = AsyncSearch()
     s = (
         s.query("match", title="python")
@@ -475,7 +476,7 @@ def test_complex_example():
     } == s.to_dict()
 
 
-def test_reverse():
+def test_reverse() -> None:
     d = {
         "query": {
             "filtered": {
@@ -525,14 +526,14 @@ def test_reverse():
     assert d == s.to_dict()
 
 
-def test_from_dict_doesnt_need_query():
+def test_from_dict_doesnt_need_query() -> None:
     s = AsyncSearch.from_dict({"size": 5})
 
     assert {"size": 5} == s.to_dict()
 
 
 @pytest.mark.asyncio
-async def test_params_being_passed_to_search(async_mock_client):
+async def test_params_being_passed_to_search(async_mock_client: Any) -> None:
     s = AsyncSearch(using="mock")
     s = s.params(routing="42")
     await s.execute()
@@ -540,7 +541,7 @@ async def test_params_being_passed_to_search(async_mock_client):
     async_mock_client.search.assert_awaited_once_with(index=None, body={}, routing="42")
 
 
-def test_source():
+def test_source() -> None:
     assert {} == AsyncSearch().source().to_dict()
 
     assert {
@@ -554,7 +555,7 @@ def test_source():
     ).source(["f1", "f2"]).to_dict()
 
 
-def test_source_on_clone():
+def test_source_on_clone() -> None:
     assert {
         "_source": {"includes": ["foo.bar.*"], "excludes": ["foo.one"]},
         "query": {"bool": {"filter": [{"term": {"title": "python"}}]}},
@@ -569,7 +570,7 @@ def test_source_on_clone():
     } == AsyncSearch().source(False).filter("term", title="python").to_dict()
 
 
-def test_source_on_clear():
+def test_source_on_clear() -> None:
     assert (
         {}
         == AsyncSearch()
@@ -579,7 +580,7 @@ def test_source_on_clear():
     )
 
 
-def test_suggest_accepts_global_text():
+def test_suggest_accepts_global_text() -> None:
     s = AsyncSearch.from_dict(
         {
             "suggest": {
@@ -601,7 +602,7 @@ def test_suggest_accepts_global_text():
     } == s.to_dict()
 
 
-def test_suggest():
+def test_suggest() -> None:
     s = AsyncSearch()
     s = s.suggest("my_suggestion", "pyhton", term={"field": "title"})
 
@@ -610,7 +611,7 @@ def test_suggest():
     } == s.to_dict()
 
 
-def test_exclude():
+def test_exclude() -> None:
     s = AsyncSearch()
     s = s.exclude("match", title="python")
 
@@ -624,7 +625,7 @@ def test_exclude():
 
 
 @pytest.mark.asyncio
-async def test_delete_by_query(async_mock_client):
+async def test_delete_by_query(async_mock_client: Any) -> None:
     s = AsyncSearch(using="mock", index="i").query("match", lang="java")
     await s.delete()
 
@@ -633,7 +634,7 @@ async def test_delete_by_query(async_mock_client):
     )
 
 
-def test_update_from_dict():
+def test_update_from_dict() -> None:
     s = AsyncSearch()
     s.update_from_dict({"indices_boost": [{"important-documents": 2}]})
     s.update_from_dict({"_source": ["id", "name"]})
@@ -646,7 +647,7 @@ def test_update_from_dict():
     } == s.to_dict()
 
 
-def test_rescore_query_to_dict():
+def test_rescore_query_to_dict() -> None:
     s = AsyncSearch(index="index-name")
 
     positive_query = Q(
@@ -709,10 +710,10 @@ def test_rescore_query_to_dict():
 
 
 @pytest.mark.asyncio
-async def test_empty_search():
+async def test_empty_search() -> None:
     s = AsyncEmptySearch(index="index-name")
     s = s.query("match", lang="java")
-    s.aggs.bucket("versions", A("terms", field="version"))
+    s.aggs.bucket("versions", "terms", field="version")
 
     assert await s.count() == 0
     assert [hit async for hit in s] == []
@@ -720,7 +721,7 @@ async def test_empty_search():
     await s.delete()  # should not error
 
 
-def test_suggest_completion():
+def test_suggest_completion() -> None:
     s = AsyncSearch()
     s = s.suggest("my_suggestion", "pyhton", completion={"field": "title"})
 
@@ -731,7 +732,7 @@ def test_suggest_completion():
     } == s.to_dict()
 
 
-def test_suggest_regex_query():
+def test_suggest_regex_query() -> None:
     s = AsyncSearch()
     s = s.suggest("my_suggestion", regex="py[thon|py]", completion={"field": "title"})
 
@@ -742,19 +743,19 @@ def test_suggest_regex_query():
     } == s.to_dict()
 
 
-def test_suggest_must_pass_text_or_regex():
+def test_suggest_must_pass_text_or_regex() -> None:
     s = AsyncSearch()
     with raises(ValueError):
         s.suggest("my_suggestion")
 
 
-def test_suggest_can_only_pass_text_or_regex():
+def test_suggest_can_only_pass_text_or_regex() -> None:
     s = AsyncSearch()
     with raises(ValueError):
         s.suggest("my_suggestion", text="python", regex="py[hton|py]")
 
 
-def test_suggest_regex_must_be_wtih_completion():
+def test_suggest_regex_must_be_wtih_completion() -> None:
     s = AsyncSearch()
     with raises(ValueError):
         s.suggest("my_suggestion", regex="py[thon|py]")

--- a/tests/_async/test_update_by_query.py
+++ b/tests/_async/test_update_by_query.py
@@ -16,20 +16,22 @@
 #  under the License.
 
 from copy import deepcopy
+from typing import Any
 
 import pytest
 
 from elasticsearch_dsl import AsyncUpdateByQuery, Q
 from elasticsearch_dsl.response import UpdateByQueryResponse
+from elasticsearch_dsl.search_base import SearchBase
 
 
-def test_ubq_starts_with_no_query():
+def test_ubq_starts_with_no_query() -> None:
     ubq = AsyncUpdateByQuery()
 
     assert ubq.query._proxied is None
 
 
-def test_ubq_to_dict():
+def test_ubq_to_dict() -> None:
     ubq = AsyncUpdateByQuery()
     assert {} == ubq.to_dict()
 
@@ -45,7 +47,7 @@ def test_ubq_to_dict():
     assert {"extra_q": {"term": {"category": "conference"}}} == ubq.to_dict()
 
 
-def test_complex_example():
+def test_complex_example() -> None:
     ubq = AsyncUpdateByQuery()
     ubq = (
         ubq.query("match", title="python")
@@ -83,7 +85,7 @@ def test_complex_example():
     } == ubq.to_dict()
 
 
-def test_exclude():
+def test_exclude() -> None:
     ubq = AsyncUpdateByQuery()
     ubq = ubq.exclude("match", title="python")
 
@@ -96,7 +98,7 @@ def test_exclude():
     } == ubq.to_dict()
 
 
-def test_reverse():
+def test_reverse() -> None:
     d = {
         "query": {
             "filtered": {
@@ -132,14 +134,14 @@ def test_reverse():
     assert d == ubq.to_dict()
 
 
-def test_from_dict_doesnt_need_query():
+def test_from_dict_doesnt_need_query() -> None:
     ubq = AsyncUpdateByQuery.from_dict({"script": {"source": "test"}})
 
     assert {"script": {"source": "test"}} == ubq.to_dict()
 
 
 @pytest.mark.asyncio
-async def test_params_being_passed_to_search(async_mock_client):
+async def test_params_being_passed_to_search(async_mock_client: Any) -> None:
     ubq = AsyncUpdateByQuery(using="mock", index="i")
     ubq = ubq.params(routing="42")
     await ubq.execute()
@@ -147,7 +149,7 @@ async def test_params_being_passed_to_search(async_mock_client):
     async_mock_client.update_by_query.assert_called_once_with(index=["i"], routing="42")
 
 
-def test_overwrite_script():
+def test_overwrite_script() -> None:
     ubq = AsyncUpdateByQuery()
     ubq = ubq.script(
         source="ctx._source.likes += params.f", lang="painless", params={"f": 3}
@@ -163,12 +165,12 @@ def test_overwrite_script():
     assert {"script": {"source": "ctx._source.likes++"}} == ubq.to_dict()
 
 
-def test_update_by_query_response_success():
-    ubqr = UpdateByQueryResponse({}, {"timed_out": False, "failures": []})
+def test_update_by_query_response_success() -> None:
+    ubqr = UpdateByQueryResponse(SearchBase(), {"timed_out": False, "failures": []})
     assert ubqr.success()
 
-    ubqr = UpdateByQueryResponse({}, {"timed_out": True, "failures": []})
+    ubqr = UpdateByQueryResponse(SearchBase(), {"timed_out": True, "failures": []})
     assert not ubqr.success()
 
-    ubqr = UpdateByQueryResponse({}, {"timed_out": False, "failures": [{}]})
+    ubqr = UpdateByQueryResponse(SearchBase(), {"timed_out": False, "failures": [{}]})
     assert not ubqr.success()

--- a/tests/_sync/test_document.py
+++ b/tests/_sync/test_document.py
@@ -727,7 +727,6 @@ def test_doc_with_type_hints() -> None:
     doc.ob = TypedInnerDoc(li=[1])
     with raises(ValidationException) as exc_info:
         doc.full_clean()
-    print(exc_info.value.args)
     assert set(exc_info.value.args[0].keys()) == {"ob"}
     assert set(exc_info.value.args[0]["ob"][0].args[0].keys()) == {"st"}
 

--- a/tests/_sync/test_document.py
+++ b/tests/_sync/test_document.py
@@ -713,12 +713,22 @@ def test_doc_with_type_hints() -> None:
     assert doc.s4 == "foo"
     with raises(ValidationException) as exc_info:
         doc.full_clean()
-    assert set(exc_info.value.args[0].keys()) == {"st", "k1", "k2", "s1", "s2", "s3"}
+    assert set(exc_info.value.args[0].keys()) == {
+        "st",
+        "k1",
+        "k2",
+        "ob",
+        "s1",
+        "s2",
+        "s3",
+    }
 
     doc.st = "s"
     doc.li = [1, 2, 3]
     doc.k1 = "k1"
     doc.k2 = "k2"
+    doc.ob.st = "s"
+    doc.ob.li = [1]
     doc.s1 = "s1"
     doc.s2 = "s2"
     doc.s3 = "s3"
@@ -731,9 +741,6 @@ def test_doc_with_type_hints() -> None:
     assert set(exc_info.value.args[0]["ob"][0].args[0].keys()) == {"st"}
 
     doc.ob.st = "s"
-    doc.ob.li = [1]
-    doc.full_clean()
-
     doc.ns.append(TypedInnerDoc(li=[1, 2]))
     with raises(ValidationException) as exc_info:
         doc.full_clean()

--- a/tests/_sync/test_document.py
+++ b/tests/_sync/test_document.py
@@ -15,12 +15,18 @@
 #  specific language governing permissions and limitations
 #  under the License.
 
+# this file creates several documents using bad or no types because
+# these are still supported and should be kept functional in spite
+# of not having appropriate type hints. For that reason the comment
+# below disables many mypy checks that fails as a result of this.
+# mypy: disable-error-code="assignment, index, arg-type, call-arg, operator, comparison-overlap, attr-defined"
+
 import codecs
 import ipaddress
 import pickle
 from datetime import datetime
 from hashlib import md5
-from typing import List, Optional
+from typing import Any, Dict, List, Optional
 
 import pytest
 from pytest import raises
@@ -94,10 +100,10 @@ class Secret(str):
 class SecretField(field.CustomField):
     builtin_type = "text"
 
-    def _serialize(self, data):
+    def _serialize(self, data: Any) -> Any:
         return codecs.encode(data, "rot_13")
 
-    def _deserialize(self, data):
+    def _deserialize(self, data: Any) -> Any:
         if isinstance(data, Secret):
             return data
         return Secret(codecs.decode(data, "rot_13"))
@@ -131,9 +137,9 @@ class Host(Document):
         name = "test-host"
 
 
-def test_range_serializes_properly():
+def test_range_serializes_properly() -> None:
     class D(Document):
-        lr = field.LongRange()
+        lr: Range[int] = field.LongRange()
 
     d = D(lr=Range(lt=42))
     assert 40 in d.lr
@@ -144,7 +150,7 @@ def test_range_serializes_properly():
     assert {"lr": {"lt": 42}} == d.to_dict()
 
 
-def test_range_deserializes_properly():
+def test_range_deserializes_properly() -> None:
     class D(InnerDoc):
         lr = field.LongRange()
 
@@ -154,13 +160,13 @@ def test_range_deserializes_properly():
     assert 47 not in d.lr
 
 
-def test_resolve_nested():
+def test_resolve_nested() -> None:
     nested, field = NestedSecret._index.resolve_nested("secrets.title")
     assert nested == ["secrets"]
     assert field is NestedSecret._doc_type.mapping["secrets"]["title"]
 
 
-def test_conflicting_mapping_raises_error_in_index_to_dict():
+def test_conflicting_mapping_raises_error_in_index_to_dict() -> None:
     class A(Document):
         name = field.Text()
 
@@ -175,18 +181,18 @@ def test_conflicting_mapping_raises_error_in_index_to_dict():
         i.to_dict()
 
 
-def test_ip_address_serializes_properly():
+def test_ip_address_serializes_properly() -> None:
     host = Host(ip=ipaddress.IPv4Address("10.0.0.1"))
 
     assert {"ip": "10.0.0.1"} == host.to_dict()
 
 
-def test_matches_uses_index():
+def test_matches_uses_index() -> None:
     assert SimpleCommit._matches({"_index": "test-git"})
     assert not SimpleCommit._matches({"_index": "not-test-git"})
 
 
-def test_matches_with_no_name_always_matches():
+def test_matches_with_no_name_always_matches() -> None:
     class D(Document):
         pass
 
@@ -194,7 +200,7 @@ def test_matches_with_no_name_always_matches():
     assert D._matches({"_index": "whatever"})
 
 
-def test_matches_accepts_wildcards():
+def test_matches_accepts_wildcards() -> None:
     class MyDoc(Document):
         class Index:
             name = "my-*"
@@ -203,7 +209,7 @@ def test_matches_accepts_wildcards():
     assert not MyDoc._matches({"_index": "not-my-index"})
 
 
-def test_assigning_attrlist_to_field():
+def test_assigning_attrlist_to_field() -> None:
     sc = SimpleCommit()
     l = ["README", "README.rst"]
     sc.files = utils.AttrList(l)
@@ -211,13 +217,13 @@ def test_assigning_attrlist_to_field():
     assert sc.to_dict()["files"] is l
 
 
-def test_optional_inner_objects_are_not_validated_if_missing():
+def test_optional_inner_objects_are_not_validated_if_missing() -> None:
     d = OptionalObjectWithRequiredField()
 
-    assert d.full_clean() is None
+    d.full_clean()
 
 
-def test_custom_field():
+def test_custom_field() -> None:
     s = SecretDoc(title=Secret("Hello"))
 
     assert {"title": "Uryyb"} == s.to_dict()
@@ -228,13 +234,13 @@ def test_custom_field():
     assert isinstance(s.title, Secret)
 
 
-def test_custom_field_mapping():
+def test_custom_field_mapping() -> None:
     assert {
         "properties": {"title": {"index": "no", "type": "text"}}
     } == SecretDoc._doc_type.mapping.to_dict()
 
 
-def test_custom_field_in_nested():
+def test_custom_field_in_nested() -> None:
     s = NestedSecret()
     s.secrets.append(SecretDoc(title=Secret("Hello")))
 
@@ -242,7 +248,7 @@ def test_custom_field_in_nested():
     assert s.secrets[0].title == "Hello"
 
 
-def test_multi_works_after_doc_has_been_saved():
+def test_multi_works_after_doc_has_been_saved() -> None:
     c = SimpleCommit()
     c.full_clean()
     c.files.append("setup.py")
@@ -250,7 +256,7 @@ def test_multi_works_after_doc_has_been_saved():
     assert c.to_dict() == {"files": ["setup.py"]}
 
 
-def test_multi_works_in_nested_after_doc_has_been_serialized():
+def test_multi_works_in_nested_after_doc_has_been_serialized() -> None:
     # Issue #359
     c = DocWithNested(comments=[Comment(title="First!")])
 
@@ -259,18 +265,18 @@ def test_multi_works_in_nested_after_doc_has_been_serialized():
     assert [] == c.comments[0].tags
 
 
-def test_null_value_for_object():
+def test_null_value_for_object() -> None:
     d = MyDoc(inner=None)
 
     assert d.inner is None
 
 
-def test_inherited_doc_types_can_override_index():
+def test_inherited_doc_types_can_override_index() -> None:
     class MyDocDifferentIndex(MySubDoc):
         class Index:
             name = "not-default-index"
             settings = {"number_of_replicas": 0}
-            aliases = {"a": {}}
+            aliases: Dict[str, Any] = {"a": {}}
             analyzers = [analyzer("my_analizer", tokenizer="keyword")]
 
     assert MyDocDifferentIndex._index._name == "not-default-index"
@@ -297,7 +303,7 @@ def test_inherited_doc_types_can_override_index():
     }
 
 
-def test_to_dict_with_meta():
+def test_to_dict_with_meta() -> None:
     d = MySubDoc(title="hello")
     d.meta.routing = "some-parent"
 
@@ -308,28 +314,28 @@ def test_to_dict_with_meta():
     } == d.to_dict(True)
 
 
-def test_to_dict_with_meta_includes_custom_index():
+def test_to_dict_with_meta_includes_custom_index() -> None:
     d = MySubDoc(title="hello")
     d.meta.index = "other-index"
 
     assert {"_index": "other-index", "_source": {"title": "hello"}} == d.to_dict(True)
 
 
-def test_to_dict_without_skip_empty_will_include_empty_fields():
+def test_to_dict_without_skip_empty_will_include_empty_fields() -> None:
     d = MySubDoc(tags=[], title=None, inner={})
 
     assert {} == d.to_dict()
     assert {"tags": [], "title": None, "inner": {}} == d.to_dict(skip_empty=False)
 
 
-def test_attribute_can_be_removed():
+def test_attribute_can_be_removed() -> None:
     d = MyDoc(title="hello")
 
     del d.title
     assert "title" not in d._d_
 
 
-def test_doc_type_can_be_correctly_pickled():
+def test_doc_type_can_be_correctly_pickled() -> None:
     d = DocWithNested(
         title="Hello World!", comments=[Comment(title="hellp")], meta={"id": 42}
     )
@@ -344,7 +350,7 @@ def test_doc_type_can_be_correctly_pickled():
     assert isinstance(d2.comments[0], Comment)
 
 
-def test_meta_is_accessible_even_on_empty_doc():
+def test_meta_is_accessible_even_on_empty_doc() -> None:
     d = MyDoc()
     d.meta
 
@@ -352,7 +358,7 @@ def test_meta_is_accessible_even_on_empty_doc():
     d.meta
 
 
-def test_meta_field_mapping():
+def test_meta_field_mapping() -> None:
     class User(Document):
         username = field.Text()
 
@@ -371,7 +377,7 @@ def test_meta_field_mapping():
     } == User._doc_type.mapping.to_dict()
 
 
-def test_multi_value_fields():
+def test_multi_value_fields() -> None:
     class Blog(Document):
         tags = field.Keyword(multi=True)
 
@@ -382,19 +388,19 @@ def test_multi_value_fields():
     assert ["search", "python"] == b.tags
 
 
-def test_docs_with_properties():
+def test_docs_with_properties() -> None:
     class User(Document):
-        pwd_hash = field.Text()
+        pwd_hash: str = field.Text()
 
-        def check_password(self, pwd):
+        def check_password(self, pwd: bytes) -> bool:
             return md5(pwd).hexdigest() == self.pwd_hash
 
         @property
-        def password(self):
+        def password(self) -> None:
             raise AttributeError("readonly")
 
         @password.setter
-        def password(self, pwd):
+        def password(self, pwd: bytes) -> None:
             self.pwd_hash = md5(pwd).hexdigest()
 
     u = User(pwd_hash=md5(b"secret").hexdigest())
@@ -410,7 +416,7 @@ def test_docs_with_properties():
         u.password
 
 
-def test_nested_can_be_assigned_to():
+def test_nested_can_be_assigned_to() -> None:
     d1 = DocWithNested(comments=[Comment(title="First!")])
     d2 = DocWithNested()
 
@@ -421,13 +427,13 @@ def test_nested_can_be_assigned_to():
     assert isinstance(d2.comments[0], Comment)
 
 
-def test_nested_can_be_none():
+def test_nested_can_be_none() -> None:
     d = DocWithNested(comments=None, title="Hello World!")
 
     assert {"title": "Hello World!"} == d.to_dict()
 
 
-def test_nested_defaults_to_list_and_can_be_updated():
+def test_nested_defaults_to_list_and_can_be_updated() -> None:
     md = DocWithNested()
 
     assert [] == md.comments
@@ -436,7 +442,7 @@ def test_nested_defaults_to_list_and_can_be_updated():
     assert {"comments": [{"title": "hello World!"}]} == md.to_dict()
 
 
-def test_to_dict_is_recursive_and_can_cope_with_multi_values():
+def test_to_dict_is_recursive_and_can_cope_with_multi_values() -> None:
     md = MyDoc(name=["a", "b", "c"])
     md.inner = [MyInner(old_field="of1"), MyInner(old_field="of2")]
 
@@ -448,13 +454,13 @@ def test_to_dict_is_recursive_and_can_cope_with_multi_values():
     } == md.to_dict()
 
 
-def test_to_dict_ignores_empty_collections():
+def test_to_dict_ignores_empty_collections() -> None:
     md = MySubDoc(name="", address={}, count=0, valid=False, tags=[])
 
     assert {"name": "", "count": 0, "valid": False} == md.to_dict()
 
 
-def test_declarative_mapping_definition():
+def test_declarative_mapping_definition() -> None:
     assert issubclass(MyDoc, Document)
     assert hasattr(MyDoc, "_doc_type")
     assert {
@@ -467,7 +473,7 @@ def test_declarative_mapping_definition():
     } == MyDoc._doc_type.mapping.to_dict()
 
 
-def test_you_can_supply_own_mapping_instance():
+def test_you_can_supply_own_mapping_instance() -> None:
     class MyD(Document):
         title = field.Text()
 
@@ -481,7 +487,7 @@ def test_you_can_supply_own_mapping_instance():
     } == MyD._doc_type.mapping.to_dict()
 
 
-def test_document_can_be_created_dynamically():
+def test_document_can_be_created_dynamically() -> None:
     n = datetime.now()
     md = MyDoc(title="hello")
     md.name = "My Fancy Document!"
@@ -502,14 +508,14 @@ def test_document_can_be_created_dynamically():
     } == md.to_dict()
 
 
-def test_invalid_date_will_raise_exception():
+def test_invalid_date_will_raise_exception() -> None:
     md = MyDoc()
     md.created_at = "not-a-date"
     with raises(ValidationException):
         md.full_clean()
 
 
-def test_document_inheritance():
+def test_document_inheritance() -> None:
     assert issubclass(MySubDoc, MyDoc)
     assert issubclass(MySubDoc, Document)
     assert hasattr(MySubDoc, "_doc_type")
@@ -523,7 +529,7 @@ def test_document_inheritance():
     } == MySubDoc._doc_type.mapping.to_dict()
 
 
-def test_child_class_can_override_parent():
+def test_child_class_can_override_parent() -> None:
     class A(Document):
         o = field.Object(dynamic=False, properties={"a": field.Text()})
 
@@ -541,7 +547,7 @@ def test_child_class_can_override_parent():
     } == B._doc_type.mapping.to_dict()
 
 
-def test_meta_fields_are_stored_in_meta_and_ignored_by_to_dict():
+def test_meta_fields_are_stored_in_meta_and_ignored_by_to_dict() -> None:
     md = MySubDoc(meta={"id": 42}, name="My First doc!")
 
     md.meta.index = "my-index"
@@ -551,7 +557,7 @@ def test_meta_fields_are_stored_in_meta_and_ignored_by_to_dict():
     assert {"id": 42, "index": "my-index"} == md.meta.to_dict()
 
 
-def test_index_inheritance():
+def test_index_inheritance() -> None:
     assert issubclass(MyMultiSubDoc, MySubDoc)
     assert issubclass(MyMultiSubDoc, MyDoc2)
     assert issubclass(MyMultiSubDoc, Document)
@@ -568,7 +574,7 @@ def test_index_inheritance():
     } == MyMultiSubDoc._doc_type.mapping.to_dict()
 
 
-def test_meta_fields_can_be_set_directly_in_init():
+def test_meta_fields_can_be_set_directly_in_init() -> None:
     p = object()
     md = MyDoc(_id=p, title="Hello World!")
 
@@ -576,27 +582,27 @@ def test_meta_fields_can_be_set_directly_in_init():
 
 
 @pytest.mark.sync
-def test_save_no_index(mock_client):
+def test_save_no_index(mock_client: Any) -> None:
     md = MyDoc()
     with raises(ValidationException):
         md.save(using="mock")
 
 
 @pytest.mark.sync
-def test_delete_no_index(mock_client):
+def test_delete_no_index(mock_client: Any) -> None:
     md = MyDoc()
     with raises(ValidationException):
         md.delete(using="mock")
 
 
 @pytest.mark.sync
-def test_update_no_fields():
+def test_update_no_fields() -> None:
     md = MyDoc()
     with raises(IllegalOperation):
         md.update()
 
 
-def test_search_with_custom_alias_and_index():
+def test_search_with_custom_alias_and_index() -> None:
     search_object = MyDoc.search(
         using="staging", index=["custom_index1", "custom_index2"]
     )
@@ -605,7 +611,7 @@ def test_search_with_custom_alias_and_index():
     assert search_object._index == ["custom_index1", "custom_index2"]
 
 
-def test_from_es_respects_underscored_non_meta_fields():
+def test_from_es_respects_underscored_non_meta_fields() -> None:
     doc = {
         "_index": "test-index",
         "_id": "elasticsearch",
@@ -629,7 +635,7 @@ def test_from_es_respects_underscored_non_meta_fields():
     assert c._tagline == "You know, for search"
 
 
-def test_nested_and_object_inner_doc():
+def test_nested_and_object_inner_doc() -> None:
     class MySubDocWithNested(MyDoc):
         nested_inner = field.Nested(MyInner)
 
@@ -646,7 +652,7 @@ def test_nested_and_object_inner_doc():
     }
 
 
-def test_doc_with_type_hints():
+def test_doc_with_type_hints() -> None:
     class TypedInnerDoc(InnerDoc):
         st: M[str]
         dt: M[Optional[datetime]]
@@ -656,16 +662,16 @@ def test_doc_with_type_hints():
         st: str
         dt: Optional[datetime]
         li: List[int]
-        ob: Optional[TypedInnerDoc]
-        ns: Optional[List[TypedInnerDoc]]
+        ob: TypedInnerDoc
+        ns: List[TypedInnerDoc]
         ip: Optional[str] = field.Ip()
         k1: str = field.Keyword(required=True)
         k2: M[str] = field.Keyword()
         k3: str = mapped_field(field.Keyword(), default="foo")
-        k4: M[Optional[str]] = mapped_field(field.Keyword())
+        k4: M[Optional[str]] = mapped_field(field.Keyword())  # type: ignore[misc]
         s1: Secret = SecretField()
         s2: M[Secret] = SecretField()
-        s3: Secret = mapped_field(SecretField())
+        s3: Secret = mapped_field(SecretField())  # type: ignore[misc]
         s4: M[Optional[Secret]] = mapped_field(
             SecretField(), default_factory=lambda: "foo"
         )
@@ -718,9 +724,10 @@ def test_doc_with_type_hints():
     doc.s3 = "s3"
     doc.full_clean()
 
-    doc.ob = TypedInnerDoc()
+    doc.ob = TypedInnerDoc(li=[1])
     with raises(ValidationException) as exc_info:
         doc.full_clean()
+    print(exc_info.value.args)
     assert set(exc_info.value.args[0].keys()) == {"ob"}
     assert set(exc_info.value.args[0]["ob"][0].args[0].keys()) == {"st"}
 
@@ -766,7 +773,7 @@ def test_doc_with_type_hints():
     assert s.to_dict() == {"sort": ["st", {"dt": {"order": "desc"}}, "ob.st"]}
 
 
-def test_instrumented_field():
+def test_instrumented_field() -> None:
     class Child(InnerDoc):
         st: M[str]
 

--- a/tests/_sync/test_faceted_search.py
+++ b/tests/_sync/test_faceted_search.py
@@ -28,10 +28,10 @@ from elasticsearch_dsl.faceted_search import (
 
 class BlogSearch(FacetedSearch):
     doc_types = ["user", "post"]
-    fields = (
+    fields = [
         "title^5",
         "body",
-    )
+    ]
 
     facets = {
         "category": TermsFacet(field="category.raw"),
@@ -39,7 +39,7 @@ class BlogSearch(FacetedSearch):
     }
 
 
-def test_query_is_created_properly():
+def test_query_is_created_properly() -> None:
     bs = BlogSearch("python search")
     s = bs.build_search()
 
@@ -56,13 +56,13 @@ def test_query_is_created_properly():
             },
         },
         "query": {
-            "multi_match": {"fields": ("title^5", "body"), "query": "python search"}
+            "multi_match": {"fields": ["title^5", "body"], "query": "python search"}
         },
         "highlight": {"fields": {"body": {}, "title": {}}},
     } == s.to_dict()
 
 
-def test_query_is_created_properly_with_sort_tuple():
+def test_query_is_created_properly_with_sort_tuple() -> None:
     bs = BlogSearch("python search", sort=("category", "-title"))
     s = bs.build_search()
 
@@ -79,14 +79,14 @@ def test_query_is_created_properly_with_sort_tuple():
             },
         },
         "query": {
-            "multi_match": {"fields": ("title^5", "body"), "query": "python search"}
+            "multi_match": {"fields": ["title^5", "body"], "query": "python search"}
         },
         "highlight": {"fields": {"body": {}, "title": {}}},
         "sort": ["category", {"title": {"order": "desc"}}],
     } == s.to_dict()
 
 
-def test_filter_is_applied_to_search_but_not_relevant_facet():
+def test_filter_is_applied_to_search_but_not_relevant_facet() -> None:
     bs = BlogSearch("python search", filters={"category": "elastic"})
     s = bs.build_search()
 
@@ -103,13 +103,13 @@ def test_filter_is_applied_to_search_but_not_relevant_facet():
         },
         "post_filter": {"terms": {"category.raw": ["elastic"]}},
         "query": {
-            "multi_match": {"fields": ("title^5", "body"), "query": "python search"}
+            "multi_match": {"fields": ["title^5", "body"], "query": "python search"}
         },
         "highlight": {"fields": {"body": {}, "title": {}}},
     } == s.to_dict()
 
 
-def test_filters_are_applied_to_search_ant_relevant_facets():
+def test_filters_are_applied_to_search_ant_relevant_facets() -> None:
     bs = BlogSearch(
         "python search", filters={"category": "elastic", "tags": ["python", "django"]}
     )
@@ -135,17 +135,17 @@ def test_filters_are_applied_to_search_ant_relevant_facets():
             },
         },
         "query": {
-            "multi_match": {"fields": ("title^5", "body"), "query": "python search"}
+            "multi_match": {"fields": ["title^5", "body"], "query": "python search"}
         },
         "post_filter": {"bool": {}},
         "highlight": {"fields": {"body": {}, "title": {}}},
     } == d
 
 
-def test_date_histogram_facet_with_1970_01_01_date():
+def test_date_histogram_facet_with_1970_01_01_date() -> None:
     dhf = DateHistogramFacet()
-    assert dhf.get_value({"key": None}) == datetime(1970, 1, 1, 0, 0)
-    assert dhf.get_value({"key": 0}) == datetime(1970, 1, 1, 0, 0)
+    assert dhf.get_value({"key": None}) == datetime(1970, 1, 1, 0, 0)  # type: ignore[arg-type]
+    assert dhf.get_value({"key": 0}) == datetime(1970, 1, 1, 0, 0)  # type: ignore[arg-type]
 
 
 @pytest.mark.parametrize(
@@ -175,7 +175,7 @@ def test_date_histogram_facet_with_1970_01_01_date():
         ("fixed_interval", "1h"),
     ],
 )
-def test_date_histogram_interval_types(interval_type, interval):
+def test_date_histogram_interval_types(interval_type: str, interval: str) -> None:
     dhf = DateHistogramFacet(field="@timestamp", **{interval_type: interval})
     assert dhf.get_aggregation().to_dict() == {
         "date_histogram": {
@@ -187,14 +187,14 @@ def test_date_histogram_interval_types(interval_type, interval):
     dhf.get_value_filter(datetime.now())
 
 
-def test_date_histogram_no_interval_keyerror():
+def test_date_histogram_no_interval_keyerror() -> None:
     dhf = DateHistogramFacet(field="@timestamp")
     with pytest.raises(KeyError) as e:
         dhf.get_value_filter(datetime.now())
     assert str(e.value) == "'interval'"
 
 
-def test_params_added_to_search():
+def test_params_added_to_search() -> None:
     bs = BlogSearch("python search")
     assert bs._s._params == {}
     bs.params(routing="42")

--- a/tests/_sync/test_index.py
+++ b/tests/_sync/test_index.py
@@ -17,6 +17,7 @@
 
 import string
 from random import choice
+from typing import Any, Dict
 
 import pytest
 from pytest import raises
@@ -29,7 +30,7 @@ class Post(Document):
     published_from = Date()
 
 
-def test_multiple_doc_types_will_combine_mappings():
+def test_multiple_doc_types_will_combine_mappings() -> None:
     class User(Document):
         username = Text()
 
@@ -47,16 +48,16 @@ def test_multiple_doc_types_will_combine_mappings():
     } == i.to_dict()
 
 
-def test_search_is_limited_to_index_name():
+def test_search_is_limited_to_index_name() -> None:
     i = Index("my-index")
     s = i.search()
 
     assert s._index == ["my-index"]
 
 
-def test_cloned_index_has_copied_settings_and_using():
+def test_cloned_index_has_copied_settings_and_using() -> None:
     client = object()
-    i = Index("my-index", using=client)
+    i = Index("my-index", using=client)  # type: ignore[arg-type]
     i.settings(number_of_shards=1)
 
     i2 = i.clone("my-other-index")
@@ -67,13 +68,13 @@ def test_cloned_index_has_copied_settings_and_using():
     assert i._settings is not i2._settings
 
 
-def test_cloned_index_has_analysis_attribute():
+def test_cloned_index_has_analysis_attribute() -> None:
     """
     Regression test for Issue #582 in which `AsyncIndex.clone()` was not copying
     over the `_analysis` attribute.
     """
     client = object()
-    i = Index("my-index", using=client)
+    i = Index("my-index", using=client)  # type: ignore[arg-type]
 
     random_analyzer_name = "".join(choice(string.ascii_letters) for _ in range(100))
     random_analyzer = analyzer(
@@ -87,7 +88,7 @@ def test_cloned_index_has_analysis_attribute():
     assert i.to_dict()["settings"]["analysis"] == i2.to_dict()["settings"]["analysis"]
 
 
-def test_settings_are_saved():
+def test_settings_are_saved() -> None:
     i = Index("i")
     i.settings(number_of_replicas=0)
     i.settings(number_of_shards=1)
@@ -95,7 +96,7 @@ def test_settings_are_saved():
     assert {"settings": {"number_of_shards": 1, "number_of_replicas": 0}} == i.to_dict()
 
 
-def test_registered_doc_type_included_in_to_dict():
+def test_registered_doc_type_included_in_to_dict() -> None:
     i = Index("i", using="alias")
     i.document(Post)
 
@@ -109,7 +110,7 @@ def test_registered_doc_type_included_in_to_dict():
     } == i.to_dict()
 
 
-def test_registered_doc_type_included_in_search():
+def test_registered_doc_type_included_in_search() -> None:
     i = Index("i", using="alias")
     i.document(Post)
 
@@ -118,9 +119,9 @@ def test_registered_doc_type_included_in_search():
     assert s._doc_type == [Post]
 
 
-def test_aliases_add_to_object():
+def test_aliases_add_to_object() -> None:
     random_alias = "".join(choice(string.ascii_letters) for _ in range(100))
-    alias_dict = {random_alias: {}}
+    alias_dict: Dict[str, Any] = {random_alias: {}}
 
     index = Index("i", using="alias")
     index.aliases(**alias_dict)
@@ -128,9 +129,9 @@ def test_aliases_add_to_object():
     assert index._aliases == alias_dict
 
 
-def test_aliases_returned_from_to_dict():
+def test_aliases_returned_from_to_dict() -> None:
     random_alias = "".join(choice(string.ascii_letters) for _ in range(100))
-    alias_dict = {random_alias: {}}
+    alias_dict: Dict[str, Any] = {random_alias: {}}
 
     index = Index("i", using="alias")
     index.aliases(**alias_dict)
@@ -138,7 +139,7 @@ def test_aliases_returned_from_to_dict():
     assert index._aliases == index.to_dict()["aliases"] == alias_dict
 
 
-def test_analyzers_added_to_object():
+def test_analyzers_added_to_object() -> None:
     random_analyzer_name = "".join(choice(string.ascii_letters) for _ in range(100))
     random_analyzer = analyzer(
         random_analyzer_name, tokenizer="standard", filter="standard"
@@ -154,7 +155,7 @@ def test_analyzers_added_to_object():
     }
 
 
-def test_analyzers_returned_from_to_dict():
+def test_analyzers_returned_from_to_dict() -> None:
     random_analyzer_name = "".join(choice(string.ascii_letters) for _ in range(100))
     random_analyzer = analyzer(
         random_analyzer_name, tokenizer="standard", filter="standard"
@@ -167,7 +168,7 @@ def test_analyzers_returned_from_to_dict():
     ] == {"filter": ["standard"], "type": "custom", "tokenizer": "standard"}
 
 
-def test_conflicting_analyzer_raises_error():
+def test_conflicting_analyzer_raises_error() -> None:
     i = Index("i")
     i.analyzer("my_analyzer", tokenizer="whitespace", filter=["lowercase", "stop"])
 
@@ -175,7 +176,7 @@ def test_conflicting_analyzer_raises_error():
         i.analyzer("my_analyzer", tokenizer="keyword", filter=["lowercase", "stop"])
 
 
-def test_index_template_can_have_order():
+def test_index_template_can_have_order() -> None:
     i = Index("i-*")
     it = i.as_template("i", order=2)
 
@@ -183,7 +184,7 @@ def test_index_template_can_have_order():
 
 
 @pytest.mark.sync
-def test_index_template_save_result(mock_client):
+def test_index_template_save_result(mock_client: Any) -> None:
     it = IndexTemplate("test-template", "test-*")
 
     assert it.save(using="mock") == mock_client.indices.put_template()

--- a/tests/_sync/test_mapping.py
+++ b/tests/_sync/test_mapping.py
@@ -20,7 +20,7 @@ import json
 from elasticsearch_dsl import Keyword, Mapping, Nested, Text, analysis
 
 
-def test_mapping_can_has_fields():
+def test_mapping_can_has_fields() -> None:
     m = Mapping()
     m.field("name", "text").field("tags", "keyword")
 
@@ -29,7 +29,7 @@ def test_mapping_can_has_fields():
     } == m.to_dict()
 
 
-def test_mapping_update_is_recursive():
+def test_mapping_update_is_recursive() -> None:
     m1 = Mapping()
     m1.field("title", "text")
     m1.field("author", "object")
@@ -62,7 +62,7 @@ def test_mapping_update_is_recursive():
     } == m1.to_dict()
 
 
-def test_properties_can_iterate_over_all_the_fields():
+def test_properties_can_iterate_over_all_the_fields() -> None:
     m = Mapping()
     m.field("f1", "text", test_attr="f1", fields={"f2": Keyword(test_attr="f2")})
     m.field("f3", Nested(test_attr="f3", properties={"f4": Text(test_attr="f4")}))
@@ -72,7 +72,7 @@ def test_properties_can_iterate_over_all_the_fields():
     }
 
 
-def test_mapping_can_collect_all_analyzers_and_normalizers():
+def test_mapping_can_collect_all_analyzers_and_normalizers() -> None:
     a1 = analysis.analyzer(
         "my_analyzer1",
         tokenizer="keyword",
@@ -145,7 +145,7 @@ def test_mapping_can_collect_all_analyzers_and_normalizers():
     assert json.loads(json.dumps(m.to_dict())) == m.to_dict()
 
 
-def test_mapping_can_collect_multiple_analyzers():
+def test_mapping_can_collect_multiple_analyzers() -> None:
     a1 = analysis.analyzer(
         "my_analyzer1",
         tokenizer="keyword",
@@ -191,7 +191,7 @@ def test_mapping_can_collect_multiple_analyzers():
     } == m._collect_analysis()
 
 
-def test_even_non_custom_analyzers_can_have_params():
+def test_even_non_custom_analyzers_can_have_params() -> None:
     a1 = analysis.analyzer("whitespace", type="pattern", pattern=r"\\s+")
     m = Mapping()
     m.field("title", "text", analyzer=a1)
@@ -201,14 +201,14 @@ def test_even_non_custom_analyzers_can_have_params():
     } == m._collect_analysis()
 
 
-def test_resolve_field_can_resolve_multifields():
+def test_resolve_field_can_resolve_multifields() -> None:
     m = Mapping()
     m.field("title", "text", fields={"keyword": Keyword()})
 
     assert isinstance(m.resolve_field("title.keyword"), Keyword)
 
 
-def test_resolve_nested():
+def test_resolve_nested() -> None:
     m = Mapping()
     m.field("n1", "nested", properties={"n2": Nested(properties={"k1": Keyword()})})
     m.field("k2", "keyword")

--- a/tests/_sync/test_search.py
+++ b/tests/_sync/test_search.py
@@ -16,61 +16,62 @@
 #  under the License.
 
 from copy import deepcopy
+from typing import Any
 
 import pytest
 from pytest import raises
 
-from elasticsearch_dsl import A, Document, EmptySearch, Q, Search, query
+from elasticsearch_dsl import Document, EmptySearch, Q, Search, query
 from elasticsearch_dsl.exceptions import IllegalOperation
 
 
-def test_expand__to_dot_is_respected():
+def test_expand__to_dot_is_respected() -> None:
     s = Search().query("match", a__b=42, _expand__to_dot=False)
 
     assert {"query": {"match": {"a__b": 42}}} == s.to_dict()
 
 
 @pytest.mark.sync
-def test_execute_uses_cache():
+def test_execute_uses_cache() -> None:
     s = Search()
     r = object()
-    s._response = r
+    s._response = r  # type: ignore[assignment]
 
     assert r is s.execute()
 
 
 @pytest.mark.sync
-def test_cache_can_be_ignored(mock_client):
+def test_cache_can_be_ignored(mock_client: Any) -> None:
     s = Search(using="mock")
     r = object()
-    s._response = r
+    s._response = r  # type: ignore[assignment]
     s.execute(ignore_cache=True)
 
     mock_client.search.assert_called_once_with(index=None, body={})
 
 
 @pytest.mark.sync
-def test_iter_iterates_over_hits():
+def test_iter_iterates_over_hits() -> None:
     s = Search()
-    s._response = [1, 2, 3]
+    s._response = [1, 2, 3]  # type: ignore[assignment]
 
     assert [1, 2, 3] == [hit for hit in s]
 
 
-def test_cache_isnt_cloned():
+def test_cache_isnt_cloned() -> None:
     s = Search()
-    s._response = object()
+    s._response = object()  # type: ignore[assignment]
 
     assert not hasattr(s._clone(), "_response")
 
 
-def test_search_starts_with_no_query():
+def test_search_starts_with_no_query() -> None:
     s = Search()
 
     assert s.query._proxied is None
 
 
-def test_search_query_combines_query():
+def test_search_query_combines_query() -> None:
     s = Search()
 
     s2 = s.query("match", f=42)
@@ -82,19 +83,19 @@ def test_search_query_combines_query():
     assert s3.query._proxied == query.Bool(must=[query.Match(f=42), query.Match(f=43)])
 
 
-def test_query_can_be_assigned_to():
+def test_query_can_be_assigned_to() -> None:
     s = Search()
 
     q = Q("match", title="python")
-    s.query = q
+    s.query = q  # type: ignore
 
     assert s.query._proxied is q
 
 
-def test_query_can_be_wrapped():
+def test_query_can_be_wrapped() -> None:
     s = Search().query("match", title="python")
 
-    s.query = Q("function_score", query=s.query, field_value_factor={"field": "rating"})
+    s.query = Q("function_score", query=s.query, field_value_factor={"field": "rating"})  # type: ignore
 
     assert {
         "query": {
@@ -106,29 +107,29 @@ def test_query_can_be_wrapped():
     } == s.to_dict()
 
 
-def test_using():
+def test_using() -> None:
     o = object()
     o2 = object()
     s = Search(using=o)
     assert s._using is o
-    s2 = s.using(o2)
+    s2 = s.using(o2)  # type: ignore[arg-type]
     assert s._using is o
     assert s2._using is o2
 
 
-def test_methods_are_proxied_to_the_query():
+def test_methods_are_proxied_to_the_query() -> None:
     s = Search().query("match_all")
 
     assert s.query.to_dict() == {"match_all": {}}
 
 
-def test_query_always_returns_search():
+def test_query_always_returns_search() -> None:
     s = Search()
 
     assert isinstance(s.query("match", f=42), Search)
 
 
-def test_source_copied_on_clone():
+def test_source_copied_on_clone() -> None:
     s = Search().source(False)
     assert s._clone()._source == s._source
     assert s._clone()._source is False
@@ -142,7 +143,7 @@ def test_source_copied_on_clone():
     assert s3._clone()._source == ["some", "fields"]
 
 
-def test_copy_clones():
+def test_copy_clones() -> None:
     from copy import copy
 
     s1 = Search().source(["some", "fields"])
@@ -152,7 +153,7 @@ def test_copy_clones():
     assert s1 is not s2
 
 
-def test_aggs_allow_two_metric():
+def test_aggs_allow_two_metric() -> None:
     s = Search()
 
     s.aggs.metric("a", "max", field="a").metric("b", "max", field="b")
@@ -162,7 +163,7 @@ def test_aggs_allow_two_metric():
     }
 
 
-def test_aggs_get_copied_on_change():
+def test_aggs_get_copied_on_change() -> None:
     s = Search().query("match_all")
     s.aggs.bucket("per_tag", "terms", field="f").metric(
         "max_score", "max", field="score"
@@ -175,7 +176,7 @@ def test_aggs_get_copied_on_change():
     s4 = s3._clone()
     s4.aggs.metric("max_score", "max", field="score")
 
-    d = {
+    d: Any = {
         "query": {"match_all": {}},
         "aggs": {
             "per_tag": {
@@ -194,7 +195,7 @@ def test_aggs_get_copied_on_change():
     assert d == s4.to_dict()
 
 
-def test_search_index():
+def test_search_index() -> None:
     s = Search(index="i")
     assert s._index == ["i"]
     s = s.index("i2")
@@ -225,7 +226,7 @@ def test_search_index():
     assert s2._index == ["i", "i2", "i3", "i4", "i5"]
 
 
-def test_doc_type_document_class():
+def test_doc_type_document_class() -> None:
     class MyDocument(Document):
         pass
 
@@ -238,15 +239,15 @@ def test_doc_type_document_class():
     assert s._doc_type_map == {}
 
 
-def test_knn():
+def test_knn() -> None:
     s = Search()
 
     with raises(TypeError):
-        s.knn()
+        s.knn()  # type: ignore[call-arg]
     with raises(TypeError):
-        s.knn("field")
+        s.knn("field")  # type: ignore[call-arg]
     with raises(TypeError):
-        s.knn("field", 5)
+        s.knn("field", 5)  # type: ignore[call-arg]
     with raises(ValueError):
         s.knn("field", 5, 100)
     with raises(ValueError):
@@ -294,7 +295,7 @@ def test_knn():
     } == s.to_dict()
 
 
-def test_rank():
+def test_rank() -> None:
     s = Search()
     s.rank(rrf=False)
     assert {} == s.to_dict()
@@ -306,7 +307,7 @@ def test_rank():
     assert {"rank": {"rrf": {"window_size": 50, "rank_constant": 20}}} == s.to_dict()
 
 
-def test_sort():
+def test_sort() -> None:
     s = Search()
     s = s.sort("fielda", "-fieldb")
 
@@ -318,7 +319,7 @@ def test_sort():
     assert Search().to_dict() == s.to_dict()
 
 
-def test_sort_by_score():
+def test_sort_by_score() -> None:
     s = Search()
     s = s.sort("_score")
     assert {"sort": ["_score"]} == s.to_dict()
@@ -328,7 +329,7 @@ def test_sort_by_score():
         s.sort("-_score")
 
 
-def test_collapse():
+def test_collapse() -> None:
     s = Search()
 
     inner_hits = {"name": "most_recent", "size": 5, "sort": [{"@timestamp": "desc"}]}
@@ -360,7 +361,7 @@ def test_collapse():
     assert Search().to_dict() == s.to_dict()
 
 
-def test_slice():
+def test_slice() -> None:
     s = Search()
     assert {"from": 3, "size": 7} == s[3:10].to_dict()
     assert {"size": 5} == s[:5].to_dict()
@@ -383,7 +384,7 @@ def test_slice():
         s[-3:-2]
 
 
-def test_index():
+def test_index() -> None:
     s = Search()
     assert {"from": 3, "size": 1} == s[3].to_dict()
     assert {"from": 3, "size": 1} == s[3][0].to_dict()
@@ -393,7 +394,7 @@ def test_index():
         s[-3]
 
 
-def test_search_to_dict():
+def test_search_to_dict() -> None:
     s = Search()
     assert {} == s.to_dict()
 
@@ -422,7 +423,7 @@ def test_search_to_dict():
     assert {"size": 5, "from": 42} == s.to_dict()
 
 
-def test_complex_example():
+def test_complex_example() -> None:
     s = Search()
     s = (
         s.query("match", title="python")
@@ -475,7 +476,7 @@ def test_complex_example():
     } == s.to_dict()
 
 
-def test_reverse():
+def test_reverse() -> None:
     d = {
         "query": {
             "filtered": {
@@ -525,14 +526,14 @@ def test_reverse():
     assert d == s.to_dict()
 
 
-def test_from_dict_doesnt_need_query():
+def test_from_dict_doesnt_need_query() -> None:
     s = Search.from_dict({"size": 5})
 
     assert {"size": 5} == s.to_dict()
 
 
 @pytest.mark.sync
-def test_params_being_passed_to_search(mock_client):
+def test_params_being_passed_to_search(mock_client: Any) -> None:
     s = Search(using="mock")
     s = s.params(routing="42")
     s.execute()
@@ -540,7 +541,7 @@ def test_params_being_passed_to_search(mock_client):
     mock_client.search.assert_called_once_with(index=None, body={}, routing="42")
 
 
-def test_source():
+def test_source() -> None:
     assert {} == Search().source().to_dict()
 
     assert {
@@ -554,7 +555,7 @@ def test_source():
     ).source(["f1", "f2"]).to_dict()
 
 
-def test_source_on_clone():
+def test_source_on_clone() -> None:
     assert {
         "_source": {"includes": ["foo.bar.*"], "excludes": ["foo.one"]},
         "query": {"bool": {"filter": [{"term": {"title": "python"}}]}},
@@ -567,7 +568,7 @@ def test_source_on_clone():
     } == Search().source(False).filter("term", title="python").to_dict()
 
 
-def test_source_on_clear():
+def test_source_on_clear() -> None:
     assert (
         {}
         == Search()
@@ -577,7 +578,7 @@ def test_source_on_clear():
     )
 
 
-def test_suggest_accepts_global_text():
+def test_suggest_accepts_global_text() -> None:
     s = Search.from_dict(
         {
             "suggest": {
@@ -599,7 +600,7 @@ def test_suggest_accepts_global_text():
     } == s.to_dict()
 
 
-def test_suggest():
+def test_suggest() -> None:
     s = Search()
     s = s.suggest("my_suggestion", "pyhton", term={"field": "title"})
 
@@ -608,7 +609,7 @@ def test_suggest():
     } == s.to_dict()
 
 
-def test_exclude():
+def test_exclude() -> None:
     s = Search()
     s = s.exclude("match", title="python")
 
@@ -622,7 +623,7 @@ def test_exclude():
 
 
 @pytest.mark.sync
-def test_delete_by_query(mock_client):
+def test_delete_by_query(mock_client: Any) -> None:
     s = Search(using="mock", index="i").query("match", lang="java")
     s.delete()
 
@@ -631,7 +632,7 @@ def test_delete_by_query(mock_client):
     )
 
 
-def test_update_from_dict():
+def test_update_from_dict() -> None:
     s = Search()
     s.update_from_dict({"indices_boost": [{"important-documents": 2}]})
     s.update_from_dict({"_source": ["id", "name"]})
@@ -644,7 +645,7 @@ def test_update_from_dict():
     } == s.to_dict()
 
 
-def test_rescore_query_to_dict():
+def test_rescore_query_to_dict() -> None:
     s = Search(index="index-name")
 
     positive_query = Q(
@@ -707,10 +708,10 @@ def test_rescore_query_to_dict():
 
 
 @pytest.mark.sync
-def test_empty_search():
+def test_empty_search() -> None:
     s = EmptySearch(index="index-name")
     s = s.query("match", lang="java")
-    s.aggs.bucket("versions", A("terms", field="version"))
+    s.aggs.bucket("versions", "terms", field="version")
 
     assert s.count() == 0
     assert [hit for hit in s] == []
@@ -718,7 +719,7 @@ def test_empty_search():
     s.delete()  # should not error
 
 
-def test_suggest_completion():
+def test_suggest_completion() -> None:
     s = Search()
     s = s.suggest("my_suggestion", "pyhton", completion={"field": "title"})
 
@@ -729,7 +730,7 @@ def test_suggest_completion():
     } == s.to_dict()
 
 
-def test_suggest_regex_query():
+def test_suggest_regex_query() -> None:
     s = Search()
     s = s.suggest("my_suggestion", regex="py[thon|py]", completion={"field": "title"})
 
@@ -740,19 +741,19 @@ def test_suggest_regex_query():
     } == s.to_dict()
 
 
-def test_suggest_must_pass_text_or_regex():
+def test_suggest_must_pass_text_or_regex() -> None:
     s = Search()
     with raises(ValueError):
         s.suggest("my_suggestion")
 
 
-def test_suggest_can_only_pass_text_or_regex():
+def test_suggest_can_only_pass_text_or_regex() -> None:
     s = Search()
     with raises(ValueError):
         s.suggest("my_suggestion", text="python", regex="py[hton|py]")
 
 
-def test_suggest_regex_must_be_wtih_completion():
+def test_suggest_regex_must_be_wtih_completion() -> None:
     s = Search()
     with raises(ValueError):
         s.suggest("my_suggestion", regex="py[thon|py]")

--- a/tests/_sync/test_update_by_query.py
+++ b/tests/_sync/test_update_by_query.py
@@ -16,20 +16,22 @@
 #  under the License.
 
 from copy import deepcopy
+from typing import Any
 
 import pytest
 
 from elasticsearch_dsl import Q, UpdateByQuery
 from elasticsearch_dsl.response import UpdateByQueryResponse
+from elasticsearch_dsl.search_base import SearchBase
 
 
-def test_ubq_starts_with_no_query():
+def test_ubq_starts_with_no_query() -> None:
     ubq = UpdateByQuery()
 
     assert ubq.query._proxied is None
 
 
-def test_ubq_to_dict():
+def test_ubq_to_dict() -> None:
     ubq = UpdateByQuery()
     assert {} == ubq.to_dict()
 
@@ -45,7 +47,7 @@ def test_ubq_to_dict():
     assert {"extra_q": {"term": {"category": "conference"}}} == ubq.to_dict()
 
 
-def test_complex_example():
+def test_complex_example() -> None:
     ubq = UpdateByQuery()
     ubq = (
         ubq.query("match", title="python")
@@ -83,7 +85,7 @@ def test_complex_example():
     } == ubq.to_dict()
 
 
-def test_exclude():
+def test_exclude() -> None:
     ubq = UpdateByQuery()
     ubq = ubq.exclude("match", title="python")
 
@@ -96,7 +98,7 @@ def test_exclude():
     } == ubq.to_dict()
 
 
-def test_reverse():
+def test_reverse() -> None:
     d = {
         "query": {
             "filtered": {
@@ -132,14 +134,14 @@ def test_reverse():
     assert d == ubq.to_dict()
 
 
-def test_from_dict_doesnt_need_query():
+def test_from_dict_doesnt_need_query() -> None:
     ubq = UpdateByQuery.from_dict({"script": {"source": "test"}})
 
     assert {"script": {"source": "test"}} == ubq.to_dict()
 
 
 @pytest.mark.sync
-def test_params_being_passed_to_search(mock_client):
+def test_params_being_passed_to_search(mock_client: Any) -> None:
     ubq = UpdateByQuery(using="mock", index="i")
     ubq = ubq.params(routing="42")
     ubq.execute()
@@ -147,7 +149,7 @@ def test_params_being_passed_to_search(mock_client):
     mock_client.update_by_query.assert_called_once_with(index=["i"], routing="42")
 
 
-def test_overwrite_script():
+def test_overwrite_script() -> None:
     ubq = UpdateByQuery()
     ubq = ubq.script(
         source="ctx._source.likes += params.f", lang="painless", params={"f": 3}
@@ -163,12 +165,12 @@ def test_overwrite_script():
     assert {"script": {"source": "ctx._source.likes++"}} == ubq.to_dict()
 
 
-def test_update_by_query_response_success():
-    ubqr = UpdateByQueryResponse({}, {"timed_out": False, "failures": []})
+def test_update_by_query_response_success() -> None:
+    ubqr = UpdateByQueryResponse(SearchBase(), {"timed_out": False, "failures": []})
     assert ubqr.success()
 
-    ubqr = UpdateByQueryResponse({}, {"timed_out": True, "failures": []})
+    ubqr = UpdateByQueryResponse(SearchBase(), {"timed_out": True, "failures": []})
     assert not ubqr.success()
 
-    ubqr = UpdateByQueryResponse({}, {"timed_out": False, "failures": [{}]})
+    ubqr = UpdateByQueryResponse(SearchBase(), {"timed_out": False, "failures": [{}]})
     assert not ubqr.success()

--- a/tests/async_sleep.py
+++ b/tests/async_sleep.py
@@ -16,8 +16,9 @@
 #  under the License.
 
 import asyncio
+from typing import Union
 
 
-async def sleep(secs):
+async def sleep(secs: Union[int, float]) -> None:
     """Tests can use this function to sleep."""
     await asyncio.sleep(secs)

--- a/tests/sleep.py
+++ b/tests/sleep.py
@@ -16,8 +16,9 @@
 #  under the License.
 
 import time
+from typing import Union
 
 
-def sleep(secs):
+def sleep(secs: Union[int, float]) -> None:
     """Tests can use this function to sleep."""
     time.sleep(secs)

--- a/tests/test_integration/_async/test_analysis.py
+++ b/tests/test_integration/_async/test_analysis.py
@@ -16,12 +16,15 @@
 #  under the License.
 
 import pytest
+from elasticsearch import AsyncElasticsearch
 
 from elasticsearch_dsl import analyzer, token_filter, tokenizer
 
 
 @pytest.mark.asyncio
-async def test_simulate_with_just__builtin_tokenizer(async_client):
+async def test_simulate_with_just__builtin_tokenizer(
+    async_client: AsyncElasticsearch,
+) -> None:
     a = analyzer("my-analyzer", tokenizer="keyword")
     tokens = (await a.async_simulate("Hello World!", using=async_client)).tokens
 
@@ -30,7 +33,7 @@ async def test_simulate_with_just__builtin_tokenizer(async_client):
 
 
 @pytest.mark.asyncio
-async def test_simulate_complex(async_client):
+async def test_simulate_complex(async_client: AsyncElasticsearch) -> None:
     a = analyzer(
         "my-analyzer",
         tokenizer=tokenizer("split_words", "simple_pattern_split", pattern=":"),
@@ -44,7 +47,7 @@ async def test_simulate_complex(async_client):
 
 
 @pytest.mark.asyncio
-async def test_simulate_builtin(async_client):
+async def test_simulate_builtin(async_client: AsyncElasticsearch) -> None:
     a = analyzer("my-analyzer", "english")
     tokens = (await a.async_simulate("fixes running")).tokens
 

--- a/tests/test_integration/_async/test_index.py
+++ b/tests/test_integration/_async/test_index.py
@@ -16,6 +16,7 @@
 #  under the License.
 
 import pytest
+from elasticsearch import AsyncElasticsearch
 
 from elasticsearch_dsl import (
     AsyncDocument,
@@ -33,7 +34,7 @@ class Post(AsyncDocument):
 
 
 @pytest.mark.asyncio
-async def test_index_template_works(async_write_client):
+async def test_index_template_works(async_write_client: AsyncElasticsearch) -> None:
     it = AsyncIndexTemplate("test-template", "test-*")
     it.document(Post)
     it.settings(number_of_replicas=0, number_of_shards=1)
@@ -55,7 +56,9 @@ async def test_index_template_works(async_write_client):
 
 
 @pytest.mark.asyncio
-async def test_index_can_be_saved_even_with_settings(async_write_client):
+async def test_index_can_be_saved_even_with_settings(
+    async_write_client: AsyncElasticsearch,
+) -> None:
     i = AsyncIndex("test-blog", using=async_write_client)
     i.settings(number_of_shards=3, number_of_replicas=0)
     await i.save()
@@ -71,13 +74,15 @@ async def test_index_can_be_saved_even_with_settings(async_write_client):
 
 
 @pytest.mark.asyncio
-async def test_index_exists(async_data_client):
+async def test_index_exists(async_data_client: AsyncElasticsearch) -> None:
     assert await AsyncIndex("git").exists()
     assert not await AsyncIndex("not-there").exists()
 
 
 @pytest.mark.asyncio
-async def test_index_can_be_created_with_settings_and_mappings(async_write_client):
+async def test_index_can_be_created_with_settings_and_mappings(
+    async_write_client: AsyncElasticsearch,
+) -> None:
     i = AsyncIndex("test-blog", using=async_write_client)
     i.document(Post)
     i.settings(number_of_replicas=0, number_of_shards=1)
@@ -103,7 +108,7 @@ async def test_index_can_be_created_with_settings_and_mappings(async_write_clien
 
 
 @pytest.mark.asyncio
-async def test_delete(async_write_client):
+async def test_delete(async_write_client: AsyncElasticsearch) -> None:
     await async_write_client.indices.create(
         index="test-index",
         body={"settings": {"number_of_replicas": 0, "number_of_shards": 1}},
@@ -115,7 +120,9 @@ async def test_delete(async_write_client):
 
 
 @pytest.mark.asyncio
-async def test_multiple_indices_with_same_doc_type_work(async_write_client):
+async def test_multiple_indices_with_same_doc_type_work(
+    async_write_client: AsyncElasticsearch,
+) -> None:
     i1 = AsyncIndex("test-index-1", using=async_write_client)
     i2 = AsyncIndex("test-index-2", using=async_write_client)
 
@@ -123,8 +130,8 @@ async def test_multiple_indices_with_same_doc_type_work(async_write_client):
         i.document(Post)
         await i.create()
 
-    for i in ("test-index-1", "test-index-2"):
-        settings = await async_write_client.indices.get_settings(index=i)
-        assert settings[i]["settings"]["index"]["analysis"] == {
+    for j in ("test-index-1", "test-index-2"):
+        settings = await async_write_client.indices.get_settings(index=j)
+        assert settings[j]["settings"]["index"]["analysis"] == {
             "analyzer": {"my_analyzer": {"type": "custom", "tokenizer": "keyword"}}
         }

--- a/tests/test_integration/_async/test_mapping.py
+++ b/tests/test_integration/_async/test_mapping.py
@@ -16,13 +16,14 @@
 #  under the License.
 
 import pytest
+from elasticsearch import AsyncElasticsearch
 from pytest import raises
 
 from elasticsearch_dsl import AsyncMapping, analysis, exceptions
 
 
 @pytest.mark.asyncio
-async def test_mapping_saved_into_es(async_write_client):
+async def test_mapping_saved_into_es(async_write_client: AsyncElasticsearch) -> None:
     m = AsyncMapping()
     m.field(
         "name", "text", analyzer=analysis.analyzer("my_analyzer", tokenizer="keyword")
@@ -44,8 +45,8 @@ async def test_mapping_saved_into_es(async_write_client):
 
 @pytest.mark.asyncio
 async def test_mapping_saved_into_es_when_index_already_exists_closed(
-    async_write_client,
-):
+    async_write_client: AsyncElasticsearch,
+) -> None:
     m = AsyncMapping()
     m.field(
         "name", "text", analyzer=analysis.analyzer("my_analyzer", tokenizer="keyword")
@@ -72,8 +73,8 @@ async def test_mapping_saved_into_es_when_index_already_exists_closed(
 
 @pytest.mark.asyncio
 async def test_mapping_saved_into_es_when_index_already_exists_with_analysis(
-    async_write_client,
-):
+    async_write_client: AsyncElasticsearch,
+) -> None:
     m = AsyncMapping()
     analyzer = analysis.analyzer("my_analyzer", tokenizer="keyword")
     m.field("name", "text", analyzer=analyzer)
@@ -103,7 +104,9 @@ async def test_mapping_saved_into_es_when_index_already_exists_with_analysis(
 
 
 @pytest.mark.asyncio
-async def test_mapping_gets_updated_from_es(async_write_client):
+async def test_mapping_gets_updated_from_es(
+    async_write_client: AsyncElasticsearch,
+) -> None:
     await async_write_client.indices.create(
         index="test-mapping",
         body={
@@ -136,7 +139,7 @@ async def test_mapping_gets_updated_from_es(async_write_client):
     m = await AsyncMapping.from_es("test-mapping", using=async_write_client)
 
     assert ["comments", "created_at", "title"] == list(
-        sorted(m.properties.properties._d_.keys())
+        sorted(m.properties.properties._d_.keys())  # type: ignore[attr-defined]
     )
     assert {
         "date_detection": False,

--- a/tests/test_integration/_async/test_update_by_query.py
+++ b/tests/test_integration/_async/test_update_by_query.py
@@ -16,13 +16,16 @@
 #  under the License.
 
 import pytest
+from elasticsearch import AsyncElasticsearch
 
 from elasticsearch_dsl import AsyncUpdateByQuery
 from elasticsearch_dsl.search import Q
 
 
 @pytest.mark.asyncio
-async def test_update_by_query_no_script(async_write_client, setup_ubq_tests):
+async def test_update_by_query_no_script(
+    async_write_client: AsyncElasticsearch, setup_ubq_tests: str
+) -> None:
     index = setup_ubq_tests
 
     ubq = (
@@ -42,7 +45,9 @@ async def test_update_by_query_no_script(async_write_client, setup_ubq_tests):
 
 
 @pytest.mark.asyncio
-async def test_update_by_query_with_script(async_write_client, setup_ubq_tests: str):
+async def test_update_by_query_with_script(
+    async_write_client: AsyncElasticsearch, setup_ubq_tests: str
+) -> None:
     index = setup_ubq_tests
 
     ubq = (
@@ -60,7 +65,9 @@ async def test_update_by_query_with_script(async_write_client, setup_ubq_tests: 
 
 
 @pytest.mark.asyncio
-async def test_delete_by_query_with_script(async_write_client, setup_ubq_tests: str):
+async def test_delete_by_query_with_script(
+    async_write_client: AsyncElasticsearch, setup_ubq_tests: str
+) -> None:
     index = setup_ubq_tests
 
     ubq = (

--- a/tests/test_integration/_sync/test_analysis.py
+++ b/tests/test_integration/_sync/test_analysis.py
@@ -16,12 +16,15 @@
 #  under the License.
 
 import pytest
+from elasticsearch import Elasticsearch
 
 from elasticsearch_dsl import analyzer, token_filter, tokenizer
 
 
 @pytest.mark.sync
-def test_simulate_with_just__builtin_tokenizer(client):
+def test_simulate_with_just__builtin_tokenizer(
+    client: Elasticsearch,
+) -> None:
     a = analyzer("my-analyzer", tokenizer="keyword")
     tokens = (a.simulate("Hello World!", using=client)).tokens
 
@@ -30,7 +33,7 @@ def test_simulate_with_just__builtin_tokenizer(client):
 
 
 @pytest.mark.sync
-def test_simulate_complex(client):
+def test_simulate_complex(client: Elasticsearch) -> None:
     a = analyzer(
         "my-analyzer",
         tokenizer=tokenizer("split_words", "simple_pattern_split", pattern=":"),
@@ -44,7 +47,7 @@ def test_simulate_complex(client):
 
 
 @pytest.mark.sync
-def test_simulate_builtin(client):
+def test_simulate_builtin(client: Elasticsearch) -> None:
     a = analyzer("my-analyzer", "english")
     tokens = (a.simulate("fixes running")).tokens
 

--- a/tests/test_integration/_sync/test_index.py
+++ b/tests/test_integration/_sync/test_index.py
@@ -16,6 +16,7 @@
 #  under the License.
 
 import pytest
+from elasticsearch import Elasticsearch
 
 from elasticsearch_dsl import Date, Document, Index, IndexTemplate, Text, analysis
 
@@ -26,7 +27,7 @@ class Post(Document):
 
 
 @pytest.mark.sync
-def test_index_template_works(write_client):
+def test_index_template_works(write_client: Elasticsearch) -> None:
     it = IndexTemplate("test-template", "test-*")
     it.document(Post)
     it.settings(number_of_replicas=0, number_of_shards=1)
@@ -48,7 +49,9 @@ def test_index_template_works(write_client):
 
 
 @pytest.mark.sync
-def test_index_can_be_saved_even_with_settings(write_client):
+def test_index_can_be_saved_even_with_settings(
+    write_client: Elasticsearch,
+) -> None:
     i = Index("test-blog", using=write_client)
     i.settings(number_of_shards=3, number_of_replicas=0)
     i.save()
@@ -62,13 +65,15 @@ def test_index_can_be_saved_even_with_settings(write_client):
 
 
 @pytest.mark.sync
-def test_index_exists(data_client):
+def test_index_exists(data_client: Elasticsearch) -> None:
     assert Index("git").exists()
     assert not Index("not-there").exists()
 
 
 @pytest.mark.sync
-def test_index_can_be_created_with_settings_and_mappings(write_client):
+def test_index_can_be_created_with_settings_and_mappings(
+    write_client: Elasticsearch,
+) -> None:
     i = Index("test-blog", using=write_client)
     i.document(Post)
     i.settings(number_of_replicas=0, number_of_shards=1)
@@ -94,7 +99,7 @@ def test_index_can_be_created_with_settings_and_mappings(write_client):
 
 
 @pytest.mark.sync
-def test_delete(write_client):
+def test_delete(write_client: Elasticsearch) -> None:
     write_client.indices.create(
         index="test-index",
         body={"settings": {"number_of_replicas": 0, "number_of_shards": 1}},
@@ -106,7 +111,9 @@ def test_delete(write_client):
 
 
 @pytest.mark.sync
-def test_multiple_indices_with_same_doc_type_work(write_client):
+def test_multiple_indices_with_same_doc_type_work(
+    write_client: Elasticsearch,
+) -> None:
     i1 = Index("test-index-1", using=write_client)
     i2 = Index("test-index-2", using=write_client)
 
@@ -114,8 +121,8 @@ def test_multiple_indices_with_same_doc_type_work(write_client):
         i.document(Post)
         i.create()
 
-    for i in ("test-index-1", "test-index-2"):
-        settings = write_client.indices.get_settings(index=i)
-        assert settings[i]["settings"]["index"]["analysis"] == {
+    for j in ("test-index-1", "test-index-2"):
+        settings = write_client.indices.get_settings(index=j)
+        assert settings[j]["settings"]["index"]["analysis"] == {
             "analyzer": {"my_analyzer": {"type": "custom", "tokenizer": "keyword"}}
         }

--- a/tests/test_integration/_sync/test_mapping.py
+++ b/tests/test_integration/_sync/test_mapping.py
@@ -16,13 +16,14 @@
 #  under the License.
 
 import pytest
+from elasticsearch import Elasticsearch
 from pytest import raises
 
 from elasticsearch_dsl import Mapping, analysis, exceptions
 
 
 @pytest.mark.sync
-def test_mapping_saved_into_es(write_client):
+def test_mapping_saved_into_es(write_client: Elasticsearch) -> None:
     m = Mapping()
     m.field(
         "name", "text", analyzer=analysis.analyzer("my_analyzer", tokenizer="keyword")
@@ -44,8 +45,8 @@ def test_mapping_saved_into_es(write_client):
 
 @pytest.mark.sync
 def test_mapping_saved_into_es_when_index_already_exists_closed(
-    write_client,
-):
+    write_client: Elasticsearch,
+) -> None:
     m = Mapping()
     m.field(
         "name", "text", analyzer=analysis.analyzer("my_analyzer", tokenizer="keyword")
@@ -70,8 +71,8 @@ def test_mapping_saved_into_es_when_index_already_exists_closed(
 
 @pytest.mark.sync
 def test_mapping_saved_into_es_when_index_already_exists_with_analysis(
-    write_client,
-):
+    write_client: Elasticsearch,
+) -> None:
     m = Mapping()
     analyzer = analysis.analyzer("my_analyzer", tokenizer="keyword")
     m.field("name", "text", analyzer=analyzer)
@@ -101,7 +102,9 @@ def test_mapping_saved_into_es_when_index_already_exists_with_analysis(
 
 
 @pytest.mark.sync
-def test_mapping_gets_updated_from_es(write_client):
+def test_mapping_gets_updated_from_es(
+    write_client: Elasticsearch,
+) -> None:
     write_client.indices.create(
         index="test-mapping",
         body={
@@ -134,7 +137,7 @@ def test_mapping_gets_updated_from_es(write_client):
     m = Mapping.from_es("test-mapping", using=write_client)
 
     assert ["comments", "created_at", "title"] == list(
-        sorted(m.properties.properties._d_.keys())
+        sorted(m.properties.properties._d_.keys())  # type: ignore[attr-defined]
     )
     assert {
         "date_detection": False,

--- a/tests/test_integration/_sync/test_update_by_query.py
+++ b/tests/test_integration/_sync/test_update_by_query.py
@@ -16,13 +16,16 @@
 #  under the License.
 
 import pytest
+from elasticsearch import Elasticsearch
 
 from elasticsearch_dsl import UpdateByQuery
 from elasticsearch_dsl.search import Q
 
 
 @pytest.mark.sync
-def test_update_by_query_no_script(write_client, setup_ubq_tests):
+def test_update_by_query_no_script(
+    write_client: Elasticsearch, setup_ubq_tests: str
+) -> None:
     index = setup_ubq_tests
 
     ubq = (
@@ -42,7 +45,9 @@ def test_update_by_query_no_script(write_client, setup_ubq_tests):
 
 
 @pytest.mark.sync
-def test_update_by_query_with_script(write_client, setup_ubq_tests: str):
+def test_update_by_query_with_script(
+    write_client: Elasticsearch, setup_ubq_tests: str
+) -> None:
     index = setup_ubq_tests
 
     ubq = (
@@ -60,7 +65,9 @@ def test_update_by_query_with_script(write_client, setup_ubq_tests: str):
 
 
 @pytest.mark.sync
-def test_delete_by_query_with_script(write_client, setup_ubq_tests: str):
+def test_delete_by_query_with_script(
+    write_client: Elasticsearch, setup_ubq_tests: str
+) -> None:
     index = setup_ubq_tests
 
     ubq = (

--- a/tests/test_integration/test_count.py
+++ b/tests/test_integration/test_count.py
@@ -15,28 +15,32 @@
 #  specific language governing permissions and limitations
 #  under the License.
 
+from typing import Any
+
+from elasticsearch import Elasticsearch
+
 from elasticsearch_dsl.search import Q, Search
 
 
-def test_count_all(data_client):
+def test_count_all(data_client: Elasticsearch) -> None:
     s = Search(using=data_client).index("git")
     assert 53 == s.count()
 
 
-def test_count_prefetch(data_client, mocker):
+def test_count_prefetch(data_client: Elasticsearch, mocker: Any) -> None:
     mocker.spy(data_client, "count")
 
     search = Search(using=data_client).index("git")
     search.execute()
     assert search.count() == 53
-    assert data_client.count.call_count == 0
+    assert data_client.count.call_count == 0  # type: ignore[attr-defined]
 
-    search._response.hits.total.relation = "gte"
+    search._response.hits.total.relation = "gte"  # type: ignore[attr-defined]
     assert search.count() == 53
-    assert data_client.count.call_count == 1
+    assert data_client.count.call_count == 1  # type: ignore[attr-defined]
 
 
-def test_count_filter(data_client):
+def test_count_filter(data_client: Elasticsearch) -> None:
     s = Search(using=data_client).index("git").filter(~Q("exists", field="parent_shas"))
     # initial commit + repo document
     assert 2 == s.count()

--- a/tests/test_integration/test_data.py
+++ b/tests/test_integration/test_data.py
@@ -15,8 +15,12 @@
 #  specific language governing permissions and limitations
 #  under the License.
 
+from typing import Any, Dict
 
-def create_flat_git_index(client, index):
+from elasticsearch import Elasticsearch
+
+
+def create_flat_git_index(client: Elasticsearch, index: str) -> None:
     # we will use user on several places
     user_mapping = {
         "properties": {"name": {"type": "text", "fields": {"raw": {"type": "keyword"}}}}
@@ -59,7 +63,7 @@ def create_flat_git_index(client, index):
     )
 
 
-def create_git_index(client, index):
+def create_git_index(client: Elasticsearch, index: str) -> None:
     # we will use user on several places
     user_mapping = {
         "properties": {"name": {"type": "text", "fields": {"raw": {"type": "keyword"}}}}
@@ -1081,7 +1085,7 @@ DATA = [
 ]
 
 
-def flatten_doc(d):
+def flatten_doc(d: Dict[str, Any]) -> Dict[str, Any]:
     src = d["_source"].copy()
     del src["commit_repo"]
     return {"_index": "flat-git", "_id": d["_id"], "_source": src}
@@ -1090,7 +1094,7 @@ def flatten_doc(d):
 FLAT_DATA = [flatten_doc(d) for d in DATA if "routing" in d]
 
 
-def create_test_git_data(d):
+def create_test_git_data(d: Dict[str, Any]) -> Dict[str, Any]:
     src = d["_source"].copy()
     return {
         "_index": "test-git",

--- a/tests/test_integration/test_examples/_async/test_alias_migration.py
+++ b/tests/test_integration/test_examples/_async/test_alias_migration.py
@@ -52,7 +52,6 @@ async def test_alias_migration(async_write_client: AsyncElasticsearch) -> None:
     # _matches work which means we get BlogPost instance
     bp = (await BlogPost.search().execute())[0]
     assert isinstance(bp, BlogPost)
-    print("**", bp.published)
     assert not bp.is_published()
     assert "0" == bp.meta.id
 

--- a/tests/test_integration/test_examples/_async/test_alias_migration.py
+++ b/tests/test_integration/test_examples/_async/test_alias_migration.py
@@ -16,13 +16,14 @@
 #  under the License.
 
 import pytest
+from elasticsearch import AsyncElasticsearch
 
 from ..async_examples import alias_migration
 from ..async_examples.alias_migration import ALIAS, PATTERN, BlogPost, migrate
 
 
 @pytest.mark.asyncio
-async def test_alias_migration(async_write_client):
+async def test_alias_migration(async_write_client: AsyncElasticsearch) -> None:
     # create the index
     await alias_migration.setup()
 
@@ -42,6 +43,7 @@ async def test_alias_migration(async_write_client):
             title="Hello World!",
             tags=["testing", "dummy"],
             content=f.read(),
+            published=None,
         )
         await bp.save(refresh=True)
 
@@ -50,6 +52,7 @@ async def test_alias_migration(async_write_client):
     # _matches work which means we get BlogPost instance
     bp = (await BlogPost.search().execute())[0]
     assert isinstance(bp, BlogPost)
+    print("**", bp.published)
     assert not bp.is_published()
     assert "0" == bp.meta.id
 

--- a/tests/test_integration/test_examples/_async/test_completion.py
+++ b/tests/test_integration/test_examples/_async/test_completion.py
@@ -16,15 +16,18 @@
 #  under the License.
 
 import pytest
+from elasticsearch import AsyncElasticsearch
 
 from ..async_examples.completion import Person
 
 
 @pytest.mark.asyncio
-async def test_person_suggests_on_all_variants_of_name(async_write_client):
+async def test_person_suggests_on_all_variants_of_name(
+    async_write_client: AsyncElasticsearch,
+) -> None:
     await Person.init(using=async_write_client)
 
-    await Person(name="Honza Král", popularity=42).save(refresh=True)
+    await Person(_id=None, name="Honza Král", popularity=42).save(refresh=True)
 
     s = Person.search().suggest("t", "kra", completion={"field": "suggest"})
     response = await s.execute()

--- a/tests/test_integration/test_examples/_async/test_composite_aggs.py
+++ b/tests/test_integration/test_examples/_async/test_composite_aggs.py
@@ -16,6 +16,7 @@
 #  under the License.
 
 import pytest
+from elasticsearch import AsyncElasticsearch
 
 from elasticsearch_dsl import A, AsyncSearch
 
@@ -23,7 +24,9 @@ from ..async_examples.composite_agg import scan_aggs
 
 
 @pytest.mark.asyncio
-async def test_scan_aggs_exhausts_all_files(async_data_client):
+async def test_scan_aggs_exhausts_all_files(
+    async_data_client: AsyncElasticsearch,
+) -> None:
     s = AsyncSearch(index="flat-git")
     key_aggs = {"files": A("terms", field="files")}
     file_list = [f async for f in scan_aggs(s, key_aggs)]
@@ -32,17 +35,16 @@ async def test_scan_aggs_exhausts_all_files(async_data_client):
 
 
 @pytest.mark.asyncio
-async def test_scan_aggs_with_multiple_aggs(async_data_client):
+async def test_scan_aggs_with_multiple_aggs(
+    async_data_client: AsyncElasticsearch,
+) -> None:
     s = AsyncSearch(index="flat-git")
     key_aggs = [
         {"files": A("terms", field="files")},
         {
-            "months": {
-                "date_histogram": {
-                    "field": "committed_date",
-                    "calendar_interval": "month",
-                }
-            }
+            "months": A(
+                "date_histogram", field="committed_date", calendar_interval="month"
+            )
         },
     ]
     file_list = [f async for f in scan_aggs(s, key_aggs)]

--- a/tests/test_integration/test_examples/_async/test_composite_aggs.py
+++ b/tests/test_integration/test_examples/_async/test_composite_aggs.py
@@ -47,6 +47,11 @@ async def test_scan_aggs_with_multiple_aggs(
             )
         },
     ]
-    file_list = [f async for f in scan_aggs(s, key_aggs)]
+    file_list = [
+        f
+        async for f in scan_aggs(
+            s, key_aggs, {"first_seen": A("min", field="committed_date")}
+        )
+    ]
 
     assert len(file_list) == 47

--- a/tests/test_integration/test_examples/_async/test_parent_child.py
+++ b/tests/test_integration/test_examples/_async/test_parent_child.py
@@ -19,6 +19,7 @@ from datetime import datetime
 
 import pytest
 import pytest_asyncio
+from elasticsearch import AsyncElasticsearch
 
 from elasticsearch_dsl import Q
 
@@ -42,7 +43,7 @@ nick = User(
 
 
 @pytest_asyncio.fixture
-async def question(async_write_client):
+async def question(async_write_client: AsyncElasticsearch) -> Question:
     await setup()
     assert await async_write_client.indices.exists_template(name="base")
 
@@ -55,16 +56,21 @@ async def question(async_write_client):
         body="""
         I want to use elasticsearch, how do I do it from Python?
         """,
+        created=None,
+        question_answer=None,
+        comments=[],
     )
     await q.save()
     return q
 
 
 @pytest.mark.asyncio
-async def test_comment(async_write_client, question):
+async def test_comment(
+    async_write_client: AsyncElasticsearch, question: Question
+) -> None:
     await question.add_comment(nick, "Just use elasticsearch-py")
 
-    q = await Question.get(1)
+    q = await Question.get(1)  # type: ignore[arg-type]
     assert isinstance(q, Question)
     assert 1 == len(q.comments)
 
@@ -74,7 +80,9 @@ async def test_comment(async_write_client, question):
 
 
 @pytest.mark.asyncio
-async def test_question_answer(async_write_client, question):
+async def test_question_answer(
+    async_write_client: AsyncElasticsearch, question: Question
+) -> None:
     a = await question.add_answer(honza, "Just use `elasticsearch-py`!")
 
     assert isinstance(a, Answer)

--- a/tests/test_integration/test_examples/_async/test_percolate.py
+++ b/tests/test_integration/test_examples/_async/test_percolate.py
@@ -16,12 +16,15 @@
 #  under the License.
 
 import pytest
+from elasticsearch import AsyncElasticsearch
 
 from ..async_examples.percolate import BlogPost, setup
 
 
 @pytest.mark.asyncio
-async def test_post_gets_tagged_automatically(async_write_client):
+async def test_post_gets_tagged_automatically(
+    async_write_client: AsyncElasticsearch,
+) -> None:
     await setup()
 
     bp = BlogPost(_id=47, content="nothing about snakes here!")

--- a/tests/test_integration/test_examples/_async/test_vectors.py
+++ b/tests/test_integration/test_examples/_async/test_vectors.py
@@ -16,9 +16,11 @@
 #  under the License.
 
 from hashlib import md5
+from typing import Any, List, Tuple
 from unittest import SkipTest
 
 import pytest
+from elasticsearch import AsyncElasticsearch
 
 from tests.async_sleep import sleep
 
@@ -26,17 +28,19 @@ from ..async_examples import vectors
 
 
 @pytest.mark.asyncio
-async def test_vector_search(async_write_client, es_version, mocker):
+async def test_vector_search(
+    async_write_client: AsyncElasticsearch, es_version: Tuple[int, ...], mocker: Any
+) -> None:
     # this test only runs on Elasticsearch >= 8.11 because the example uses
     # a dense vector without specifying an explicit size
     if es_version < (8, 11):
         raise SkipTest("This test requires Elasticsearch 8.11 or newer")
 
     class MockModel:
-        def __init__(self, model):
+        def __init__(self, model: Any):
             pass
 
-        def encode(self, text):
+        def encode(self, text: str) -> List[float]:
             vector = [int(ch) for ch in md5(text.encode()).digest()]
             total = sum(vector)
             return [float(v) / total for v in vector]

--- a/tests/test_integration/test_examples/_sync/test_alias_migration.py
+++ b/tests/test_integration/test_examples/_sync/test_alias_migration.py
@@ -52,7 +52,6 @@ def test_alias_migration(write_client: Elasticsearch) -> None:
     # _matches work which means we get BlogPost instance
     bp = (BlogPost.search().execute())[0]
     assert isinstance(bp, BlogPost)
-    print("**", bp.published)
     assert not bp.is_published()
     assert "0" == bp.meta.id
 

--- a/tests/test_integration/test_examples/_sync/test_alias_migration.py
+++ b/tests/test_integration/test_examples/_sync/test_alias_migration.py
@@ -16,13 +16,14 @@
 #  under the License.
 
 import pytest
+from elasticsearch import Elasticsearch
 
 from ..examples import alias_migration
 from ..examples.alias_migration import ALIAS, PATTERN, BlogPost, migrate
 
 
 @pytest.mark.sync
-def test_alias_migration(write_client):
+def test_alias_migration(write_client: Elasticsearch) -> None:
     # create the index
     alias_migration.setup()
 
@@ -42,6 +43,7 @@ def test_alias_migration(write_client):
             title="Hello World!",
             tags=["testing", "dummy"],
             content=f.read(),
+            published=None,
         )
         bp.save(refresh=True)
 
@@ -50,6 +52,7 @@ def test_alias_migration(write_client):
     # _matches work which means we get BlogPost instance
     bp = (BlogPost.search().execute())[0]
     assert isinstance(bp, BlogPost)
+    print("**", bp.published)
     assert not bp.is_published()
     assert "0" == bp.meta.id
 

--- a/tests/test_integration/test_examples/_sync/test_completion.py
+++ b/tests/test_integration/test_examples/_sync/test_completion.py
@@ -16,15 +16,18 @@
 #  under the License.
 
 import pytest
+from elasticsearch import Elasticsearch
 
 from ..examples.completion import Person
 
 
 @pytest.mark.sync
-def test_person_suggests_on_all_variants_of_name(write_client):
+def test_person_suggests_on_all_variants_of_name(
+    write_client: Elasticsearch,
+) -> None:
     Person.init(using=write_client)
 
-    Person(name="Honza Král", popularity=42).save(refresh=True)
+    Person(_id=None, name="Honza Král", popularity=42).save(refresh=True)
 
     s = Person.search().suggest("t", "kra", completion={"field": "suggest"})
     response = s.execute()

--- a/tests/test_integration/test_examples/_sync/test_composite_aggs.py
+++ b/tests/test_integration/test_examples/_sync/test_composite_aggs.py
@@ -16,6 +16,7 @@
 #  under the License.
 
 import pytest
+from elasticsearch import Elasticsearch
 
 from elasticsearch_dsl import A, Search
 
@@ -23,7 +24,9 @@ from ..examples.composite_agg import scan_aggs
 
 
 @pytest.mark.sync
-def test_scan_aggs_exhausts_all_files(data_client):
+def test_scan_aggs_exhausts_all_files(
+    data_client: Elasticsearch,
+) -> None:
     s = Search(index="flat-git")
     key_aggs = {"files": A("terms", field="files")}
     file_list = [f for f in scan_aggs(s, key_aggs)]
@@ -32,17 +35,16 @@ def test_scan_aggs_exhausts_all_files(data_client):
 
 
 @pytest.mark.sync
-def test_scan_aggs_with_multiple_aggs(data_client):
+def test_scan_aggs_with_multiple_aggs(
+    data_client: Elasticsearch,
+) -> None:
     s = Search(index="flat-git")
     key_aggs = [
         {"files": A("terms", field="files")},
         {
-            "months": {
-                "date_histogram": {
-                    "field": "committed_date",
-                    "calendar_interval": "month",
-                }
-            }
+            "months": A(
+                "date_histogram", field="committed_date", calendar_interval="month"
+            )
         },
     ]
     file_list = [f for f in scan_aggs(s, key_aggs)]

--- a/tests/test_integration/test_examples/_sync/test_composite_aggs.py
+++ b/tests/test_integration/test_examples/_sync/test_composite_aggs.py
@@ -47,6 +47,11 @@ def test_scan_aggs_with_multiple_aggs(
             )
         },
     ]
-    file_list = [f for f in scan_aggs(s, key_aggs)]
+    file_list = [
+        f
+        for f in scan_aggs(
+            s, key_aggs, {"first_seen": A("min", field="committed_date")}
+        )
+    ]
 
     assert len(file_list) == 47

--- a/tests/test_integration/test_examples/_sync/test_parent_child.py
+++ b/tests/test_integration/test_examples/_sync/test_parent_child.py
@@ -18,6 +18,7 @@
 from datetime import datetime
 
 import pytest
+from elasticsearch import Elasticsearch
 
 from elasticsearch_dsl import Q
 
@@ -41,7 +42,7 @@ nick = User(
 
 
 @pytest.fixture
-def question(write_client):
+def question(write_client: Elasticsearch) -> Question:
     setup()
     assert write_client.indices.exists_template(name="base")
 
@@ -54,16 +55,19 @@ def question(write_client):
         body="""
         I want to use elasticsearch, how do I do it from Python?
         """,
+        created=None,
+        question_answer=None,
+        comments=[],
     )
     q.save()
     return q
 
 
 @pytest.mark.sync
-def test_comment(write_client, question):
+def test_comment(write_client: Elasticsearch, question: Question) -> None:
     question.add_comment(nick, "Just use elasticsearch-py")
 
-    q = Question.get(1)
+    q = Question.get(1)  # type: ignore[arg-type]
     assert isinstance(q, Question)
     assert 1 == len(q.comments)
 
@@ -73,7 +77,7 @@ def test_comment(write_client, question):
 
 
 @pytest.mark.sync
-def test_question_answer(write_client, question):
+def test_question_answer(write_client: Elasticsearch, question: Question) -> None:
     a = question.add_answer(honza, "Just use `elasticsearch-py`!")
 
     assert isinstance(a, Answer)

--- a/tests/test_integration/test_examples/_sync/test_percolate.py
+++ b/tests/test_integration/test_examples/_sync/test_percolate.py
@@ -16,12 +16,15 @@
 #  under the License.
 
 import pytest
+from elasticsearch import Elasticsearch
 
 from ..examples.percolate import BlogPost, setup
 
 
 @pytest.mark.sync
-def test_post_gets_tagged_automatically(write_client):
+def test_post_gets_tagged_automatically(
+    write_client: Elasticsearch,
+) -> None:
     setup()
 
     bp = BlogPost(_id=47, content="nothing about snakes here!")

--- a/tests/test_integration/test_examples/_sync/test_vectors.py
+++ b/tests/test_integration/test_examples/_sync/test_vectors.py
@@ -16,9 +16,11 @@
 #  under the License.
 
 from hashlib import md5
+from typing import Any, List, Tuple
 from unittest import SkipTest
 
 import pytest
+from elasticsearch import Elasticsearch
 
 from tests.sleep import sleep
 
@@ -26,17 +28,19 @@ from ..examples import vectors
 
 
 @pytest.mark.sync
-def test_vector_search(write_client, es_version, mocker):
+def test_vector_search(
+    write_client: Elasticsearch, es_version: Tuple[int, ...], mocker: Any
+) -> None:
     # this test only runs on Elasticsearch >= 8.11 because the example uses
     # a dense vector without specifying an explicit size
     if es_version < (8, 11):
         raise SkipTest("This test requires Elasticsearch 8.11 or newer")
 
     class MockModel:
-        def __init__(self, model):
+        def __init__(self, model: Any):
             pass
 
-        def encode(self, text):
+        def encode(self, text: str) -> List[float]:
             vector = [int(ch) for ch in md5(text.encode()).digest()]
             total = sum(vector)
             return [float(v) / total for v in vector]

--- a/tests/test_package.py
+++ b/tests/test_package.py
@@ -18,5 +18,5 @@
 import elasticsearch_dsl
 
 
-def test__all__is_sorted():
+def test__all__is_sorted() -> None:
     assert elasticsearch_dsl.__all__ == sorted(elasticsearch_dsl.__all__)

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -31,7 +31,7 @@ def test_attrdict_pickle() -> None:
 
 
 def test_attrlist_pickle() -> None:
-    al = utils.AttrList([])
+    al = utils.AttrList[Any]([])
 
     pickled_al = pickle.dumps(al)
     assert al == pickle.loads(pickled_al)
@@ -41,7 +41,7 @@ def test_attrlist_slice() -> None:
     class MyAttrDict(utils.AttrDict[str]):
         pass
 
-    l = utils.AttrList([{}, {}], obj_wrapper=MyAttrDict)
+    l = utils.AttrList[Any]([{}, {}], obj_wrapper=MyAttrDict)
     assert isinstance(l[:][0], MyAttrDict)
 
 
@@ -111,6 +111,6 @@ def test_recursive_to_dict() -> None:
 
 
 def test_attrlist_to_list() -> None:
-    l = utils.AttrList([{}, {}]).to_list()
+    l = utils.AttrList[Any]([{}, {}]).to_list()
     assert isinstance(l, list)
     assert l == [{}, {}]

--- a/utils/run-unasync.py
+++ b/utils/run-unasync.py
@@ -40,7 +40,7 @@ def main(check=False):
             "tests/test_integration/_sync/",
         ),
         (
-            "tests/test_integration/test_examples/_async",
+            "tests/test_integration/test_examples/_async/",
             "tests/test_integration/test_examples/_sync/",
         ),
         ("examples/async/", "examples/"),


### PR DESCRIPTION
Type hints for all remaining tests and examples.

There are some notes embedded in the code, but the main changes are:

- All the code, tests and examples now pass mypy strict 🎉 
- I've added pyright to the type checking pass, but only for examples, to make sure vscode/vim/etc. do not produce any errors. This also passes.
- I'm closing #1858 as those changes are included in this PR as well. The description of the change in that PR is still useful for you to read.
- In test files that work with `Document` instances I have silenced a number of mypy errors that come as a result of using the old way of creating document fields without type hints. This is because I want to make sure these continue to be supported and tested.
- For consistency, I have added a generic type to `AttrList`. In all current usages we are doing `AttrList[Any]` and `AttrDict[Any]`, but this might change in the future.

Work that remains wrt types:

- Responses are typed with `Any`. It would be useful to create specific types for all the fields.
- There are inconsistencies in typing lists with `List` vs. `Sequence` and dicts with `Dict` and `Mapping` or `MutableMapping` that I will try to clean up at some point.