### PR TITLE
Removed `__orig_class__` attribute out of AttrDict instances

### DIFF
--- a/elasticsearch_dsl/utils.py
+++ b/elasticsearch_dsl/utils.py
@@ -215,7 +215,11 @@ class AttrDict(Generic[_ValT]):
         del self._d_[key]
 
     def __setattr__(self, name: str, value: _ValT) -> None:
-        if name in self._d_ or not hasattr(self.__class__, name):
+        # the __orig__class__ attribute has to be treated as an exception, as
+        # is it added to an object when it is instantiated with type arguments
+        if (
+            name in self._d_ or not hasattr(self.__class__, name)
+        ) and name != "__orig_class__":
             self._d_[name] = value
         else:
             # there is an attribute on the class (could be property, ..) - don't add it as field

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -45,10 +45,21 @@ def test_attrlist_slice() -> None:
     assert isinstance(l[:][0], MyAttrDict)
 
 
+def test_attrlist_with_type_argument() -> None:
+    a = utils.AttrList[str](["a", "b"])
+    assert list(a) == ["a", "b"]
+
+
 def test_attrdict_keys_items() -> None:
     a = utils.AttrDict({"a": {"b": 42, "c": 47}, "d": "e"})
     assert list(a.keys()) == ["a", "d"]
     assert list(a.items()) == [("a", {"b": 42, "c": 47}), ("d", "e")]
+
+
+def test_attrdict_with_type_argument() -> None:
+    a = utils.AttrDict[str]({"a": "b"})
+    assert list(a.keys()) == ["a"]
+    assert list(a.items()) == [("a", "b")]
 
 
 def test_merge() -> None:


### PR DESCRIPTION
Fixes #1876 

This change addressed a regression introduced in 8.15.0 as part of the refactor to support type hints.

The problem is in `AttrDict`, which can get confused and inject an attribute named `__orig_class__` in the underlying dict. For example:

```python
>>> from typing import Any
>>> from elasticsearch_dsl import AttrDict
>>> d = AttrDict[Any]({})
>>> d.to_dict()
{'__orig_class__': elasticsearch_dsl.utils.AttrDict[typing.Any]}
```

This happens because Python adds the `__orig_class__` attribute to all instances that were created with explicit generic arguments given. The logic in `AttrDict.__setattr__` to detect if an attribute is part of the dictionary or a real attribute of the instance does not work for `__orig_class__`.