### PR TITLE
Instrumented fields in queries

### DIFF
--- a/elasticsearch_dsl/utils.py
+++ b/elasticsearch_dsl/utils.py
@@ -311,8 +311,12 @@ class DslBase(metaclass=DslMeta):
             _expand__to_dot = EXPAND__TO_DOT
         self._params: Dict[str, Any] = {}
         for pname, pvalue in params.items():
+            # expand "__" to dots
             if "__" in pname and _expand__to_dot:
                 pname = pname.replace("__", ".")
+            # convert instrumented fields to string
+            if type(pvalue).__name__ == "InstrumentedField":
+                pvalue = str(pvalue)
             self._setattr(pname, pvalue)
 
     def _repr_params(self) -> str:

--- a/tests/_async/test_document.py
+++ b/tests/_async/test_document.py
@@ -776,7 +776,11 @@ def test_doc_with_type_hints() -> None:
     }
 
     s = TypedDoc.search().sort(TypedDoc.st, -TypedDoc.dt, +TypedDoc.ob.st)
-    assert s.to_dict() == {"sort": ["st", {"dt": {"order": "desc"}}, "ob.st"]}
+    s.aggs.bucket("terms_agg", "terms", field=TypedDoc.k1)
+    assert s.to_dict() == {
+        "aggs": {"terms_agg": {"terms": {"field": "k1"}}},
+        "sort": ["st", {"dt": {"order": "desc"}}, "ob.st"],
+    }
 
 
 def test_instrumented_field() -> None:

--- a/tests/_sync/test_document.py
+++ b/tests/_sync/test_document.py
@@ -776,7 +776,11 @@ def test_doc_with_type_hints() -> None:
     }
 
     s = TypedDoc.search().sort(TypedDoc.st, -TypedDoc.dt, +TypedDoc.ob.st)
-    assert s.to_dict() == {"sort": ["st", {"dt": {"order": "desc"}}, "ob.st"]}
+    s.aggs.bucket("terms_agg", "terms", field=TypedDoc.k1)
+    assert s.to_dict() == {
+        "aggs": {"terms_agg": {"terms": {"field": "k1"}}},
+        "sort": ["st", {"dt": {"order": "desc"}}, "ob.st"],
+    }
 
 
 def test_instrumented_field() -> None:


### PR DESCRIPTION
Instances of `InstrumentedField` might pop up in queries and aggregations, for example:

```python
s = s.query('knn', field=QuoteDoc.embedding, query_vector=model.encode(q).tolist())
s.aggs.bucket('tags', 'terms', field=QuoteDoc.tags, size=100)
```

With this change they are handled appropriately.