### PR TITLE
Fixed use of dictionaries as values in Terms query (#1921)

### DIFF
--- a/elasticsearch_dsl/query.py
+++ b/elasticsearch_dsl/query.py
@@ -552,7 +552,7 @@ class Terms(Query):
 
     def _setattr(self, name: str, value: Any) -> None:
         # here we convert any iterables that are not strings to lists
-        if hasattr(value, "__iter__") and not isinstance(value, (str, list)):
+        if hasattr(value, "__iter__") and not isinstance(value, (str, list, dict)):
             value = list(value)
         super()._setattr(name, value)
 

--- a/tests/test_query.py
+++ b/tests/test_query.py
@@ -84,6 +84,14 @@ def test_terms_to_dict() -> None:
     assert {"terms": {"_type": ["article", "section"], "boost": 1.1}} == query.Terms(
         _type=("article", "section"), boost=1.1
     ).to_dict()
+    assert {"terms": {"_type": "article", "boost": 1.1}} == query.Terms(
+        _type="article", boost=1.1
+    ).to_dict()
+    assert {
+        "terms": {"_id": {"index": "my-other-index", "id": "my-id"}, "boost": 1.1}
+    } == query.Terms(
+        _id={"index": "my-other-index", "id": "my-id"}, boost=1.1
+    ).to_dict()
 
 
 def test_bool_to_dict() -> None:


### PR DESCRIPTION
Fixes #1920
Backport of #1921 for the 8.x branch.