### PR TITLE
Use `collections.abc.Mapping` instead of `collections.Mapping`

### DIFF
--- a/elasticsearch_dsl/aggs.py
+++ b/elasticsearch_dsl/aggs.py
@@ -1,4 +1,4 @@
-import collections
+import collections.abc
 
 from .utils import DslBase
 from .response.aggs import BucketData, FieldBucketData, AggResponse, TopHitsData
@@ -10,7 +10,7 @@ def A(name_or_agg, filter=None, **params):
         params['filter'] = filter
 
     # {"terms": {"field": "tags"}, "aggs": {...}}
-    if isinstance(name_or_agg, collections.Mapping):
+    if isinstance(name_or_agg, collections.abc.Mapping):
         if params:
             raise ValueError('A() cannot accept parameters when passing in a dict.')
         # copy to avoid modifying in-place

--- a/elasticsearch_dsl/document.py
+++ b/elasticsearch_dsl/document.py
@@ -1,4 +1,4 @@
-import collections
+import collections.abc
 import re
 
 from elasticsearch.exceptions import NotFoundError, RequestError
@@ -210,7 +210,7 @@ class DocType(ObjectBase):
         es = connections.get_connection(using or cls._doc_type.using)
         body = {
             'docs': [
-                doc if isinstance(doc, collections.Mapping) else {'_id': doc}
+                doc if isinstance(doc, collections.abc.Mapping) else {'_id': doc}
                 for doc in docs
             ]
         }

--- a/elasticsearch_dsl/field.py
+++ b/elasticsearch_dsl/field.py
@@ -1,4 +1,4 @@
-import collections
+import collections.abc
 
 from datetime import date, datetime
 from dateutil import parser
@@ -10,7 +10,7 @@ from .exceptions import ValidationException
 
 def construct_field(name_or_field, **params):
     # {"type": "text", "analyzer": "snowball"}
-    if isinstance(name_or_field, collections.Mapping):
+    if isinstance(name_or_field, collections.abc.Mapping):
         if params:
             raise ValueError('construct_field() cannot accept parameters when passing in a dict.')
         params = name_or_field.copy()

--- a/elasticsearch_dsl/function.py
+++ b/elasticsearch_dsl/function.py
@@ -1,10 +1,10 @@
-import collections
+import collections.abc
 
 from .utils import DslBase
 
 def SF(name_or_sf, **params):
     # {"script_score": {"script": "_score"}, "filter": {}}
-    if isinstance(name_or_sf, collections.Mapping):
+    if isinstance(name_or_sf, collections.abc.Mapping):
         if params:
             raise ValueError('SF() cannot accept parameters when passing in a dict.')
         kwargs = {}
@@ -23,7 +23,7 @@ def SF(name_or_sf, **params):
             raise ValueError('SF() got an unexpected fields in the dictionary: %r' % sf)
 
         # boost factor special case, see elasticsearch #6343
-        if not isinstance(params, collections.Mapping):
+        if not isinstance(params, collections.abc.Mapping):
             params = {'value': params}
 
         # mix known params (from _param_defs) and from inside the function

--- a/elasticsearch_dsl/mapping.py
+++ b/elasticsearch_dsl/mapping.py
@@ -1,4 +1,4 @@
-import collections
+import collections.abc
 
 from six import iteritems
 from itertools import chain
@@ -90,7 +90,7 @@ class Mapping(object):
         # metadata like _all etc
         for name, value in iteritems(raw):
             if name != 'properties':
-                if isinstance(value, collections.Mapping):
+                if isinstance(value, collections.abc.Mapping):
                     self.meta(name, **value)
                 else:
                     self.meta(name, value)

--- a/elasticsearch_dsl/query.py
+++ b/elasticsearch_dsl/query.py
@@ -1,4 +1,4 @@
-import collections
+import collections.abc
 
 from itertools import chain
 
@@ -8,7 +8,7 @@ from .function import SF, ScoreFunction
 
 def Q(name_or_query='match_all', **params):
     # {"match": {"title": "python"}}
-    if isinstance(name_or_query, collections.Mapping):
+    if isinstance(name_or_query, collections.abc.Mapping):
         if params:
             raise ValueError('Q() cannot accept parameters when passing in a dict.')
         if len(name_or_query) != 1:

