### PR TITLE
Add param passing notes to documentation on Search.delete

### DIFF
--- a/docs/search_dsl.rst
+++ b/docs/search_dsl.rst
@@ -98,6 +98,7 @@ explicitly:
 
 Delete By Query
 ~~~~~~~~~~~~~~~
+
 You can delete the documents matching a search by calling ``delete`` on the ``Search`` object instead of
 ``execute`` like this:
 
@@ -106,6 +107,14 @@ You can delete the documents matching a search by calling ``delete`` on the ``Se
     s = Search(index='i').query("match", title="python")
     response = s.delete()
 
+To pass deletion parameters in your query, you can add them by calling ``params`` on the ``Search`` object before
+``delete`` like this:
+
+.. code:: python
+
+    s = Search(index='i').query("match", title="python")
+    s = s.params(ignore_unavailable=False, wait_for_completion=True)
+    response = s.delete()
 
 
 Queries

--- a/elasticsearch_dsl/_async/search.py
+++ b/elasticsearch_dsl/_async/search.py
@@ -106,9 +106,9 @@ class AsyncSearch(SearchBase[_R]):
         Turn the search into a scan search and return a generator that will
         iterate over all the documents matching the query.
 
-        Use ``params`` method to specify any additional arguments you with to
+        Use the ``params`` method to specify any additional arguments you wish to
         pass to the underlying ``scan`` helper from ``elasticsearch-py`` -
-        https://elasticsearch-py.readthedocs.io/en/master/helpers.html#elasticsearch.helpers.scan
+        https://elasticsearch-py.readthedocs.io/en/latest/helpers.html#scan
 
         The ``iterate()`` method should be preferred, as it provides similar
         functionality using an Elasticsearch point in time.
@@ -123,6 +123,11 @@ class AsyncSearch(SearchBase[_R]):
     async def delete(self) -> AttrDict[Any]:
         """
         delete() executes the query by delegating to delete_by_query()
+        ``delete()`` executes the query by delegating to ``delete_by_query()``.
+
+        Use the ``params`` method to specify any additional arguments you wish to
+        pass to the underlying ``delete_by_query`` helper from ``elasticsearch-py`` -
+        https://elasticsearch-py.readthedocs.io/en/latest/async.html#elasticsearch.AsyncElasticsearch.delete_by_query
         """
 
         es = get_connection(self._using)

--- a/elasticsearch_dsl/_sync/search.py
+++ b/elasticsearch_dsl/_sync/search.py
@@ -95,9 +95,9 @@ class Search(SearchBase[_R]):
         Turn the search into a scan search and return a generator that will
         iterate over all the documents matching the query.
 
-        Use ``params`` method to specify any additional arguments you with to
+        Use the ``params`` method to specify any additional arguments you wish to
         pass to the underlying ``scan`` helper from ``elasticsearch-py`` -
-        https://elasticsearch-py.readthedocs.io/en/master/helpers.html#elasticsearch.helpers.scan
+        https://elasticsearch-py.readthedocs.io/en/latest/helpers.html#scan
 
         The ``iterate()`` method should be preferred, as it provides similar
         functionality using an Elasticsearch point in time.
@@ -109,7 +109,11 @@ class Search(SearchBase[_R]):
 
     def delete(self) -> AttrDict[Any]:
         """
-        delete() executes the query by delegating to delete_by_query()
+        ``delete()`` executes the query by delegating to ``delete_by_query()``.
+
+        Use the ``params`` method to specify any additional arguments you wish to
+        pass to the underlying ``delete_by_query`` helper from ``elasticsearch-py`` -
+        https://elasticsearch-py.readthedocs.io/en/latest/api/elasticsearch.html#elasticsearch.Elasticsearch.delete_by_query
         """
 
         es = get_connection(self._using)

--- a/elasticsearch_dsl/faceted_search_base.py
+++ b/elasticsearch_dsl/faceted_search_base.py
@@ -469,7 +469,7 @@ class FacetedSearchBase(Generic[_R]):
         """
         Specify query params to be used when executing the search. All the
         keyword arguments will override the current values. See
-        https://elasticsearch-py.readthedocs.io/en/master/api.html#elasticsearch.Elasticsearch.search
+        https://elasticsearch-py.readthedocs.io/en/latest/api/elasticsearch.html#elasticsearch.Elasticsearch.search
         for all available parameters.
         """
         self._s = self._s.params(**kwargs)


### PR DESCRIPTION
Earlier today I was trying to pass `wait_for_completion=True` to `Search.delete` but found `Search.delete` does not support `**kwargs`.

I was going to just add support for `**kwargs` (it would be a fairly trivial change), but after seeing #1115 and #1395, it seems the preferred way is to call `Search.params` first. However, this is not called out in the documentation for `Search.delete`, so I instead opted to add it to the documentation.

While I was at it, I noticed `Search.scan` and `FacetedSearch.params` had broken links so I fixed those as well.

Edit: Closing in favor of MR on the other repo: elastic/elasticsearch-py#2861