### PR TITLE
Fixed the the type hint for `Document.get()`

### DIFF
--- a/elasticsearch_dsl/_async/document.py
+++ b/elasticsearch_dsl/_async/document.py
@@ -134,7 +134,7 @@ class AsyncDocument(DocumentBase, metaclass=AsyncIndexMeta):
         using: Optional[AsyncUsingType] = None,
         index: Optional[str] = None,
         **kwargs: Any,
-    ) -> Optional[Self]:
+    ) -> Self:
         """
         Retrieve a single document from elasticsearch using its ``id``.
 
@@ -144,12 +144,11 @@ class AsyncDocument(DocumentBase, metaclass=AsyncIndexMeta):
         :arg using: connection alias to use, defaults to ``'default'``
 
         Any additional keyword arguments will be passed to
-        ``Elasticsearch.get`` unchanged.
+        ``Elasticsearch.get`` unchanged. If the given ``id`` is not found,
+        a ``NotFoundError`` exception is raised.
         """
         es = cls._get_connection(using)
         doc = await es.get(index=cls._default_index(index), id=id, **kwargs)
-        if not doc.get("found", False):
-            return None
         return cls.from_es(doc)
 
     @classmethod

--- a/elasticsearch_dsl/_sync/document.py
+++ b/elasticsearch_dsl/_sync/document.py
@@ -128,7 +128,7 @@ class Document(DocumentBase, metaclass=IndexMeta):
         using: Optional[UsingType] = None,
         index: Optional[str] = None,
         **kwargs: Any,
-    ) -> Optional[Self]:
+    ) -> Self:
         """
         Retrieve a single document from elasticsearch using its ``id``.
 
@@ -138,12 +138,11 @@ class Document(DocumentBase, metaclass=IndexMeta):
         :arg using: connection alias to use, defaults to ``'default'``
 
         Any additional keyword arguments will be passed to
-        ``Elasticsearch.get`` unchanged.
+        ``Elasticsearch.get`` unchanged. If the given ``id`` is not found,
+        a ``NotFoundError`` exception is raised.
         """
         es = cls._get_connection(using)
         doc = es.get(index=cls._default_index(index), id=id, **kwargs)
-        if not doc.get("found", False):
-            return None
         return cls.from_es(doc)
 
     @classmethod


### PR DESCRIPTION
Fixes #1908