### PR TITLE
Configure dependabot to keep dependencies uptodate

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -1,0 +1,20 @@
+version: 2
+
+updates:
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: monthly
+    groups:
+      all_dependencies:
+        patterns:
+          - "*"
+
+  - package-ecosystem: pip
+    directory: /
+    schedule:
+      interval: monthly
+    groups:
+      all_dependencies:
+        patterns:
+          - "*"


### PR DESCRIPTION
This change aims to remove or decrease alerts in CI.

![image](https://github.com/user-attachments/assets/94a4b58a-cf57-4139-be2c-ba6c0b1b75f6)
