### PR TITLE
Accepts boost param on Terms

### DIFF
--- a/elasticsearch_dsl/query.py
+++ b/elasticsearch_dsl/query.py
@@ -551,7 +551,10 @@ class Terms(Query):
     name = "terms"
 
     def _setattr(self, name: str, value: Any) -> None:
-        super()._setattr(name, list(value))
+        if name != "boost":
+            value = list(value)
+
+        super()._setattr(name, value)
 
 
 class TermsSet(Query):

--- a/tests/test_query.py
+++ b/tests/test_query.py
@@ -86,6 +86,12 @@ def test_terms_to_dict() -> None:
     ).to_dict()
 
 
+def test_terms_to_dict_should_accept_boost_param() -> None:
+    assert {"terms": {"_type": ["article", "section"], "boost": 2}} == query.Terms(
+        _type=["article", "section"], boost=2
+    ).to_dict()
+
+
 def test_bool_to_dict() -> None:
     bool = query.Bool(must=[query.Match(f="value")], should=[])
 


### PR DESCRIPTION
https://github.com/elastic/elasticsearch-dsl-py/pull/1887 introduced a bug when we tried to pass a boost in the search for terms.

This PR ignores the value list transformation when param name is `boost`.