--- a/elasticsearch_dsl/search.py
+++ b/elasticsearch_dsl/search.py
@@ -1,5 +1,5 @@
 import copy
-import collections
+import collections.abc
 
 from six import iteritems, string_types
 
@@ -94,7 +94,7 @@ class Request(object):
         if isinstance(doc_type, (tuple, list)):
             for dt in doc_type:
                 self._add_doc_type(dt)
-        elif isinstance(doc_type, collections.Mapping):
+        elif isinstance(doc_type, collections.abc.Mapping):
             self._doc_type.extend(doc_type.keys())
             self._doc_type_map.update(doc_type)
         elif doc_type:

--- a/elasticsearch_dsl/utils.py
+++ b/elasticsearch_dsl/utils.py
@@ -1,6 +1,6 @@
 from __future__ import unicode_literals
 
-import collections
+import collections.abc
 
 from six import iteritems, add_metaclass
 from six.moves import map
@@ -11,7 +11,7 @@ SKIP_VALUES = ('', None)
 EXPAND__TO_DOT=True
 
 def _wrap(val, obj_wrapper=None):
-    if isinstance(val, collections.Mapping):
+    if isinstance(val, collections.abc.Mapping):
         return AttrDict(val) if obj_wrapper is None else obj_wrapper(val)
     if isinstance(val, list):
         return AttrList(val)
@@ -283,7 +283,7 @@ class DslBase(object):
                 '%r object has no attribute %r' % (self.__class__.__name__, name))
 
         # wrap nested dicts in AttrDict for convenient access
-        if isinstance(value, collections.Mapping):
+        if isinstance(value, collections.abc.Mapping):
             return AttrDict(value)
         return value
 
@@ -399,13 +399,13 @@ class ObjectBase(AttrDict):
         self.clean()
 
 def merge(data, new_data):
-    if not (isinstance(data, (AttrDict, collections.Mapping))
-            and isinstance(new_data, (AttrDict, collections.Mapping))):
+    if not (isinstance(data, (AttrDict, collections.abc.Mapping))
+            and isinstance(new_data, (AttrDict, collections.abc.Mapping))):
         raise ValueError('You can only merge two dicts! Got %r and %r instead.' % (data, new_data))
 
     for key, value in iteritems(new_data):
-        if key in data and isinstance(getattr(data, key), (AttrDict, collections.Mapping)) and \
-                isinstance(value, (AttrDict, collections.Mapping)):
+        if key in data and isinstance(getattr(data, key), (AttrDict, collections.abc.Mapping)) and \
+                isinstance(value, (AttrDict, collections.abc.Mapping)):
             merge(getattr(data, key), value)
         else:
             setattr(data, key, value)


### PR DESCRIPTION
For anyone running an older version of ElasticSearch `5.x`, who wants to upgrade to `Python >=3.10` (`3.12` in my case), the current `collections.Mapping` import becomes a hard error as it has been deprecated since 3.3 and removed in 3.10.

This PR updates the imports to point to `collections.abc.Mapping` instead, and hopes to release a `5.x` minor version that works with Python3.10+.

The deprecation warning in Python3.9:
```
Python 3.9.23 (main, Jun  4 2025, 00:00:00)
[GCC 15.1.1 20250521 (Red Hat 15.1.1-2)] on linux
Type "help", "copyright", "credits" or "license" for more information.
>>> import collections
>>> collections.Mapping
<stdin>:1: DeprecationWarning: Using or importing the ABCs from 'collections' instead of from 'collections.abc' is deprecated since Python 3.3, and in 3.10 it will stop working
<class 'collections.abc.Mapping'>
>>>
```

The hard error in Python3.12:
```
Python 3.12.11 (main, Jul  1 2025, 15:29:55) [GCC 8.5.0 20210514 (Red Hat 8.5.0-26)] on linux
Type "help", "copyright", "credits" or "license" for more information.
>>> import collections.abc
>>> collections.abc.Mapping
<class 'collections.abc.Mapping'>
>>> import collections
>>> collections.Mapping
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
AttributeError: module 'collections' has no attribute 'Mapping'
```