### PR TITLE
Add index creation to aggregations example

### DIFF
--- a/tests/test_integration/test_data.py
+++ b/tests/test_integration/test_data.py
@@ -25,9 +25,6 @@ user_mapping = {
 
 FLAT_GIT_INDEX: Dict[str, Any] = {
     "settings": {
-        # just one shard, no replicas for testing
-        "number_of_shards": 1,
-        "number_of_replicas": 0,
         # custom analyzer for analyzing file paths
         "analysis": {
             "analyzer": {
@@ -58,9 +55,6 @@ FLAT_GIT_INDEX: Dict[str, Any] = {
 
 GIT_INDEX: Dict[str, Any] = {
     "settings": {
-        # just one shard, no replicas for testing
-        "number_of_shards": 1,
-        "number_of_replicas": 0,
         # custom analyzer for analyzing file paths
         "analysis": {
             "analyzer": {

--- a/utils/run-unasync.py
+++ b/utils/run-unasync.py
@@ -64,6 +64,7 @@ def main(check=False):
         "async_connections": "connections",
         "async_scan": "scan",
         "async_simulate": "simulate",
+        "async_bulk": "bulk",
         "async_mock_client": "mock_client",
         "async_client": "client",
         "async_data_client": "data_client",


### PR DESCRIPTION
The aggregations example (composite_agg.py) assumes an index called `git` has been created and populated in advance, which in practice makes it impossible for most people to get the example to run.

The git index is one of the datasets used by the integration tests. In this change I have added the logic to create and populate the index, so that the example can be standalone like all the other examples.